### PR TITLE
Made priorities configurable

### DIFF
--- a/src/Sentry/SentryBundle/DependencyInjection/Configuration.php
+++ b/src/Sentry/SentryBundle/DependencyInjection/Configuration.php
@@ -71,6 +71,14 @@ class Configuration implements ConfigurationInterface
                         '%kernel.root_dir%/../var/cache',
                     ))
                 ->end()
+                ->arrayNode('listener_priorities')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('request')->defaultValue(0)->end()
+                        ->scalarNode('kernel_exception')->defaultValue(0)->end()
+                        ->scalarNode('console_exception')->defaultValue(0)->end()
+                    ->end()
+                ->end()
             ->end()
         ;
 

--- a/src/Sentry/SentryBundle/DependencyInjection/SentryExtension.php
+++ b/src/Sentry/SentryBundle/DependencyInjection/SentryExtension.php
@@ -23,8 +23,13 @@ class SentryExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
+
         foreach ($config as $key => $value) {
             $container->setParameter('sentry.' . $key, $value);
+        }
+
+        foreach ($config['listener_priorities'] as $key => $priority) {
+            $container->setParameter('sentry.listener_priorities.' . $key, $priority);
         }
     }
 }

--- a/src/Sentry/SentryBundle/Resources/config/services.yml
+++ b/src/Sentry/SentryBundle/Resources/config/services.yml
@@ -19,6 +19,6 @@ services:
           - '%sentry.skip_capture%'
           - '@event_dispatcher'
         tags:
-            - { name: kernel.event_listener, event: kernel.request,    method: onKernelRequest }
-            - { name: kernel.event_listener, event: kernel.exception,  method: onKernelException }
-            - { name: kernel.event_listener, event: console.exception, method: onConsoleException }
+            - { name: kernel.event_listener, event: kernel.request,    method: onKernelRequest, priority: '%sentry.listener_priorities.request%'}
+            - { name: kernel.event_listener, event: kernel.exception,  method: onKernelException, priority: '%sentry.listener_priorities.kernel_exception%' }
+            - { name: kernel.event_listener, event: console.exception, method: onConsoleException, priority: '%sentry.listener_priorities.console_exception%' }

--- a/test/Sentry/SentryBundle/Test/DependencyInjection/ExtensionTest.php
+++ b/test/Sentry/SentryBundle/Test/DependencyInjection/ExtensionTest.php
@@ -133,6 +133,20 @@ class ExtensionTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function test_that_it_has_default_priority_values()
+    {
+        $container = $this->getContainer();
+
+        $this->assertTrue($container->hasParameter('sentry.listener_priorities'));
+
+        $priorities = $container->getParameter('sentry.listener_priorities');
+        $this->assertInternalType('array', $priorities);
+
+        $this->assertSame(0, $priorities['request']);
+        $this->assertSame(0, $priorities['kernel_exception']);
+        $this->assertSame(0, $priorities['console_exception']);
+    }
+
     /**
      * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      */
@@ -274,9 +288,9 @@ class ExtensionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame(
             array(
-                array('event' => 'kernel.request', 'method' => 'onKernelRequest'),
-                array('event' => 'kernel.exception', 'method' => 'onKernelException'),
-                array('event' => 'console.exception', 'method' => 'onConsoleException'),
+                array('event' => 'kernel.request', 'method' => 'onKernelRequest', 'priority' => '%sentry.listener_priorities.request%' ),
+                array('event' => 'kernel.exception', 'method' => 'onKernelException', 'priority' => '%sentry.listener_priorities.kernel_exception%'),
+                array('event' => 'console.exception', 'method' => 'onConsoleException', 'priority' => '%sentry.listener_priorities.console_exception%'),
             ),
             $tags
         );


### PR DESCRIPTION
In order to allow users to move the listeners in their priorities queue
the value is now configurable via configuration parameters. In order to
maintain BC these values default to 0 which is the current value.

this closes #49.