### PR TITLE
test against different dependency versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ matrix:
   include:
     - php: 7.0
       env: COMPOSER_OPTIONS="--prefer-lowest --prefer-stable"
-    - php: 7.0
-      env: COMPOSER_OPTIONS=""
     - php: 7.1
       env: TEST_COVERAGE=true
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,15 @@ php:
   - 7.1
   - hhvm
 
+env:
+  - COMPOSER_OPTIONS="--prefer-stable"
+
 matrix:
   include:
+    - php: 7.0
+      env: COMPOSER_OPTIONS="--prefer-lowest --prefer-stable"
+    - php: 7.0
+      env: COMPOSER_OPTIONS=""
     - php: 7.1
       env: TEST_COVERAGE=true
   allow_failures:
@@ -26,7 +33,7 @@ before_install:
   - composer self-update
   - if [[ $TEST_COVERAGE ]]; then PHPUNIT_FLAGS="--coverage-clover clover.xml"; fi
 
-install: travis_retry composer install --no-interaction --prefer-dist
+install: travis_retry composer update --no-interaction --prefer-dist $COMPOSER_OPTIONS
 
 script:
   - vendor/bin/phpunit -v $PHPUNIT_FLAGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,12 @@ php:
   - 7.1
   - hhvm
 
-env:
-  - COMPOSER_OPTIONS="--prefer-stable"
-
 matrix:
   include:
+    - php: 5.3
+      env: COMPOSER_OPTIONS="--prefer-lowest"
     - php: 7.0
-      env: COMPOSER_OPTIONS="--prefer-lowest --prefer-stable"
+      env: COMPOSER_OPTIONS="--prefer-lowest"
     - php: 7.1
       env: TEST_COVERAGE=true
   allow_failures:
@@ -31,7 +30,7 @@ before_install:
   - composer self-update
   - if [[ $TEST_COVERAGE ]]; then PHPUNIT_FLAGS="--coverage-clover clover.xml"; fi
 
-install: travis_retry composer update --no-interaction --prefer-dist $COMPOSER_OPTIONS
+install: travis_retry composer update --no-interaction --prefer-dist --prefer-stable $COMPOSER_OPTIONS
 
 script:
   - vendor/bin/phpunit -v $PHPUNIT_FLAGS

--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,17 @@
     "require": {
         "php": ">=5.3.3",
         "sentry/sentry": ">=1.5.0",
-        "symfony/framework-bundle": ">=2.4.0"
+        "symfony/config": "^2.4|^3.0",
+        "symfony/console": "^2.4|^3.0",
+        "symfony/dependency-injection": "^2.4|^3.0",
+        "symfony/event-dispatcher": "^2.4|^3.0",
+        "symfony/http-kernel": "^2.4|^3.0",
+        "symfony/security-core": "^2.4|^3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^1.8.0",
         "phpunit/phpunit": "^4.6.6"
     },
-    "minimum-stability": "dev",
     "autoload": {
         "psr-0" : {
             "Sentry\\SentryBundle\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "friendsofphp/php-cs-fixer": "^1.8.0",
         "phpunit/phpunit": "^4.6.6"
     },
+    "minimum-stability": "dev",
     "autoload": {
         "psr-0" : {
             "Sentry\\SentryBundle\\": "src/"


### PR DESCRIPTION
* by default, run with latest stable versions
* add a job with lowest stable constrained deps
* run with upcoming releases of required deps