### PR TITLE
add php_version

### DIFF
--- a/src/SentrySymfonyClient.php
+++ b/src/SentrySymfonyClient.php
@@ -16,6 +16,7 @@ class SentrySymfonyClient extends \Raven_Client
             'version' => SentryBundle::getVersion(),
         ];
         $options['tags']['symfony_version'] = \Symfony\Component\HttpKernel\Kernel::VERSION;
+        $options['tags']['php_version'] = phpversion();
 
         parent::__construct($dsn, $options);
     }

--- a/test/SentrySymfonyClientTest.php
+++ b/test/SentrySymfonyClientTest.php
@@ -31,6 +31,7 @@ class SentrySymfonyClientTest extends TestCase
         // Perhaps, refactor is needed for this class?
         $this->assertEquals('test', $data['server_name']);
         $this->assertEquals(\Symfony\Component\HttpKernel\Kernel::VERSION, $data['tags']['symfony_version']);
+        $this->assertEquals(phpversion(), $data['tags']['php_version']);
         $this->assertEquals('test', $data['tags']['some_custom']);
         $this->assertEquals('https://app.getsentry.com/api/project/store/', $client->getServerEndpoint(null));
         $this->assertEquals('a', $client->public_key);


### PR DESCRIPTION
add `php_version` as a default tag.
i upgraded my prod to 7.2 and there where strange errors comming in, and then i realized it was a single node still having <php7.2