### PR TITLE
Listens on console.command to trigger client load

### DIFF
--- a/src/Sentry/SentryBundle/EventListener/ExceptionListener.php
+++ b/src/Sentry/SentryBundle/EventListener/ExceptionListener.php
@@ -6,6 +6,7 @@ use Sentry\SentryBundle;
 use Sentry\SentryBundle\Event\SentryUserContextEvent;
 use Sentry\SentryBundle\SentrySymfonyClient;
 use Sentry\SentryBundle\SentrySymfonyEvents;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Event\ConsoleExceptionEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -109,6 +110,19 @@ class ExceptionListener implements SentryExceptionListenerInterface
 
         $this->eventDispatcher->dispatch(SentrySymfonyEvents::PRE_CAPTURE, $event);
         $this->client->captureException($exception);
+    }
+
+    /**
+     * This method only ensures that the client and error handlers are registered at the start of the command
+     * execution cycle, and not only on exceptions
+     *
+     * @param ConsoleCommandEvent $event
+     *
+     * @return void
+     */
+    public function onConsoleCommand(ConsoleCommandEvent $event)
+    {
+        // only triggers loading of client, does not need to do anything.
     }
 
     /**

--- a/src/Sentry/SentryBundle/Resources/config/services.yml
+++ b/src/Sentry/SentryBundle/Resources/config/services.yml
@@ -21,4 +21,5 @@ services:
         tags:
             - { name: kernel.event_listener, event: kernel.request,    method: onKernelRequest, priority: '%sentry.listener_priorities.request%'}
             - { name: kernel.event_listener, event: kernel.exception,  method: onKernelException, priority: '%sentry.listener_priorities.kernel_exception%' }
+            - { name: kernel.event_listener, event: console.command,   method: onConsoleCommand }
             - { name: kernel.event_listener, event: console.exception, method: onConsoleException, priority: '%sentry.listener_priorities.console_exception%' }

--- a/test/Sentry/SentryBundle/Test/DependencyInjection/ExtensionTest.php
+++ b/test/Sentry/SentryBundle/Test/DependencyInjection/ExtensionTest.php
@@ -290,6 +290,7 @@ class ExtensionTest extends \PHPUnit_Framework_TestCase
             array(
                 array('event' => 'kernel.request', 'method' => 'onKernelRequest', 'priority' => '%sentry.listener_priorities.request%' ),
                 array('event' => 'kernel.exception', 'method' => 'onKernelException', 'priority' => '%sentry.listener_priorities.kernel_exception%'),
+                array('event' => 'console.command', 'method' => 'onConsoleCommand'),
                 array('event' => 'console.exception', 'method' => 'onConsoleException', 'priority' => '%sentry.listener_priorities.console_exception%'),
             ),
             $tags


### PR DESCRIPTION
Closes #66. 

This hook up forces the boot of the client to happen always when a command is triggered, which before only happened if an exception was thrown.

This should offer no BC issues and the only side effect is catching more notices then before as these may have been going unnoticed.