### PR TITLE
Bump minimum Symfony version to 2.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
     "require": {
         "php": ">=5.3.3",
         "sentry/sentry": ">=1.5.0",
-        "symfony/config": "^2.4|^3.0",
-        "symfony/console": "^2.4|^3.0",
-        "symfony/dependency-injection": "^2.4|^3.0",
-        "symfony/event-dispatcher": "^2.4|^3.0",
-        "symfony/http-kernel": "^2.4|^3.0",
-        "symfony/security-core": "^2.4|^3.0"
+        "symfony/config": "^2.7|^3.0",
+        "symfony/console": "^2.7|^3.0",
+        "symfony/dependency-injection": "^2.7|^3.0",
+        "symfony/event-dispatcher": "^2.7|^3.0",
+        "symfony/http-kernel": "^2.7|^3.0",
+        "symfony/security-core": "^2.7|^3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^1.8.0",


### PR DESCRIPTION
Since #58 I discovered that we do not really support Symfony <2.7, since `TokenStorageInterface` and `AuthorizationCheckerInterface` were implemented later than 2.4, in 2.6.

Since 2.6 and previous versions are now no longer supported, it makes sense to bump to the oldest currently supported version.