### PR TITLE
Validate skip_capture Classes

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -127,6 +127,18 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('skip_capture')
                     ->prototype('scalar')->end()
                     ->defaultValue([HttpExceptionInterface::class])
+                    ->validate()
+                        ->ifTrue(function (array $classes) {
+                            foreach ($classes as $class) {
+                                if (! class_exists($class)) {
+                                    return true;
+                                }
+                            }
+
+                            return false;
+                        })
+                        ->thenInvalid('Unknown classes passed to skip_capture')
+                    ->end()
                 ->end()
                 ->arrayNode('listener_priorities')
                     ->addDefaultsIfNotSet()

--- a/test/DependencyInjection/SentryExtensionTest.php
+++ b/test/DependencyInjection/SentryExtensionTest.php
@@ -201,19 +201,31 @@ class SentryExtensionTest extends TestCase
         );
     }
 
+    public function test_skip_capture_classes_exist()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+
+        $this->getContainer(
+            [
+                'skip_capture' => [
+                    'ThisClassDoesNotExist',
+                ],
+            ]
+        );
+    }
+
     public function test_that_it_uses_skipped_capture_value()
     {
         $container = $this->getContainer(
             [
                 'skip_capture' => [
-                    'classA',
-                    'classB',
+                    self::class,
                 ],
             ]
         );
 
         $this->assertSame(
-            ['classA', 'classB'],
+            [self::class],
             $container->getParameter('sentry.skip_capture')
         );
     }


### PR DESCRIPTION
Related to #125, adds configuration validation that the classes passed to `skip_capture` exist.