### PR TITLE
Docs Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The following options can be configured via ``app/config/config.yml``.
 ```yaml
 sentry:
     skip_capture:
-        - "Symfony\\Component\\HttpKernel\\Exception\\HttpExceptionInterface"
+        - "Symfony\Component\HttpKernel\Exception\HttpExceptionInterface"
 ```
 
 ### Listeners' priority


### PR DESCRIPTION
Slashes are not needed in FQCN's to `skip_capture` (escaping the slashes actually breaks it).