### PR TITLE
Retrieve user IP from request context

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -11,6 +11,7 @@ services:
     arguments:
       - '@sentry.client'
       - '@event_dispatcher'
+      - '@request_stack'
       - '%sentry.skip_capture%'
       - '@?security.token_storage'
       - '@?security.authorization_checker'

--- a/test/DependencyInjection/SentryExtensionTest.php
+++ b/test/DependencyInjection/SentryExtensionTest.php
@@ -12,6 +12,7 @@ use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
 class SentryExtensionTest extends TestCase
@@ -376,6 +377,10 @@ class SentryExtensionTest extends TestCase
         $mockEventDispatcher = $this
             ->createMock(EventDispatcherInterface::class);
 
+        $mockRequestStack = $this
+            ->createMock(RequestStack::class);
+
+        $containerBuilder->set('request_stack', $mockRequestStack);
         $containerBuilder->set('event_dispatcher', $mockEventDispatcher);
         $containerBuilder->setAlias(self::LISTENER_TEST_PUBLIC_ALIAS, new Alias('sentry.exception_listener', true));
 

--- a/test/EventListener/ExceptionListenerTest.php
+++ b/test/EventListener/ExceptionListenerTest.php
@@ -16,6 +16,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -40,17 +42,21 @@ class ExceptionListenerTest extends TestCase
 
     private $mockEventDispatcher;
 
+    private $mockRequestStack;
+
     public function setUp()
     {
         $this->mockTokenStorage = $this->createMock(TokenStorageInterface::class);
         $this->mockAuthorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
         $this->mockSentryClient = $this->createMock(\Raven_Client::class);
         $this->mockEventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $this->mockRequestStack = $this->createMock(RequestStack::class);
 
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->setParameter('kernel.root_dir', 'kernel/root');
         $containerBuilder->setParameter('kernel.environment', 'test');
 
+        $containerBuilder->set('request_stack', $this->mockRequestStack);
         $containerBuilder->set('security.token_storage', $this->mockTokenStorage);
         $containerBuilder->set('security.authorization_checker', $this->mockAuthorizationChecker);
         $containerBuilder->set('sentry.client', $this->mockSentryClient);
@@ -378,6 +384,54 @@ class ExceptionListenerTest extends TestCase
                 $this->identicalTo(SentrySymfonyEvents::SET_USER_CONTEXT),
                 $this->isInstanceOf(SentryUserContextEvent::class)
             );
+
+        $this->containerBuilder->compile();
+        $listener = $this->getListener();
+        $listener->onKernelRequest($mockEvent);
+    }
+
+    public function test_that_ip_is_set_from_request_stack()
+    {
+        $mockToken = $this->createMock(TokenInterface::class);
+
+        $mockToken
+            ->method('getUser')
+            ->willReturn('some_user');
+
+        $mockToken
+            ->method('isAuthenticated')
+            ->willReturn(true);
+
+        $mockEvent = $this->createMock(GetResponseEvent::class);
+
+        $mockRequest = $this->createMock(Request::class);
+
+        $mockRequest
+            ->method('getClientIp')
+            ->willReturn('1.2.3.4');
+
+        $this->mockRequestStack
+            ->method('getCurrentRequest')
+            ->willReturn($mockRequest);
+
+        $mockEvent
+            ->expects($this->once())
+            ->method('getRequestType')
+            ->willReturn(HttpKernelInterface::MASTER_REQUEST);
+
+        $this->mockAuthorizationChecker
+            ->method('isGranted')
+            ->with($this->identicalTo(AuthenticatedVoter::IS_AUTHENTICATED_REMEMBERED))
+            ->willReturn(true);
+
+        $this->mockTokenStorage
+            ->method('getToken')
+            ->willReturn($mockToken);
+
+        $this->mockSentryClient
+            ->expects($this->once())
+            ->method('set_user_data')
+            ->with($this->identicalTo('some_user'), null, ['ip_address' => '1.2.3.4']);
 
         $this->containerBuilder->compile();
         $listener = $this->getListener();


### PR DESCRIPTION
Fix #127 

- [x] Fix tests
- [x] Add test

Tested under docker env with symfony configured like this

```yaml
framework:
    trusted_proxies:
        - 172.0.0.0/8 # Docker ip ranges
```

![selection_763](https://user-images.githubusercontent.com/6154987/40315114-c87eafb6-5d1a-11e8-9ef1-7d439b24d3a1.jpg)

Context dumped from symfony

![selection_764](https://user-images.githubusercontent.com/6154987/40315206-030d2d38-5d1b-11e8-9854-fe3fa9e2f2c0.jpg)


