### PR TITLE
Moving setting userinfo from request-listener to exception-listener

### DIFF
--- a/src/Sentry/SentryBundle/EventListener/ExceptionListener.php
+++ b/src/Sentry/SentryBundle/EventListener/ExceptionListener.php
@@ -63,20 +63,10 @@ class ExceptionListener
     }
 
     /**
-     * Set the username from the security context by listening on core.request
-     *
-     * @param GetResponseEvent $event
+     * Set the username from the security context
      */
-    public function onKernelRequest(GetResponseEvent $event)
+    private function setCurrentUser()
     {
-        if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
-            return;
-        }
-
-        if (null === $this->tokenStorage || null === $this->authorizationChecker) {
-            return;
-        }
-
         $token = $this->tokenStorage->getToken();
 
         if (null !== $token && $this->authorizationChecker->isGranted(AuthenticatedVoter::IS_AUTHENTICATED_REMEMBERED)) {
@@ -96,6 +86,7 @@ class ExceptionListener
             }
         }
 
+        $this->setCurrentUser();
         $this->client->captureException($exception);
     }
 
@@ -114,6 +105,7 @@ class ExceptionListener
             ),
         );
 
+        $this->setCurrentUser();
         $this->client->captureException($exception, $data);
     }
 

--- a/src/Sentry/SentryBundle/Resources/config/services.yml
+++ b/src/Sentry/SentryBundle/Resources/config/services.yml
@@ -18,6 +18,5 @@ services:
           - '@sentry.client'
           - '%sentry.skip_capture%'
         tags:
-            - { name: kernel.event_listener, event: kernel.request,    method: onKernelRequest }
             - { name: kernel.event_listener, event: kernel.exception,  method: onKernelException }
             - { name: kernel.event_listener, event: console.exception, method: onConsoleException }


### PR DESCRIPTION
Use case : 
 - using AuthorizationChecker::isGranted() trigger a query (I know, it shouldn't but some devs are doing wrong things sometimes...)
 - triggering a query means "hello doctrine" and fetching the result of that query
 - lost severals milliseconds because of that.

In fact, this is done on each request but it should only be done when an exception arise.

This PR move some codes where it should be handled properly.