### PR TITLE
Making ExceptionHelper friendly to Extensions

### DIFF
--- a/src/Sentry/SentryBundle/EventListener/ExceptionListener.php
+++ b/src/Sentry/SentryBundle/EventListener/ExceptionListener.php
@@ -26,10 +26,10 @@ class ExceptionListener
     private $authorizationChecker;
 
     /** @var \Raven_Client */
-    private $client;
+    protected $client;
 
     /** @var  string[] */
-    private $skipCapture;
+    protected $skipCapture;
 
     /**
      * ExceptionListener constructor.


### PR DESCRIPTION
I need to extend this class so I can add extra context information that is pertinent to our setup.

However since the client is protected, this is not possible.
For now i have made it protected so i can be accessed.

The second option if you do not like this, is to have a ExceptionHandler Interface available to we can then implement our own stuff and replicate functionality, or use composition.