### PR TITLE
Improve app path handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "sentry/sentry": ">=1.2.0",
+        "sentry/sentry": ">=1.5.0",
         "symfony/symfony": ">=2.4.0"
     },
     "require-dev": {

--- a/src/Sentry/SentryBundle/DependencyInjection/Configuration.php
+++ b/src/Sentry/SentryBundle/DependencyInjection/Configuration.php
@@ -23,7 +23,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('app_path')
-                    ->defaultValue('%kernel.root_dir%')
+                    ->defaultValue('%kernel.root_dir%/..')
                 ->end()
                 ->scalarNode('client')
                     ->defaultValue('Sentry\SentryBundle\SentrySymfonyClient')
@@ -49,6 +49,11 @@ class Configuration implements ConfigurationInterface
                     ->prototype('scalar')->end()
                     ->treatNullLike(array())
                     ->defaultValue(array('%kernel.root_dir%/..'))
+                ->end()
+                ->arrayNode('excluded_app_paths')
+                    ->prototype('scalar')->end()
+                    ->treatNullLike(array())
+                    ->defaultValue(array('%kernel.root_dir%/../vendor'))
                 ->end()
             ->end()
         ;

--- a/src/Sentry/SentryBundle/Resources/config/services.yml
+++ b/src/Sentry/SentryBundle/Resources/config/services.yml
@@ -6,6 +6,7 @@ services:
             - [setRelease, ['%sentry.release%']]
             - [setEnvironment, ['%sentry.environment%']]
             - [setAppPath, ['%sentry.app_path%']]
+            - [setExcludedAppPaths, ['%sentry.excluded_app_paths%']]
             - [setPrefixes, ['%sentry.prefixes%']]
             - [install, []]
 

--- a/test/Sentry/SentryBundle/Test/DependencyInjection/ExtensionTest.php
+++ b/test/Sentry/SentryBundle/Test/DependencyInjection/ExtensionTest.php
@@ -9,12 +9,12 @@ class ExtensionTest extends \PHPUnit_Framework_TestCase
 {
     const CONFIG_ROOT = 'sentry';
 
-    public function test_that_it_uses_kernel_root_as_app_path_by_default()
+    public function test_that_it_uses_kernel_root_parent_as_app_path_by_default()
     {
         $container = $this->getContainer();
 
         $this->assertSame(
-            'kernel/root',
+            'kernel/root/..',
             $container->getParameter('sentry.app_path')
         );
     }
@@ -30,6 +30,16 @@ class ExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(
             'sentry/app/path',
             $container->getParameter('sentry.app_path')
+        );
+    }
+
+    public function test_vendor_in_default_excluded_paths()
+    {
+        $container = $this->getContainer();
+
+        $this->assertContains(
+            'kernel/root/../vendor',
+            $container->getParameter('sentry.excluded_app_paths')
         );
     }
 


### PR DESCRIPTION
Utilize new exclusion list to include top level directory as app path, and exclude vendor subpath.

Fixes GH-31