### PR TITLE
Fix travis slow builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,10 @@ before_install:
   - composer self-update
   - composer global require hirak/prestissimo
 
-install: travis_retry travis_wait composer update --no-interaction --prefer-dist --prefer-stable $COMPOSER_OPTIONS
+install:
+  - composer install --prefer-dist
+  - composer remove friendsofphp/php-cs-fixer --dev
+  - travis_retry travis_wait composer update --no-interaction --prefer-dist --prefer-stable $COMPOSER_OPTIONS
 
 script:
   - vendor/bin/phpunit -v
@@ -36,7 +39,9 @@ jobs:
         - composer require --dev phpstan/phpstan symfony/expression-language --no-interaction --prefer-dist --prefer-stable
         - vendor/bin/phpstan analyse src --level 7 -c phpstan.neon
       env: PHPSTAN=true
-    - script: vendor/bin/php-cs-fixer fix --verbose --diff --dry-run
+    - script:
+        - composer require friendsofphp/php-cs-fixer ^2.5 --dev
+        - vendor/bin/php-cs-fixer fix --verbose --diff --dry-run
       env: CS-FIXER=true
     - stage: coverage
       php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - composer global require hirak/prestissimo
 
 install:
-  - composer remove friendsofphp/php-cs-fixer --dev
+  - composer remove friendsofphp/php-cs-fixer --dev --no-update
   - travis_retry travis_wait composer update --no-interaction --prefer-dist --prefer-stable $COMPOSER_OPTIONS
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ before_install:
   - composer global require hirak/prestissimo
 
 install:
-  - composer install --prefer-dist
   - composer remove friendsofphp/php-cs-fixer --dev
   - travis_retry travis_wait composer update --no-interaction --prefer-dist --prefer-stable $COMPOSER_OPTIONS
 


### PR DESCRIPTION
For improve perfomance we need:

1. Remove package `friendsofphp/php-cs-fixer` before UnitTests
2. Return package on `cs` task

See #110 