### PR TITLE
Preparation to release 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ cache:
 before_install:
   - composer self-update
   - composer global require hirak/prestissimo
-  - if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then composer remove --dev friendsofphp/php-cs-fixer --no-update --no-interaction; fi
 
 install: travis_wait travis_retry composer update --no-interaction --prefer-dist --prefer-stable $COMPOSER_OPTIONS
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Re-sort the constructor's arguments of `ExceptionListener`
  - The `SentrySymfonyClient` is no longer an optional argument of `ExceptionListener`; it's now required
 ### Fixed
- - Remove usage of create_function to avoid deprecations (#71)
+ - Remove usage of `create_function()` to avoid deprecations (#71)
  - Fix a possible bug that could make Sentry crash if an error is triggered before loading a console command
 ### Removed
  - Drop deprecated fields from configuration; the same options can be used (since 0.8.3) under `sentry.options`

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require": {
         "php": "^5.6|^7.0",
-        "sentry/sentry": "^1.7",
+        "sentry/sentry": "^1.8",
         "symfony/config": "^2.7|^3.0",
         "symfony/console": "^2.7|^3.0",
         "symfony/dependency-injection": "^2.7|^3.0",


### PR DESCRIPTION
We should now be ready to release this bundle as stable, so we can also have a Symfony Flex recipe; see #86 and https://github.com/symfony/recipes-contrib/pull/128.

I've also upped the constraint to the Sentry SDK to `^1.8` which was released yesterday.

Please @dcramer approve this so we can merge, tag and release!