### PR TITLE
Restore master after 0.8 release

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.9.0 (unreleased)
+-----
+
 0.8.0
 -----
  - Add `SentryExceptionListenerInterface` and the `exception_listener` option in the configuration (#47) to allow customization of the exception listener

--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@
  - Add `SentryExceptionListenerInterface` and the `exception_listener` option in the configuration (#47) to allow customization of the exception listener
  - Add `SentrySymfonyEvents::PRE_CAPTURE` and `SentrySymfonyEvents::SET_USER_CONTEXT` events (#47) to customize event capturing information 
  - Make SkipCapture work on console exceptions too
+ - Make listeners' priority customizable through the new `listener_priorities` configuration key
 
 0.7.1
 -----

--- a/README.md
+++ b/README.md
@@ -130,6 +130,19 @@ sentry:
     error_types: E_ALL & ~E_DEPRECATED & ~E_NOTICE
 ```
 
+### Listeners' priority
+
+You can change the priority of the 3 default listeners of this bundle with the `listener_priorities` key of your config.
+The default value is `0`, and here are the 3 possible sub-keys:
+
+```yaml
+listener_priorities:
+    request: 0
+    kernel_exception: 0
+    console_exception: 0
+```
+
+... respectively for the `onKernelRequest`, `onKernelException` and `onConsoleException` events.
 
 ## Customization
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Symfony integration for [Sentry](https://getsentry.com/).
 
 [![Build status][Master build image]][Master build link]
 [![Scrutinizer][Master scrutinizer image]][Master scrutinizer link]
-[![Coverage Status][Master coverage image]][Master coverage link]
+[![Coverage Status][Master coverage image]][Master scrutinizer link]
 
 
 ## Installation
@@ -279,9 +279,9 @@ app.my_sentry_event_subscriber:
 [Last unstable image]: https://poser.pugx.org/sentry/sentry-symfony/v/unstable.svg
 [Master build image]: https://travis-ci.org/getsentry/sentry-symfony.svg?branch=master
 [Master scrutinizer image]: https://scrutinizer-ci.com/g/getsentry/sentry-symfony/badges/quality-score.png?b=master
-[Master coverage image]: https://coveralls.io/repos/getsentry/sentry-symfony/badge.svg?branch=master&service=github
+[Master coverage image]: https://scrutinizer-ci.com/g/getsentry/sentry-symfony/badges/coverage.png?b=master
 
 [Packagist link]: https://packagist.org/packages/sentry/sentry-symfony
 [Master build link]: https://travis-ci.org/getsentry/sentry-symfony
 [Master scrutinizer link]: https://scrutinizer-ci.com/g/getsentry/sentry-symfony/?branch=master
-[Master coverage link]: https://coveralls.io/github/getsentry/sentry-symfony?branch=master
+

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.7.x-dev"
+            "dev-master": "0.9.x-dev"
         }
     }
 }

--- a/src/Sentry/SentryBundle/EventListener/ExceptionListener.php
+++ b/src/Sentry/SentryBundle/EventListener/ExceptionListener.php
@@ -2,7 +2,6 @@
 
 namespace Sentry\SentryBundle\EventListener;
 
-use Sentry\SentryBundle;
 use Sentry\SentryBundle\Event\SentryUserContextEvent;
 use Sentry\SentryBundle\SentrySymfonyClient;
 use Sentry\SentryBundle\SentrySymfonyEvents;

--- a/src/Sentry/SentryBundle/SentryBundle.php
+++ b/src/Sentry/SentryBundle/SentryBundle.php
@@ -6,5 +6,5 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class SentryBundle extends Bundle
 {
-    const VERSION = '0.8.x-dev';
+    const VERSION = '0.8.0';
 }

--- a/src/Sentry/SentryBundle/SentryBundle.php
+++ b/src/Sentry/SentryBundle/SentryBundle.php
@@ -6,5 +6,5 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class SentryBundle extends Bundle
 {
-    const VERSION = '0.8.0';
+    const VERSION = '0.9.x-dev';
 }


### PR DESCRIPTION
I cannot self-approve this PR... @dcramer can you do it?

This PR moves master to 0.9.x-dev and merges all the leftover changes from 0.8