### PR TITLE
Exclude examples from distribution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+examples/ export-ignore


### PR DESCRIPTION
This PR suggests exclusion of examples directory from git distribution package (so, no example dir in vendors, except if installed with prefer source)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry-symfony/22)
<!-- Reviewable:end -->
