### PR TITLE
ExceptionListener > Add `route` tag

### DIFF
--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -111,8 +111,14 @@ class ExceptionListener implements SentryExceptionListenerInterface
             return;
         }
 
+        $data = ['tags' => []];
+        $request = $this->requestStack->getCurrentRequest();
+        if ($request instanceof Request) {
+            $data['tags']['route'] = $request->attributes->get('_route');
+        }
+
         $this->eventDispatcher->dispatch(SentrySymfonyEvents::PRE_CAPTURE, $event);
-        $this->client->captureException($exception);
+        $this->client->captureException($exception, $data);
     }
 
     /**


### PR DESCRIPTION
This will make it easier to find which controller / route was executed when an exception occurred.