### PR TITLE
Improve CI

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,22 @@
+checks:
+  php: true
+
+coding_style:
+  php:
+    spaces:
+      around_operators:
+        concatenation: true
+        negation: true
+      other:
+        after_type_cast: false
+
+tools:
+  external_code_coverage: true
+
+  php_code_sniffer:
+    config:
+      standard: "PSR2"
+
+filter:
+  excluded_paths:
+    - tests/*

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -20,3 +20,4 @@ tools:
 filter:
   excluded_paths:
     - tests/*
+    - examples/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,25 +6,25 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 
 matrix:
   allow_failures:
     - php: hhvm
-    - php: 7.0
   fast_finish: true
 
 sudo: false
 
 cache:
   directories:
-    - $HOME/.composer/cache
+    - $HOME/.composer/cache/files
 
 before_install:
   - composer self-update
 
-install: travis_retry composer install --no-interaction --prefer-source
+install: travis_retry composer install --no-interaction --prefer-dist
 
 script:
-  - vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff --dry-run
   - vendor/bin/phpunit
+  - vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff --dry-run

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+sudo: false
 
 php:
   - 5.3
@@ -10,11 +11,12 @@ php:
   - hhvm
 
 matrix:
+  include:
+    - php: 7.1
+      env: TEST_COVERAGE=true
   allow_failures:
     - php: hhvm
   fast_finish: true
-
-sudo: false
 
 cache:
   directories:
@@ -22,9 +24,13 @@ cache:
 
 before_install:
   - composer self-update
+  - if [[ $TEST_COVERAGE ]]; then PHPUNIT_FLAGS="--coverage-clover clover.xml"; fi
 
 install: travis_retry composer install --no-interaction --prefer-dist
 
 script:
-  - vendor/bin/phpunit
+  - vendor/bin/phpunit -v $PHPUNIT_FLAGS
   - vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff --dry-run
+
+after_success:
+  - if [[ $TEST_COVERAGE ]]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover clover.xml; fi

--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 Symfony integration for [Sentry](https://getsentry.com/).
 
-[![Build Status](https://travis-ci.org/getsentry/sentry-symfony.svg?branch=master)](https://travis-ci.org/getsentry/sentry-symfony)
+[![Stable release][Last stable image]][Packagist link]
+[![Unstable release][Last unstable image]][Packagist link]
+
+[![Build status][Master build image]][Master build link]
+[![Scrutinizer][Master scrutinizer image]][Master scrutinizer link]
+[![Coverage Status][Master coverage image]][Master coverage link]
+
 
 ## Installation
 
@@ -124,3 +130,14 @@ Define which error types should be reported.
 sentry:
     error_types: E_ALL & ~E_DEPRECATED & ~E_NOTICE
 ```
+
+[Last stable image]: https://poser.pugx.org/sentry/sentry-symfony/version.svg
+[Last unstable image]: https://poser.pugx.org/sentry/sentry-symfony/v/unstable.svg
+[Master build image]: https://travis-ci.org/getsentry/sentry-symfony.svg?branch=master
+[Master scrutinizer image]: https://scrutinizer-ci.com/g/getsentry/sentry-symfony/badges/quality-score.png?b=master
+[Master coverage image]: https://coveralls.io/repos/getsentry/sentry-symfony/badge.svg?branch=master&service=github
+
+[Packagist link]: https://packagist.org/packages/sentry/sentry-symfony
+[Master build link]: https://travis-ci.org/getsentry/sentry-symfony
+[Master scrutinizer link]: https://scrutinizer-ci.com/g/getsentry/sentry-symfony/?branch=master
+[Master coverage link]: https://coveralls.io/github/getsentry/sentry-symfony?branch=master


### PR DESCRIPTION
 - add PHP 7.1
 - do not allow failure for 7.0
 - cache only composer downloads, not info about lib versions
 - prefer to install dist version of dependencies
 - let the build fail for tests first, CS latter

I would also like to add some external quality/test coverage check tool, but that would require some intervention on the repo settings. Any preference? I like Scrutinizer, but we also have CodeClimate and many others... @dcramer it's up to you, I will gladly add the integration in this PR!