### PR TITLE
[Feature] Allow configure sentry.client service as lazy

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -44,6 +44,9 @@ class Configuration implements ConfigurationInterface
                         ->then($this->getTrimClosure())
                     ->end()
                     ->defaultNull()
+                ->end()
+                ->booleanNode('lazy')
+                    ->defaultFalse()
                 ->end();
 
         // Sentry client options

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -2,6 +2,7 @@ services:
   sentry.client:
     class: '%sentry.client%'
     arguments: ['%sentry.dsn%', '%sentry.options%']
+    lazy: '%sentry.lazy%'
     public: true
     calls:
       - [install, []]


### PR DESCRIPTION
Sometimes ago i get error while cache warmup inside `docker build`.

Some service was try to instantiate `sentry.client` with this config
```yaml
sentry:
    dsn: '%env(SENTRY_DSN)%'
```
And inside `docker build` there is no environments. 

But after i was create this PR i can't reproduce this error. Maybe migrating to symfony 4.1 solve that. 

If you think this changes not necessary, please close it.