### PR TITLE
Update services.yml

### DIFF
--- a/src/Sentry/SentryBundle/Resources/config/services.yml
+++ b/src/Sentry/SentryBundle/Resources/config/services.yml
@@ -1,7 +1,7 @@
 services:
     sentry.client:
         class: '%sentry.client%'
-        arguments: ['%sentry.dsn%', %sentry.options%, '%sentry.error_types%']
+        arguments: ['%sentry.dsn%', '%sentry.options%', '%sentry.error_types%']
         calls:
             - [setRelease, ['%sentry.release%']]
             - [setEnvironment, ['%sentry.environment%']]


### PR DESCRIPTION
Not quoting the scalar "%sentry.options%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0