### PR TITLE
shouldExceptionCaptureBeSkipped method visibilty

### DIFF
--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -142,7 +142,7 @@ class ExceptionListener implements SentryExceptionListenerInterface
         $this->client->captureException($exception, $data);
     }
 
-    private function shouldExceptionCaptureBeSkipped(\Exception $exception)
+    protected function shouldExceptionCaptureBeSkipped(\Exception $exception)
     {
         foreach ($this->skipCapture as $className) {
             if ($exception instanceof $className) {


### PR DESCRIPTION
Since `skipCapture` property is protected method `shouldExceptionCaptureBeSkipped` should also be protected.
Otherwise sometimes if class is extended it must be implemented  by copy&paste.