### PR TITLE
Prepare release 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,10 @@ jobs:
       env: COMPOSER_OPTIONS="--prefer-lowest"
     - stage: Code style and static analysis
       script:
-        - vendor/bin/phpstan analyse src test --level 7
+        - composer phpstan
       env: PHPSTAN=true
     - script: 
-        - vendor/bin/php-cs-fixer fix --verbose --diff --dry-run
+        - composer cs-check
       env: CS-FIXER=true
     - stage: coverage
       script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ sudo: false
 dist: trusty
 
 php:
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
 
@@ -13,34 +11,29 @@ cache:
     - $HOME/.composer/cache/files
 
 before_install:
+  - phpenv config-rm xdebug.ini
   - composer self-update
   - composer global require hirak/prestissimo
-  - if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then composer remove --dev friendsofphp/php-cs-fixer --no-update --no-interaction; fi
 
-install: travis_wait travis_retry composer update --no-interaction --prefer-dist --prefer-stable $COMPOSER_OPTIONS
+install: 
+  - travis_wait travis_retry composer update --no-interaction --prefer-dist --prefer-stable $COMPOSER_OPTIONS
 
 script:
   - vendor/bin/phpunit -v
 
 jobs:
   include:
-    - stage: test
-      php: 5.6
-      env: COMPOSER_OPTIONS="--prefer-lowest"
     - stage: Test
-      php: 7.0
-      env: COMPOSER_OPTIONS="--prefer-lowest"
-    - stage: codestyle and SCA
       php: 7.1
+      env: COMPOSER_OPTIONS="--prefer-lowest"
+    - stage: Code style and static analysis
       script:
-        - phpenv config-rm xdebug.ini
-        - composer require --dev phpstan/phpstan symfony/expression-language --no-interaction --prefer-dist --prefer-stable
         - vendor/bin/phpstan analyse src --level 7
       env: PHPSTAN=true
-    - script: vendor/bin/php-cs-fixer fix --verbose --diff --dry-run
+    - script: 
+        - vendor/bin/php-cs-fixer fix --verbose --diff --dry-run
       env: CS-FIXER=true
     - stage: coverage
-      php: 7.1
       script: 
         - phpdbg -qrr vendor/bin/phpunit --coverage-clover clover.xml
       after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jobs:
       env: COMPOSER_OPTIONS="--prefer-lowest"
     - stage: Code style and static analysis
       script:
-        - vendor/bin/phpstan analyse src --level 7
+        - vendor/bin/phpstan analyse src test --level 7
       env: PHPSTAN=true
     - script: 
         - vendor/bin/php-cs-fixer fix --verbose --diff --dry-run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 2.0.0 - [Unreleased]
