### PR TITLE
Avoid double-reporting of CLI errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 2.0.1 - TBA
+### Fixed
+ - Avoid reporting CLI errors twice (#104)
+
 ## 2.0.0 - 2017-12-12
 ### Added
  - Add support for Symfony 4.x

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -18,5 +18,4 @@ services:
       - { name: kernel.event_listener, event: kernel.request,    method: onKernelRequest, priority: '%sentry.listener_priorities.request%'}
       - { name: kernel.event_listener, event: kernel.exception,  method: onKernelException, priority: '%sentry.listener_priorities.kernel_exception%' }
       - { name: kernel.event_listener, event: console.command,   method: onConsoleCommand }
-      - { name: kernel.event_listener, event: console.exception, method: onConsoleException, priority: '%sentry.listener_priorities.console_exception%' }
       - { name: kernel.event_listener, event: console.error,     method: onConsoleError, priority: '%sentry.listener_priorities.console_exception%' }

--- a/test/DependencyInjection/SentryExtensionTest.php
+++ b/test/DependencyInjection/SentryExtensionTest.php
@@ -288,11 +288,6 @@ class SentryExtensionTest extends TestCase
                 ],
                 ['event' => 'console.command', 'method' => 'onConsoleCommand'],
                 [
-                    'event' => 'console.exception',
-                    'method' => 'onConsoleException',
-                    'priority' => '%sentry.listener_priorities.console_exception%',
-                ],
-                [
                     'event' => 'console.error',
                     'method' => 'onConsoleError',
                     'priority' => '%sentry.listener_priorities.console_exception%',


### PR DESCRIPTION
This should solve #104. Since we already require `symfony/console` 3.3+, we can rely on the `console.error` event only, without the need of the older, deprecated `console.exception`.