### PR TITLE
Fix processorOptions configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+ - Fix `processorOptions` in yaml configuration
 
 ## 2.0.1 - 2018-01-31
 ### Fixed

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -107,7 +107,9 @@ class Configuration implements ConfigurationInterface
                             ->prototype('scalar')->end()
                         ->end()
                         ->arrayNode('processorOptions')
-                            ->prototype('scalar')->end()
+                            ->arrayPrototype()
+                                ->prototype('scalar')->end()
+                            ->end()
                         ->end()
                     ->end()
                 ->end();

--- a/test/DependencyInjection/SentryExtensionTest.php
+++ b/test/DependencyInjection/SentryExtensionTest.php
@@ -343,7 +343,12 @@ class SentryExtensionTest extends TestCase
             'install_shutdown_handler' => false,
             'processors' => ['processor1', 'processor2'],
             'processorOptions' => [
-                'processorOption1' => 'asasdf',
+                'processor1'    =>  [
+                    'processorOption1' => 'asasdf',
+                ],
+                'processor2'    =>  [
+                    'processorOption2' => 'asasdf',
+                ]
             ],
         ];
 

--- a/test/DependencyInjection/SentryExtensionTest.php
+++ b/test/DependencyInjection/SentryExtensionTest.php
@@ -343,12 +343,12 @@ class SentryExtensionTest extends TestCase
             'install_shutdown_handler' => false,
             'processors' => ['processor1', 'processor2'],
             'processorOptions' => [
-                'processor1'    =>  [
+                'processor1' => [
                     'processorOption1' => 'asasdf',
                 ],
-                'processor2'    =>  [
+                'processor2' => [
                     'processorOption2' => 'asasdf',
-                ]
+                ],
             ],
         ];
 


### PR DESCRIPTION
Hello.

Example configuration:
```
sentry:
    dsn: '%sentry_dsn%'
    options:
        processorOptions:
            Raven_Processor_SanitizeDataProcessor:
                fields_re: '/(authorization|password|passwd|secret|password_confirmation|card_number|auth_pw|userPass)/i'
```
And and we have exception:

```
(1/1) InvalidTypeException
Invalid type for path "sentry.options.processorOptions.Raven_Processor_SanitizeDataProcessor". Expected scalar, but got array.
```

Thanks!