### PR TITLE
Symfony security service should be optional

### DIFF
--- a/src/Sentry/SentryBundle/EventListener/ExceptionListener.php
+++ b/src/Sentry/SentryBundle/EventListener/ExceptionListener.php
@@ -35,8 +35,8 @@ class ExceptionListener
      * @param array $skipCapture
      */
     public function __construct(
-        TokenStorageInterface $tokenStorage,
-        AuthorizationCheckerInterface $authorizationChecker,
+        TokenStorageInterface $tokenStorage = null,
+        AuthorizationCheckerInterface $authorizationChecker = null,
         \Raven_Client $client = null,
         array $skipCapture
     ) {
@@ -78,7 +78,7 @@ class ExceptionListener
             $this->setUserValue($token->getUser());
         }
     }
-    
+
     /**
      * @param GetResponseForExceptionEvent $event
      */

--- a/src/Sentry/SentryBundle/Resources/config/services.yml
+++ b/src/Sentry/SentryBundle/Resources/config/services.yml
@@ -11,8 +11,8 @@ services:
     sentry.exception_listener:
         class: '%sentry.exception_listener%'
         arguments:
-          - '@security.token_storage'
-          - '@security.authorization_checker'
+          - '@?security.token_storage'
+          - '@?security.authorization_checker'
           - '@sentry.client'
           - '%sentry.skip_capture%'
         tags:


### PR DESCRIPTION
I am using [symfony as a microframework](http://symfony.com/blog/new-in-symfony-2-8-symfony-as-a-microframework) and I don't use the security component.

I don't think it should be a mandatory dependency.
