### PR TITLE
Fix package description in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "sentry/sentry-symfony",
-    "type": "library",
+    "type": "symfony-bundle",
     "description": "Symfony integration for Sentry (http://getsentry.com)",
     "keywords": ["logging", "errors", "symfony", "sentry"],
     "homepage": "http://getsentry.com",
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.3.3",
         "sentry/sentry": ">=1.5.0",
-        "symfony/symfony": ">=2.4.0"
+        "symfony/framework-bundle": ">=2.4.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^1.8.0",


### PR DESCRIPTION
I'm trying to [integrate this bundle to Symfony Flex recipes](https://github.com/symfony/recipes-contrib/pull/40), but I hit an issue with its definition.

![image](https://cloud.githubusercontent.com/assets/400034/26165890/e51dccd0-3b31-11e7-8e6b-d9c463b7b3cc.png)