+### Added
+ - Add support for Symfony 4.x
+### Changed
+ - The `SentryBundle::VERSION` constant has been replaced with the `SentryBundle::getVersion(): string` method, to get a more accurate result
+ - Due to a deprecation in `symfony/console`, we require it at at least version 3.3, and we made this change to the `SentryExceptionListenerInterface`:
+```php
+    // before
+    public function onConsoleException(ConsoleExceptionEvent $event);
+    // after
+    public function onConsoleException(ConsoleErrorEvent $event);
+```
+### Removed
+ - Drop support for Symfony 2.x
+ - Drop support for PHP 5 and 7.0
+
 ## 1.0.0 - [Unreleased]
 ### Added
  - Add official support to PHP 7.2 (#71)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Add support for Symfony 4.x
 ### Changed
  - The `SentryBundle::VERSION` constant has been replaced with the `SentryBundle::getVersion(): string` method, to get a more accurate result
- - Due to a deprecation in `symfony/console`, we require it at at least version 3.3, and we made this change to the `SentryExceptionListenerInterface`:
+ - Due to a deprecation in `symfony/console`, we require it at at least version 3.3, and we added a method to `SentryExceptionListenerInterface`:
 ```php
-    // before
-    public function onConsoleException(ConsoleExceptionEvent $event);
-    // after
     public function onConsoleException(ConsoleErrorEvent $event);
 ```
 ### Removed

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,10 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.5",
+        "phpstan/phpstan": "^0.8.5",
         "phpunit/phpunit": "^6.0",
-        "scrutinizer/ocular": "^1.4"
+        "scrutinizer/ocular": "^1.4",
+        "symfony/expression-language ": "^3.0||^4.0"
     },
     "autoload": {
         "psr-4" : {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": "^7.1",
         "sentry/sentry": "^1.7",
         "symfony/config": "^3.0||^4.0",
-        "symfony/console": "^3.0||^4.0",
+        "symfony/console": "^3.3||^4.0",
         "symfony/dependency-injection": "^3.0||^4.0",
         "symfony/event-dispatcher": "^3.0||^4.0",
         "symfony/http-kernel": "^3.0||^4.0",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "phpstan/phpstan": "^0.8.5",
         "phpunit/phpunit": "^6.0",
         "scrutinizer/ocular": "^1.4",
-        "symfony/expression-language ": "^3.0||^4.0"
+        "symfony/expression-language": "^3.0||^4.0"
     },
     "autoload": {
         "psr-4" : {

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.5",
         "phpstan/phpstan": "^0.9.1",
+        "phpstan/phpstan-phpunit": "^0.9.1",
         "phpunit/phpunit": "^6.0",
         "scrutinizer/ocular": "^1.4",
         "symfony/expression-language": "^3.0||^4.0"

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.5",
-        "phpstan/phpstan": "^0.8.5",
+        "phpstan/phpstan": "^0.9.1",
         "phpunit/phpunit": "^6.0",
         "scrutinizer/ocular": "^1.4",
         "symfony/expression-language": "^3.0||^4.0"
@@ -46,6 +46,11 @@
         "psr-4" : {
             "Sentry\\SentryBundle\\Test\\": "test"
         }
+    },
+    "scripts": {
+        "phpstan": "vendor/bin/phpstan analyse src test --level 7 -c phpstan.neon",
+        "cs-check": "vendor/bin/php-cs-fixer fix --verbose --diff --dry-run",
+        "cs-fix": "vendor/bin/php-cs-fixer fix --verbose --diff"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     },
     "require": {
         "php": "^7.1",
+        "jean85/pretty-package-versions": "^1.0",
         "sentry/sentry": "^1.7",
         "symfony/config": "^3.0||^4.0",
         "symfony/console": "^3.3||^4.0",

--- a/composer.json
+++ b/composer.json
@@ -31,10 +31,10 @@
         "symfony/yaml": "^3.0||^4.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.5",
+        "friendsofphp/php-cs-fixer": "^2.8",
         "phpstan/phpstan": "^0.9.1",
         "phpstan/phpstan-phpunit": "^0.9.1",
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^6.5",
         "scrutinizer/ocular": "^1.4",
         "symfony/expression-language": "^3.0||^4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,19 +19,19 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^5.6|^7.0",
+        "php": "^7.1",
         "sentry/sentry": "^1.7",
-        "symfony/config": "^2.7|^3.0",
-        "symfony/console": "^2.7|^3.0",
-        "symfony/dependency-injection": "^2.7|^3.0",
-        "symfony/event-dispatcher": "^2.7|^3.0",
-        "symfony/http-kernel": "^2.7|^3.0",
-        "symfony/security-core": "^2.7|^3.0",
-        "symfony/yaml": "^2.7|^3.0"
+        "symfony/config": "^3.0||^4.0",
+        "symfony/console": "^3.0||^4.0",
+        "symfony/dependency-injection": "^3.0||^4.0",
+        "symfony/event-dispatcher": "^3.0||^4.0",
+        "symfony/http-kernel": "^3.0||^4.0",
+        "symfony/security-core": "^3.0||^4.0",
+        "symfony/yaml": "^3.0||^4.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.5",
-        "phpunit/phpunit": "^5.7|^6.0",
+        "phpunit/phpunit": "^6.0",
         "scrutinizer/ocular": "^1.4"
     },
     "autoload": {
@@ -46,7 +46,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "2.0.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,9 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0.x-dev"
+            "master": "2.0.x-dev",
+            "releases/0.8.x": "0.8.x-dev",
+            "releases/1.x": "1.0.x-dev"
         }
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+    ignoreErrors:
+        - '/Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface::/'
+        - '/Calling method \w+ on possibly null value of type Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface|null/'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,3 +2,5 @@ parameters:
     ignoreErrors:
         - '/Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface::/'
         - '/Calling method \w+ on possibly null value of type Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface|null/'
+includes:
+	- vendor/phpstan/phpstan-phpunit/extension.neon

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -6,6 +6,8 @@ use Raven_Compat;
 use Sentry\SentryBundle\EventListener\ExceptionListener;
 use Sentry\SentryBundle\EventListener\SentryExceptionListenerInterface;
 use Sentry\SentryBundle\SentrySymfonyClient;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
@@ -25,6 +27,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
+        /** @var ArrayNodeDefinition $rootNode */
         $rootNode = $treeBuilder->root('sentry');
 
         // Basic Sentry configuration

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -138,10 +138,7 @@ class Configuration implements ConfigurationInterface
         return $treeBuilder;
     }
 
-    /**
-     * @return \Closure
-     */
-    private function getExceptionListenerInvalidationClosure()
+    private function getExceptionListenerInvalidationClosure(): callable
     {
         return function ($value) {
             $implements = class_implements($value);
@@ -153,10 +150,7 @@ class Configuration implements ConfigurationInterface
         };
     }
 
-    /**
-     * @return \Closure
-     */
-    private function getTrimClosure()
+    private function getTrimClosure(): callable
     {
         return function ($str) {
             $value = trim($str);

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -7,7 +7,6 @@ use Sentry\SentryBundle\EventListener\ExceptionListener;
 use Sentry\SentryBundle\EventListener\SentryExceptionListenerInterface;
 use Sentry\SentryBundle\SentrySymfonyClient;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
-use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;

--- a/src/ErrorTypesParser.php
+++ b/src/ErrorTypesParser.php
@@ -7,14 +7,15 @@ namespace Sentry\SentryBundle;
  */
 class ErrorTypesParser
 {
-    private $expression = null;
+    /** @var string */
+    private $expression;
 
     /**
      * Initialize ErrorParser
      *
      * @param string $expression Error Types e.g. E_ALL & ~E_DEPRECATED & ~E_NOTICE
      */
-    public function __construct($expression)
+    public function __construct(string $expression)
     {
         $this->expression = $expression;
     }
@@ -23,8 +24,9 @@ class ErrorTypesParser
      * Parse and compute the error types expression
      *
      * @return int the parsed expression
+     * @throws \InvalidArgumentException
      */
-    public function parse()
+    public function parse(): int
     {
         // convert constants to ints
         $this->expression = $this->convertErrorConstants($this->expression);
@@ -43,7 +45,7 @@ class ErrorTypesParser
      * @param  string $expression e.g. E_ALL & ~E_DEPRECATED & ~E_NOTICE
      * @return string   converted expression e.g. 32767 & ~8192 & ~8
      */
-    private function convertErrorConstants($expression)
+    private function convertErrorConstants(string $expression): string
     {
         $output = preg_replace_callback('/(E_[a-zA-Z_]+)/', function ($errorConstant) {
             if (defined($errorConstant[1])) {
@@ -61,8 +63,9 @@ class ErrorTypesParser
      *
      * @param  string $expression prepared expression e.g. 32767&~8192&~8
      * @return int  computed expression e.g. 24567
+     * @throws \InvalidArgumentException
      */
-    private function compute($expression)
+    private function compute(string $expression): int
     {
         // catch anything which could be a security issue
         if (0 !== preg_match("/[^\d.+*%^|&~<>\/()-]/", $this->expression)) {

--- a/src/Event/SentryUserContextEvent.php
+++ b/src/Event/SentryUserContextEvent.php
@@ -7,6 +7,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class SentryUserContextEvent extends Event
 {
+    /** @var TokenInterface */
     private $authenticationToken;
 
     public function __construct(TokenInterface $authenticationToken)
@@ -14,7 +15,7 @@ class SentryUserContextEvent extends Event
         $this->authenticationToken = $authenticationToken;
     }
 
-    public function getAuthenticationToken()
+    public function getAuthenticationToken(): TokenInterface
     {
         return $this->authenticationToken;
     }

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -143,7 +143,7 @@ class ExceptionListener implements SentryExceptionListenerInterface
         $this->client->captureException($exception, $data);
     }
 
-    protected function shouldExceptionCaptureBeSkipped(\Throwable $exception)
+    protected function shouldExceptionCaptureBeSkipped(\Throwable $exception): bool
     {
         foreach ($this->skipCapture as $className) {
             if ($exception instanceof $className) {

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -172,7 +172,7 @@ class ExceptionListener implements SentryExceptionListenerInterface
         }
 
         if (is_object($user) && method_exists($user, '__toString')) {
-            $this->client->set_user_data($user->__toString());
+            $this->client->set_user_data((string)$user);
         }
     }
 }

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -131,6 +131,9 @@ class ExceptionListener implements SentryExceptionListenerInterface
         $this->handleConsoleError($event);
     }
 
+    /**
+     * @param ConsoleExceptionEvent|ConsoleErrorEvent $event
+     */
     private function handleConsoleError(ConsoleEvent $event): void
     {
         $command = $event->getCommand();

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -125,6 +125,7 @@ class ExceptionListener implements SentryExceptionListenerInterface
     public function onConsoleException(ConsoleErrorEvent $event)
     {
         $command = $event->getCommand();
+        /** @var \Exception $exception to avoid issues with PHPStan */
         $exception = $event->getError();
 
         if ($this->shouldExceptionCaptureBeSkipped($exception)) {

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -5,7 +5,7 @@ namespace Sentry\SentryBundle\EventListener;
 use Sentry\SentryBundle\Event\SentryUserContextEvent;
 use Sentry\SentryBundle\SentrySymfonyEvents;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
-use Symfony\Component\Console\Event\ConsoleExceptionEvent;
+use Symfony\Component\Console\Event\ConsoleErrorEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
@@ -71,7 +71,7 @@ class ExceptionListener implements SentryExceptionListenerInterface
      *
      * @param GetResponseEvent $event
      */
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequest(GetResponseEvent $event): void
     {
         if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
             return;
@@ -120,9 +120,9 @@ class ExceptionListener implements SentryExceptionListenerInterface
     }
 
     /**
-     * @param ConsoleExceptionEvent $event
+     * @param ConsoleErrorEvent $event
      */
-    public function onConsoleException(ConsoleExceptionEvent $event)
+    public function onConsoleException(ConsoleErrorEvent $event)
     {
         $command = $event->getCommand();
         $exception = $event->getException();

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -94,7 +94,7 @@ class ExceptionListener implements SentryExceptionListenerInterface
     /**
      * @param GetResponseForExceptionEvent $event
      */
-    public function onKernelException(GetResponseForExceptionEvent $event)
+    public function onKernelException(GetResponseForExceptionEvent $event): void
     {
         $exception = $event->getException();
 
@@ -114,7 +114,7 @@ class ExceptionListener implements SentryExceptionListenerInterface
      *
      * @return void
      */
-    public function onConsoleCommand(ConsoleCommandEvent $event)
+    public function onConsoleCommand(ConsoleCommandEvent $event): void
     {
         // only triggers loading of client, does not need to do anything.
     }
@@ -122,7 +122,7 @@ class ExceptionListener implements SentryExceptionListenerInterface
     /**
      * @param ConsoleErrorEvent $event
      */
-    public function onConsoleException(ConsoleErrorEvent $event)
+    public function onConsoleException(ConsoleErrorEvent $event): void
     {
         $command = $event->getCommand();
         /** @var \Exception $exception to avoid issues with PHPStan */

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -125,7 +125,7 @@ class ExceptionListener implements SentryExceptionListenerInterface
     public function onConsoleException(ConsoleErrorEvent $event)
     {
         $command = $event->getCommand();
-        $exception = $event->getException();
+        $exception = $event->getError();
 
         if ($this->shouldExceptionCaptureBeSkipped($exception)) {
             return;
@@ -142,7 +142,7 @@ class ExceptionListener implements SentryExceptionListenerInterface
         $this->client->captureException($exception, $data);
     }
 
-    protected function shouldExceptionCaptureBeSkipped(\Exception $exception)
+    protected function shouldExceptionCaptureBeSkipped(\Throwable $exception)
     {
         foreach ($this->skipCapture as $className) {
             if ($exception instanceof $className) {

--- a/src/EventListener/SentryExceptionListenerInterface.php
+++ b/src/EventListener/SentryExceptionListenerInterface.php
@@ -2,7 +2,7 @@
 
 namespace Sentry\SentryBundle\EventListener;
 
-use Symfony\Component\Console\Event\ConsoleExceptionEvent;
+use Symfony\Component\Console\Event\ConsoleErrorEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 
@@ -31,7 +31,7 @@ interface SentryExceptionListenerInterface
      * When an exception occurs on the command line, this method will be
      * triggered for capturing the error.
      *
-     * @param ConsoleExceptionEvent $event
+     * @param ConsoleErrorEvent $event
      */
-    public function onConsoleException(ConsoleExceptionEvent $event);
+    public function onConsoleException(ConsoleErrorEvent $event);
 }

--- a/src/EventListener/SentryExceptionListenerInterface.php
+++ b/src/EventListener/SentryExceptionListenerInterface.php
@@ -3,6 +3,7 @@
 namespace Sentry\SentryBundle\EventListener;
 
 use Symfony\Component\Console\Event\ConsoleErrorEvent;
+use Symfony\Component\Console\Event\ConsoleExceptionEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 
@@ -33,5 +34,14 @@ interface SentryExceptionListenerInterface
      *
      * @param ConsoleErrorEvent $event
      */
-    public function onConsoleException(ConsoleErrorEvent $event): void;
+    public function onConsoleError(ConsoleErrorEvent $event): void;
+
+    /**
+     * When an exception occurs on the command line, this method will be
+     * triggered for capturing the error.
+     *
+     * @param ConsoleErrorEvent $event
+     * @deprecated This method exists for BC with Symfony 3.x
+     */
+    public function onConsoleException(ConsoleExceptionEvent $event): void;
 }

--- a/src/EventListener/SentryExceptionListenerInterface.php
+++ b/src/EventListener/SentryExceptionListenerInterface.php
@@ -17,7 +17,7 @@ interface SentryExceptionListenerInterface
      *
      * @param GetResponseEvent $event
      */
-    public function onKernelRequest(GetResponseEvent $event);
+    public function onKernelRequest(GetResponseEvent $event): void;
 
     /**
      * When an exception occurs as part of a web request, this method will be
@@ -25,7 +25,7 @@ interface SentryExceptionListenerInterface
      *
      * @param GetResponseForExceptionEvent $event
      */
-    public function onKernelException(GetResponseForExceptionEvent $event);
+    public function onKernelException(GetResponseForExceptionEvent $event): void;
 
     /**
      * When an exception occurs on the command line, this method will be
@@ -33,5 +33,5 @@ interface SentryExceptionListenerInterface
      *
      * @param ConsoleErrorEvent $event
      */
-    public function onConsoleException(ConsoleErrorEvent $event);
+    public function onConsoleException(ConsoleErrorEvent $event): void;
 }

--- a/src/EventListener/SentryExceptionListenerInterface.php
+++ b/src/EventListener/SentryExceptionListenerInterface.php
@@ -40,7 +40,7 @@ interface SentryExceptionListenerInterface
      * When an exception occurs on the command line, this method will be
      * triggered for capturing the error.
      *
-     * @param ConsoleErrorEvent $event
+     * @param ConsoleExceptionEvent $event
      * @deprecated This method exists for BC with Symfony 3.x
      */
     public function onConsoleException(ConsoleExceptionEvent $event): void;

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -2,6 +2,7 @@ services:
     sentry.client:
         class: '%sentry.client%'
         arguments: ['%sentry.dsn%', '%sentry.options%']
+        public: true
         calls:
             - [install, []]
 

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,21 +1,22 @@
 services:
-    sentry.client:
-        class: '%sentry.client%'
-        arguments: ['%sentry.dsn%', '%sentry.options%']
-        public: true
-        calls:
-            - [install, []]
+  sentry.client:
+    class: '%sentry.client%'
+    arguments: ['%sentry.dsn%', '%sentry.options%']
+    public: true
+    calls:
+      - [install, []]
 
-    sentry.exception_listener:
-        class: '%sentry.exception_listener%'
-        arguments:
-          - '@sentry.client'
-          - '@event_dispatcher'
-          - '%sentry.skip_capture%'
-          - '@?security.token_storage'
-          - '@?security.authorization_checker'
-        tags:
-            - { name: kernel.event_listener, event: kernel.request,    method: onKernelRequest, priority: '%sentry.listener_priorities.request%'}
-            - { name: kernel.event_listener, event: kernel.exception,  method: onKernelException, priority: '%sentry.listener_priorities.kernel_exception%' }
-            - { name: kernel.event_listener, event: console.command,   method: onConsoleCommand }
-            - { name: kernel.event_listener, event: console.exception, method: onConsoleException, priority: '%sentry.listener_priorities.console_exception%' }
+  sentry.exception_listener:
+    class: '%sentry.exception_listener%'
+    arguments:
+      - '@sentry.client'
+      - '@event_dispatcher'
+      - '%sentry.skip_capture%'
+      - '@?security.token_storage'
+      - '@?security.authorization_checker'
+    tags:
+      - { name: kernel.event_listener, event: kernel.request,    method: onKernelRequest, priority: '%sentry.listener_priorities.request%'}
+      - { name: kernel.event_listener, event: kernel.exception,  method: onKernelException, priority: '%sentry.listener_priorities.kernel_exception%' }
+      - { name: kernel.event_listener, event: console.command,   method: onConsoleCommand }
+      - { name: kernel.event_listener, event: console.exception, method: onConsoleException, priority: '%sentry.listener_priorities.console_exception%' }
+      - { name: kernel.event_listener, event: console.error,     method: onConsoleError, priority: '%sentry.listener_priorities.console_exception%' }

--- a/src/SentryBundle.php
+++ b/src/SentryBundle.php
@@ -2,9 +2,14 @@
 
 namespace Sentry\SentryBundle;
 
+use Jean85\PrettyVersions;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class SentryBundle extends Bundle
 {
-    const VERSION = '1.0-dev';
+    public static function getVersion(): string
+    {
+        return PrettyVersions::getVersion('sentry/sentry-symfony')
+            ->getPrettyVersion();
+    }
 }

--- a/src/SentrySymfonyClient.php
+++ b/src/SentrySymfonyClient.php
@@ -13,7 +13,7 @@ class SentrySymfonyClient extends \Raven_Client
 
         $options['sdk'] = [
             'name' => 'sentry-symfony',
-            'version' => SentryBundle::VERSION,
+            'version' => SentryBundle::getVersion(),
         ];
 
         parent::__construct($dsn, $options);

--- a/src/SentrySymfonyClient.php
+++ b/src/SentrySymfonyClient.php
@@ -4,7 +4,7 @@ namespace Sentry\SentryBundle;
 
 class SentrySymfonyClient extends \Raven_Client
 {
-    public function __construct($dsn = null, $options = [])
+    public function __construct(?string $dsn = null, array $options = [])
     {
         if (! empty($options['error_types'])) {
             $exParser = new ErrorTypesParser($options['error_types']);

--- a/test/DependencyInjection/SentryExtensionTest.php
+++ b/test/DependencyInjection/SentryExtensionTest.php
@@ -5,7 +5,6 @@ namespace Sentry\SentryBundle\Test\DependencyInjection;
 use PHPUnit\Framework\TestCase;
 use Sentry\SentryBundle\DependencyInjection\SentryExtension;
 use Sentry\SentryBundle\EventListener\ExceptionListener;
-use Sentry\SentryBundle\EventListener\SentryExceptionListenerInterface;
 use Sentry\SentryBundle\SentrySymfonyClient;
 use Sentry\SentryBundle\Test\Fixtures\CustomExceptionListener;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
@@ -370,7 +369,7 @@ class SentryExtensionTest extends TestCase
             ->createMock(EventDispatcherInterface::class);
 
         $containerBuilder->set('event_dispatcher', $mockEventDispatcher);
-        $containerBuilder->setAlias(self::LISTENER_TEST_PUBLIC_ALIAS, new Alias('sentry.exception_listener'));
+        $containerBuilder->setAlias(self::LISTENER_TEST_PUBLIC_ALIAS, new Alias('sentry.exception_listener', true));
 
         $extension = new SentryExtension();
         $extension->load(['sentry' => $configuration], $containerBuilder);

--- a/test/DependencyInjection/SentryExtensionTest.php
+++ b/test/DependencyInjection/SentryExtensionTest.php
@@ -350,8 +350,11 @@ class SentryExtensionTest extends TestCase
         $this->assertCount(self::SUPPORTED_SENTRY_OPTIONS_COUNT, $options);
         $defaultOptions = $this->getContainer()->getParameter('sentry.options');
         foreach ($options as $name => $value) {
-            $this->assertNotEquals($defaultOptions[$name], $value,
-                'Test precondition failed: using default value for ' . $name);
+            $this->assertNotEquals(
+                $defaultOptions[$name],
+                $value,
+                'Test precondition failed: using default value for ' . $name
+            );
         }
 
         $container = $this->getContainer(['options' => $options]);

--- a/test/DependencyInjection/SentryExtensionTest.php
+++ b/test/DependencyInjection/SentryExtensionTest.php
@@ -292,6 +292,11 @@ class SentryExtensionTest extends TestCase
                     'method' => 'onConsoleException',
                     'priority' => '%sentry.listener_priorities.console_exception%',
                 ],
+                [
+                    'event' => 'console.error',
+                    'method' => 'onConsoleError',
+                    'priority' => '%sentry.listener_priorities.console_exception%',
+                ],
             ],
             $tags
         );

--- a/test/DependencyInjection/SentryExtensionTest.php
+++ b/test/DependencyInjection/SentryExtensionTest.php
@@ -5,9 +5,12 @@ namespace Sentry\SentryBundle\Test\DependencyInjection;
 use PHPUnit\Framework\TestCase;
 use Sentry\SentryBundle\DependencyInjection\SentryExtension;
 use Sentry\SentryBundle\EventListener\ExceptionListener;
+use Sentry\SentryBundle\EventListener\SentryExceptionListenerInterface;
 use Sentry\SentryBundle\SentrySymfonyClient;
 use Sentry\SentryBundle\Test\Fixtures\CustomExceptionListener;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
@@ -15,6 +18,7 @@ use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 class SentryExtensionTest extends TestCase
 {
     const SUPPORTED_SENTRY_OPTIONS_COUNT = 34;
+    const LISTENER_TEST_PUBLIC_ALIAS = 'sentry.exception_listener.public_alias';
 
     public function test_that_configuration_uses_the_right_default_values()
     {
@@ -258,8 +262,8 @@ class SentryExtensionTest extends TestCase
 
     public function test_that_it_has_sentry_exception_listener_and_it_defaults_to_default_exception_listener()
     {
-        $client = $this->getContainer()->get('sentry.exception_listener');
-        $this->assertInstanceOf(ExceptionListener::class, $client);
+        $listener = $this->getContainer()->get(self::LISTENER_TEST_PUBLIC_ALIAS);
+        $this->assertInstanceOf(ExceptionListener::class, $listener);
     }
 
     public function test_that_it_has_proper_event_listener_tags_for_exception_listener()
@@ -347,7 +351,8 @@ class SentryExtensionTest extends TestCase
         $this->assertCount(self::SUPPORTED_SENTRY_OPTIONS_COUNT, $options);
         $defaultOptions = $this->getContainer()->getParameter('sentry.options');
         foreach ($options as $name => $value) {
-            $this->assertNotEquals($defaultOptions[$name], $value, 'Test precondition failed: using default value for ' . $name);
+            $this->assertNotEquals($defaultOptions[$name], $value,
+                'Test precondition failed: using default value for ' . $name);
         }
 
         $container = $this->getContainer(['options' => $options]);
@@ -355,11 +360,7 @@ class SentryExtensionTest extends TestCase
         $this->assertSame($options, $container->getParameter('sentry.options'));
     }
 
-    /**
-     * @param array $configuration
-     * @return ContainerBuilder
-     */
-    private function getContainer(array $configuration = [])
+    private function getContainer(array $configuration = []): Container
     {
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->setParameter('kernel.root_dir', 'kernel/root');
@@ -369,6 +370,7 @@ class SentryExtensionTest extends TestCase
             ->createMock(EventDispatcherInterface::class);
 
         $containerBuilder->set('event_dispatcher', $mockEventDispatcher);
+        $containerBuilder->setAlias(self::LISTENER_TEST_PUBLIC_ALIAS, new Alias('sentry.exception_listener'));
 
         $extension = new SentryExtension();
         $extension->load(['sentry' => $configuration], $containerBuilder);

--- a/test/DependencyInjection/SentryExtensionTest.php
+++ b/test/DependencyInjection/SentryExtensionTest.php
@@ -17,8 +17,8 @@ use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
 class SentryExtensionTest extends TestCase
 {
-    const SUPPORTED_SENTRY_OPTIONS_COUNT = 34;
-    const LISTENER_TEST_PUBLIC_ALIAS = 'sentry.exception_listener.public_alias';
+    private const SUPPORTED_SENTRY_OPTIONS_COUNT = 34;
+    private const LISTENER_TEST_PUBLIC_ALIAS = 'sentry.exception_listener.public_alias';
 
     public function test_that_configuration_uses_the_right_default_values()
     {

--- a/test/EventListener/ExceptionListenerTest.php
+++ b/test/EventListener/ExceptionListenerTest.php
@@ -463,13 +463,12 @@ class ExceptionListenerTest extends TestCase
     public function test_that_it_captures_console_exception(?Command $mockCommand, string $expectedCommandName)
     {
         $error = $this->createMock(\Error::class);
+        /** @var InputInterface $input */
+        $input = $this->createMock(InputInterface::class);
+        /** @var OutputInterface $output */
+        $output = $this->createMock(OutputInterface::class);
 
-        $event = new ConsoleErrorEvent(
-            $this->createMock(InputInterface::class),
-            $this->createMock(OutputInterface::class),
-            $error,
-            $mockCommand
-        );
+        $event = new ConsoleErrorEvent($input, $output, $error, $mockCommand);
         $event->setExitCode(10);
 
         $this->mockEventDispatcher

--- a/test/EventListener/ExceptionListenerTest.php
+++ b/test/EventListener/ExceptionListenerTest.php
@@ -8,6 +8,7 @@ use Sentry\SentryBundle\Event\SentryUserContextEvent;
 use Sentry\SentryBundle\EventListener\ExceptionListener;
 use Sentry\SentryBundle\SentrySymfonyEvents;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Event\ConsoleErrorEvent;
 use Symfony\Component\Console\Event\ConsoleExceptionEvent;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -75,20 +76,17 @@ class ExceptionListenerTest extends TestCase
         $mockEvent
             ->expects($this->once())
             ->method('getRequestType')
-            ->willReturn(HttpKernelInterface::SUB_REQUEST)
-        ;
+            ->willReturn(HttpKernelInterface::SUB_REQUEST);
 
         $this->mockSentryClient
             ->expects($this->never())
             ->method('set_user_data')
-            ->withAnyParameters()
-        ;
+            ->withAnyParameters();
 
         $this->mockEventDispatcher
             ->expects($this->never())
             ->method('dispatch')
-            ->withAnyParameters()
-        ;
+            ->withAnyParameters();
 
         $this->containerBuilder->compile();
         $listener = $this->containerBuilder->get('sentry.exception_listener');
@@ -104,20 +102,17 @@ class ExceptionListenerTest extends TestCase
         $mockEvent
             ->expects($this->once())
             ->method('getRequestType')
-            ->willReturn(HttpKernelInterface::MASTER_REQUEST)
-        ;
+            ->willReturn(HttpKernelInterface::MASTER_REQUEST);
 
         $this->mockSentryClient
             ->expects($this->never())
             ->method('set_user_data')
-            ->withAnyParameters()
-        ;
+            ->withAnyParameters();
 
         $this->mockEventDispatcher
             ->expects($this->never())
             ->method('dispatch')
-            ->withAnyParameters()
-        ;
+            ->withAnyParameters();
 
         $this->assertFalse($this->containerBuilder->has('security.token_storage'));
 
@@ -136,20 +131,17 @@ class ExceptionListenerTest extends TestCase
         $mockEvent
             ->expects($this->once())
             ->method('getRequestType')
-            ->willReturn(HttpKernelInterface::MASTER_REQUEST)
-        ;
+            ->willReturn(HttpKernelInterface::MASTER_REQUEST);
 
         $this->mockSentryClient
             ->expects($this->never())
             ->method('set_user_data')
-            ->withAnyParameters()
-        ;
+            ->withAnyParameters();
 
         $this->mockEventDispatcher
             ->expects($this->never())
             ->method('dispatch')
-            ->withAnyParameters()
-        ;
+            ->withAnyParameters();
 
         $this->containerBuilder->compile();
 
@@ -170,31 +162,26 @@ class ExceptionListenerTest extends TestCase
         $mockEvent
             ->expects($this->once())
             ->method('getRequestType')
-            ->willReturn(HttpKernelInterface::MASTER_REQUEST)
-        ;
+            ->willReturn(HttpKernelInterface::MASTER_REQUEST);
 
         $this->mockAuthorizationChecker
             ->method('isGranted')
             ->with($this->identicalTo(AuthenticatedVoter::IS_AUTHENTICATED_REMEMBERED))
-            ->willReturn(true)
-        ;
+            ->willReturn(true);
 
         $this->mockTokenStorage
             ->method('getToken')
-            ->willReturn(null)
-        ;
+            ->willReturn(null);
 
         $this->mockSentryClient
             ->expects($this->never())
             ->method('set_user_data')
-            ->withAnyParameters()
-        ;
+            ->withAnyParameters();
 
         $this->mockEventDispatcher
             ->expects($this->never())
             ->method('dispatch')
-            ->withAnyParameters()
-        ;
+            ->withAnyParameters();
 
         $this->containerBuilder->compile();
         $listener = $this->containerBuilder->get('sentry.exception_listener');
@@ -210,38 +197,32 @@ class ExceptionListenerTest extends TestCase
 
         $mockToken
             ->method('getUser')
-            ->willReturn($user)
-        ;
+            ->willReturn($user);
 
         $mockEvent = $this->createMock(GetResponseEvent::class);
 
         $mockEvent->expects($this->once())
             ->method('getRequestType')
-            ->willReturn(HttpKernelInterface::MASTER_REQUEST)
-        ;
+            ->willReturn(HttpKernelInterface::MASTER_REQUEST);
 
         $this->mockAuthorizationChecker
             ->method('isGranted')
             ->with($this->identicalTo(AuthenticatedVoter::IS_AUTHENTICATED_REMEMBERED))
-            ->willReturn(false)
-        ;
+            ->willReturn(false);
 
         $this->mockTokenStorage
             ->method('getToken')
-            ->willReturn($mockToken)
-        ;
+            ->willReturn($mockToken);
 
         $this->mockSentryClient
             ->expects($this->never())
             ->method('set_user_data')
-            ->withAnyParameters()
-        ;
+            ->withAnyParameters();
 
         $this->mockEventDispatcher
             ->expects($this->never())
             ->method('dispatch')
-            ->withAnyParameters()
-        ;
+            ->withAnyParameters();
 
         $this->containerBuilder->compile();
         $listener = $this->containerBuilder->get('sentry.exception_listener');
@@ -257,40 +238,34 @@ class ExceptionListenerTest extends TestCase
 
         $mockToken
             ->method('getUser')
-            ->willReturn($user)
-        ;
+            ->willReturn($user);
 
         $mockToken
             ->method('isAuthenticated')
-            ->willReturn(true)
-        ;
+            ->willReturn(true);
 
         $mockEvent = $this->createMock(GetResponseEvent::class);
 
         $mockEvent
             ->expects($this->once())
             ->method('getRequestType')
-            ->willReturn(HttpKernelInterface::MASTER_REQUEST)
-        ;
+            ->willReturn(HttpKernelInterface::MASTER_REQUEST);
 
         $this
             ->mockAuthorizationChecker
             ->method('isGranted')
             ->with($this->identicalTo(AuthenticatedVoter::IS_AUTHENTICATED_REMEMBERED))
-            ->willReturn(true)
-        ;
+            ->willReturn(true);
 
         $this->mockTokenStorage
             ->method('getToken')
-            ->willReturn($mockToken)
-        ;
+            ->willReturn($mockToken);
 
         $this
             ->mockSentryClient
             ->expects($this->once())
             ->method('set_user_data')
-            ->with($this->identicalTo('username'))
-        ;
+            ->with($this->identicalTo('username'));
 
         $this
             ->mockEventDispatcher
@@ -299,8 +274,7 @@ class ExceptionListenerTest extends TestCase
             ->with(
                 $this->identicalTo(SentrySymfonyEvents::SET_USER_CONTEXT),
                 $this->isInstanceOf(SentryUserContextEvent::class)
-            )
-        ;
+            );
 
         $this->containerBuilder->compile();
         $listener = $this->containerBuilder->get('sentry.exception_listener');
@@ -313,38 +287,32 @@ class ExceptionListenerTest extends TestCase
 
         $mockToken
             ->method('getUser')
-            ->willReturn('some_user')
-        ;
+            ->willReturn('some_user');
 
         $mockToken
             ->method('isAuthenticated')
-            ->willReturn(true)
-        ;
+            ->willReturn(true);
 
         $mockEvent = $this->createMock(GetResponseEvent::class);
 
         $mockEvent
             ->expects($this->once())
             ->method('getRequestType')
-            ->willReturn(HttpKernelInterface::MASTER_REQUEST)
-        ;
+            ->willReturn(HttpKernelInterface::MASTER_REQUEST);
 
         $this->mockAuthorizationChecker
             ->method('isGranted')
             ->with($this->identicalTo(AuthenticatedVoter::IS_AUTHENTICATED_REMEMBERED))
-            ->willReturn(true)
-        ;
+            ->willReturn(true);
 
         $this->mockTokenStorage
             ->method('getToken')
-            ->willReturn($mockToken)
-        ;
+            ->willReturn($mockToken);
 
         $this->mockSentryClient
             ->expects($this->once())
             ->method('set_user_data')
-            ->with($this->identicalTo('some_user'))
-        ;
+            ->with($this->identicalTo('some_user'));
 
         $this->mockEventDispatcher
             ->expects($this->once())
@@ -352,8 +320,7 @@ class ExceptionListenerTest extends TestCase
             ->with(
                 $this->identicalTo(SentrySymfonyEvents::SET_USER_CONTEXT),
                 $this->isInstanceOf(SentryUserContextEvent::class)
-            )
-        ;
+            );
 
         $this->containerBuilder->compile();
         $listener = $this->containerBuilder->get('sentry.exception_listener');
@@ -364,51 +331,43 @@ class ExceptionListenerTest extends TestCase
     {
         $mockUser = $this->getMockBuilder('stdClass')
             ->setMethods(['__toString'])
-            ->getMock()
-        ;
+            ->getMock();
 
         $mockUser
             ->expects($this->once())
             ->method('__toString')
-            ->willReturn('std_user')
-        ;
+            ->willReturn('std_user');
 
         $mockToken = $this->createMock(TokenInterface::class);
 
         $mockToken
             ->method('getUser')
-            ->willReturn($mockUser)
-        ;
+            ->willReturn($mockUser);
 
         $mockToken
             ->method('isAuthenticated')
-            ->willReturn(true)
-        ;
+            ->willReturn(true);
 
         $mockEvent = $this->createMock(GetResponseEvent::class);
 
         $mockEvent
             ->expects($this->once())
             ->method('getRequestType')
-            ->willReturn(HttpKernelInterface::MASTER_REQUEST)
-        ;
+            ->willReturn(HttpKernelInterface::MASTER_REQUEST);
 
         $this->mockAuthorizationChecker
             ->method('isGranted')
             ->with($this->identicalTo(AuthenticatedVoter::IS_AUTHENTICATED_REMEMBERED))
-            ->willReturn(true)
-        ;
+            ->willReturn(true);
 
         $this->mockTokenStorage
             ->method('getToken')
-            ->willReturn($mockToken)
-        ;
+            ->willReturn($mockToken);
 
         $this->mockSentryClient
             ->expects($this->once())
             ->method('set_user_data')
-            ->with($this->identicalTo('std_user'))
-        ;
+            ->with($this->identicalTo('std_user'));
 
         $this->mockEventDispatcher
             ->expects($this->once())
@@ -416,8 +375,7 @@ class ExceptionListenerTest extends TestCase
             ->with(
                 $this->identicalTo(SentrySymfonyEvents::SET_USER_CONTEXT),
                 $this->isInstanceOf(SentryUserContextEvent::class)
-            )
-        ;
+            );
 
         $this->containerBuilder->compile();
         $listener = $this->containerBuilder->get('sentry.exception_listener');
@@ -429,21 +387,18 @@ class ExceptionListenerTest extends TestCase
         $mockToken = $this->createMock(TokenInterface::class);
         $mockToken
             ->method('isAuthenticated')
-            ->willReturn(false)
-        ;
+            ->willReturn(false);
 
         $mockEvent = $this->createMock(GetResponseEvent::class);
 
         $mockEvent
             ->expects($this->once())
             ->method('getRequestType')
-            ->willReturn(HttpKernelInterface::MASTER_REQUEST)
-        ;
+            ->willReturn(HttpKernelInterface::MASTER_REQUEST);
 
         $this->mockTokenStorage
             ->method('getToken')
-            ->willReturn($mockToken)
-        ;
+            ->willReturn($mockToken);
 
         $this->containerBuilder->compile();
         $listener = $this->containerBuilder->get('sentry.exception_listener');
@@ -457,20 +412,17 @@ class ExceptionListenerTest extends TestCase
         $mockEvent
             ->expects($this->once())
             ->method('getException')
-            ->willReturn(new HttpException(401))
-        ;
+            ->willReturn(new HttpException(401));
 
         $this->mockEventDispatcher
             ->expects($this->never())
             ->method('dispatch')
-            ->withAnyParameters()
-        ;
+            ->withAnyParameters();
 
         $this->mockSentryClient
             ->expects($this->never())
             ->method('captureException')
-            ->withAnyParameters()
-        ;
+            ->withAnyParameters();
 
         $this->containerBuilder->compile();
         $listener = $this->containerBuilder->get('sentry.exception_listener');
@@ -485,20 +437,17 @@ class ExceptionListenerTest extends TestCase
         $mockEvent
             ->expects($this->once())
             ->method('getException')
-            ->willReturn($reportableException)
-        ;
+            ->willReturn($reportableException);
 
         $this->mockEventDispatcher
             ->expects($this->once())
             ->method('dispatch')
-            ->with($this->identicalTo(SentrySymfonyEvents::PRE_CAPTURE), $this->identicalTo($mockEvent))
-        ;
+            ->with($this->identicalTo(SentrySymfonyEvents::PRE_CAPTURE), $this->identicalTo($mockEvent));
 
         $this->mockSentryClient
             ->expects($this->once())
             ->method('captureException')
-            ->with($this->identicalTo($reportableException))
-        ;
+            ->with($this->identicalTo($reportableException));
 
         $this->containerBuilder->compile();
         $listener = $this->containerBuilder->get('sentry.exception_listener');
@@ -512,31 +461,27 @@ class ExceptionListenerTest extends TestCase
     {
         $reportableException = new \Exception();
 
-        $mockEvent = $this->createMock(ConsoleExceptionEvent::class);
+        $mockEvent = $this->createMock(ConsoleErrorEvent::class);
 
         $mockEvent
             ->expects($this->once())
             ->method('getExitCode')
-            ->willReturn(10)
-        ;
+            ->willReturn(10);
 
         $mockEvent
             ->expects($this->once())
             ->method('getException')
-            ->willReturn($reportableException)
-        ;
+            ->willReturn($reportableException);
 
         $mockEvent
             ->expects($this->once())
             ->method('getCommand')
-            ->willReturn($mockCommand)
-        ;
+            ->willReturn($mockCommand);
 
         $this->mockEventDispatcher
             ->expects($this->once())
             ->method('dispatch')
-            ->with($this->identicalTo(SentrySymfonyEvents::PRE_CAPTURE), $this->identicalTo($mockEvent))
-        ;
+            ->with($this->identicalTo(SentrySymfonyEvents::PRE_CAPTURE), $this->identicalTo($mockEvent));
 
         $this->mockSentryClient
             ->expects($this->once())
@@ -549,8 +494,7 @@ class ExceptionListenerTest extends TestCase
                         'status_code' => 10,
                     ],
                 ])
-            )
-        ;
+            );
 
         $this->containerBuilder->compile();
         $listener = $this->containerBuilder->get('sentry.exception_listener');
@@ -563,8 +507,7 @@ class ExceptionListenerTest extends TestCase
         $mockCommand
             ->expects($this->once())
             ->method('getName')
-            ->willReturn('cmd name')
-        ;
+            ->willReturn('cmd name');
 
         return [
             [$mockCommand, 'cmd name'],
@@ -583,26 +526,22 @@ class ExceptionListenerTest extends TestCase
         $mockEvent
             ->expects($this->once())
             ->method('getException')
-            ->willReturn($reportableException)
-        ;
+            ->willReturn($reportableException);
 
         $this->mockEventDispatcher
             ->expects($this->once())
             ->method('dispatch')
-            ->with($this->identicalTo(SentrySymfonyEvents::PRE_CAPTURE), $this->identicalTo($mockEvent))
-        ;
+            ->with($this->identicalTo(SentrySymfonyEvents::PRE_CAPTURE), $this->identicalTo($mockEvent));
 
         $this->mockSentryClient
             ->expects($this->never())
             ->method('captureException')
-            ->withAnyParameters()
-        ;
+            ->withAnyParameters();
 
         $replacementClient
             ->expects($this->once())
             ->method('captureException')
-            ->with($this->identicalTo($reportableException))
-        ;
+            ->with($this->identicalTo($reportableException));
 
         $this->containerBuilder->compile();
         $listener = $this->containerBuilder->get('sentry.exception_listener');

--- a/test/EventListener/ExceptionListenerTest.php
+++ b/test/EventListener/ExceptionListenerTest.php
@@ -59,7 +59,7 @@ class ExceptionListenerTest extends TestCase
         $containerBuilder->set('security.authorization_checker', $this->mockAuthorizationChecker);
         $containerBuilder->set('sentry.client', $this->mockSentryClient);
         $containerBuilder->set('event_dispatcher', $this->mockEventDispatcher);
-        $containerBuilder->setAlias(self::LISTENER_TEST_PUBLIC_ALIAS, new Alias('sentry.exception_listener'));
+        $containerBuilder->setAlias(self::LISTENER_TEST_PUBLIC_ALIAS, new Alias('sentry.exception_listener', true));
 
         $extension = new SentryExtension();
         $extension->load([], $containerBuilder);

--- a/test/EventListener/ExceptionListenerTest.php
+++ b/test/EventListener/ExceptionListenerTest.php
@@ -29,19 +29,14 @@ class ExceptionListenerTest extends TestCase
 {
     private const LISTENER_TEST_PUBLIC_ALIAS = 'sentry.exception_listener.public_alias';
 
-    /** @var ContainerBuilder|\PHPUnit_Framework_MockObject_MockObject */
     private $containerBuilder;
 
-    /** @var \Raven_Client|\PHPUnit_Framework_MockObject_MockObject */
     private $mockSentryClient;
 
-    /** @var TokenStorageInterface|\PHPUnit_Framework_MockObject_MockObject */
     private $mockTokenStorage;
 
-    /** @var AuthorizationCheckerInterface|\PHPUnit_Framework_MockObject_MockObject */
     private $mockAuthorizationChecker;
 
-    /** @var EventDispatcherInterface|\PHPUnit_Framework_MockObject_MockObject */
     private $mockEventDispatcher;
 
     public function setUp()
@@ -514,7 +509,7 @@ class ExceptionListenerTest extends TestCase
 
     public function test_that_it_can_replace_client()
     {
-        $replacementClient = $this->createMock('Raven_Client');
+        $replacementClient = $this->createMock(\Raven_Client::class);
 
         $reportableException = new \Exception();
 

--- a/test/EventListener/ExceptionListenerTest.php
+++ b/test/EventListener/ExceptionListenerTest.php
@@ -10,7 +10,6 @@ use Sentry\SentryBundle\EventListener\SentryExceptionListenerInterface;
 use Sentry\SentryBundle\SentrySymfonyEvents;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Event\ConsoleErrorEvent;
-use Symfony\Component\Console\Event\ConsoleExceptionEvent;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/test/SentrySymfonyClientTest.php
+++ b/test/SentrySymfonyClientTest.php
@@ -15,7 +15,7 @@ class SentrySymfonyClientTest extends TestCase
         $data = $client->get_default_data();
 
         $this->assertEquals('sentry-symfony', $data['sdk']['name']);
-        $this->assertEquals(SentryBundle::VERSION, $data['sdk']['version']);
+        $this->assertEquals(SentryBundle::getVersion(), $data['sdk']['version']);
     }
 
     public function test_that_it_forwards_options()


### PR DESCRIPTION
DO NOT MERGE BEFORE #87!! Also wait for Symfony 4.0 release, so it will be tested in Travis CI.

This follows #89:

- [x] drop support for Symfony 2.x
- [x] support Symfony 4.x
- [x] require PHP 7.1+
- [x] thus, will leverage all the new language features (return, scalar and nullable types to start with)
- [x] wait for the release of Symfony 4, to test this in CI