### PR TITLE
Fix Error when using a no authenticated token

### DIFF
--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -83,7 +83,7 @@ class ExceptionListener implements SentryExceptionListenerInterface
 
         $token = $this->tokenStorage->getToken();
 
-        if (null !== $token && $this->authorizationChecker->isGranted(AuthenticatedVoter::IS_AUTHENTICATED_REMEMBERED)) {
+        if (null !== $token && $token->isAuthenticated() && $this->authorizationChecker->isGranted(AuthenticatedVoter::IS_AUTHENTICATED_REMEMBERED)) {
             $this->setUserValue($token->getUser());
 
             $contextEvent = new SentryUserContextEvent($token);

--- a/test/EventListener/ExceptionListenerTest.php
+++ b/test/EventListener/ExceptionListenerTest.php
@@ -260,6 +260,11 @@ class ExceptionListenerTest extends TestCase
             ->willReturn($user)
         ;
 
+        $mockToken
+            ->method('isAuthenticated')
+            ->willReturn(true)
+        ;
+
         $mockEvent = $this->createMock(GetResponseEvent::class);
 
         $mockEvent
@@ -309,6 +314,11 @@ class ExceptionListenerTest extends TestCase
         $mockToken
             ->method('getUser')
             ->willReturn('some_user')
+        ;
+
+        $mockToken
+            ->method('isAuthenticated')
+            ->willReturn(true)
         ;
 
         $mockEvent = $this->createMock(GetResponseEvent::class);
@@ -368,6 +378,11 @@ class ExceptionListenerTest extends TestCase
         $mockToken
             ->method('getUser')
             ->willReturn($mockUser)
+        ;
+
+        $mockToken
+            ->method('isAuthenticated')
+            ->willReturn(true)
         ;
 
         $mockEvent = $this->createMock(GetResponseEvent::class);


### PR DESCRIPTION
When using this lib https://github.com/rezzza/SecurityBundle (for private api acces with signature security)
it create a specific token that not belongs to an user & not declare an authentication provider for it.
when sentry try to call isGranted sf want the user & call all auth providers, etc. 