### PR TITLE
Add option and API to disable Sentry reporting on demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ sentry:
 
 The following can be configured via ``app/config/config.yml``:
 
+### enabled
+
+Enable or disable reporting to Sentry. Defaults to true.
+
 ### app_path
 
 The base path to your application. Used to trim prefixes and mark frames as part of your application.

--- a/src/Sentry/SentryBundle/DependencyInjection/Configuration.php
+++ b/src/Sentry/SentryBundle/DependencyInjection/Configuration.php
@@ -22,6 +22,9 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
+                ->booleanNode('enabled')
+                    ->defaultTrue()
+                ->end()
                 ->scalarNode('app_path')
                     ->defaultValue('%kernel.root_dir%')
                 ->end()

--- a/src/Sentry/SentryBundle/EventListener/ExceptionListener.php
+++ b/src/Sentry/SentryBundle/EventListener/ExceptionListener.php
@@ -29,19 +29,26 @@ class ExceptionListener
     /** @var  string[] */
     private $skipCapture;
 
+    /** @var bool */
+    private $reportingIsEnabled;
+
     /**
      * ExceptionListener constructor.
      * @param TokenStorageInterface $tokenStorage
      * @param AuthorizationCheckerInterface $authorizationChecker
      * @param \Raven_Client $client
      * @param array $skipCapture
+     * @param $reportingIsEnabled
      */
     public function __construct(
         TokenStorageInterface $tokenStorage = null,
         AuthorizationCheckerInterface $authorizationChecker = null,
         \Raven_Client $client = null,
-        array $skipCapture
+        array $skipCapture,
+        $reportingIsEnabled
     ) {
+        $this->reportingIsEnabled = $reportingIsEnabled;
+
         if (!$client) {
             $client = new SentrySymfonyClient();
         }
@@ -50,6 +57,14 @@ class ExceptionListener
         $this->authorizationChecker = $authorizationChecker;
         $this->client = $client;
         $this->skipCapture = $skipCapture;
+    }
+
+    /**
+     * @param bool $reportingIsEnabled
+     */
+    public function setReportingEnabled($reportingIsEnabled)
+    {
+        $this->reportingIsEnabled = $reportingIsEnabled;
     }
 
     /**
@@ -86,6 +101,10 @@ class ExceptionListener
      */
     public function onKernelException(GetResponseForExceptionEvent $event)
     {
+        if (!$this->reportingIsEnabled) {
+            return;
+        }
+
         $exception = $event->getException();
 
         foreach ($this->skipCapture as $className) {
@@ -102,6 +121,10 @@ class ExceptionListener
      */
     public function onConsoleException(ConsoleExceptionEvent $event)
     {
+        if (!$this->reportingIsEnabled) {
+            return;
+        }
+
         $command = $event->getCommand();
         $exception = $event->getException();
 

--- a/src/Sentry/SentryBundle/Resources/config/services.yml
+++ b/src/Sentry/SentryBundle/Resources/config/services.yml
@@ -16,6 +16,7 @@ services:
           - '@?security.authorization_checker'
           - '@sentry.client'
           - '%sentry.skip_capture%'
+          - '%sentry.enabled%'
         tags:
             - { name: kernel.event_listener, event: kernel.request,    method: onKernelRequest }
             - { name: kernel.event_listener, event: kernel.exception,  method: onKernelException }


### PR DESCRIPTION
This PR suggests adding an option and API to disable Sentry reporting - during tests, in testing environment's etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry-symfony/21)
<!-- Reviewable:end -->
