### PR TITLE
Remove server_name default value

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -2,7 +2,6 @@
 
 namespace Sentry\SentryBundle\DependencyInjection;
 
-use Raven_Compat;
 use Sentry\SentryBundle\EventListener\ExceptionListener;
 use Sentry\SentryBundle\EventListener\SentryExceptionListenerInterface;
 use Sentry\SentryBundle\SentrySymfonyClient;
@@ -58,7 +57,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('public_key')->defaultNull()->end()
                         ->scalarNode('project')->defaultValue(1)->end()
                         ->booleanNode('auto_log_stacks')->defaultFalse()->end()
-                        ->scalarNode('name')->defaultValue(Raven_Compat::gethostname())->end()
+                        ->scalarNode('name')->defaultNull()->end()
                         ->scalarNode('site')->defaultNull()->end()
                         ->arrayNode('tags')
                             ->prototype('scalar')->end()

--- a/test/DependencyInjection/SentryExtensionTest.php
+++ b/test/DependencyInjection/SentryExtensionTest.php
@@ -45,7 +45,7 @@ class SentryExtensionTest extends TestCase
         $this->assertNull($options['public_key']);
         $this->assertSame(1, $options['project']);
         $this->assertFalse($options['auto_log_stacks']);
-        $this->assertSame(\Raven_Compat::gethostname(), $options['name']);
+        $this->assertNull($options['name']);
         $this->assertNull($options['site']);
         $this->assertSame([], $options['tags']);
         $this->assertNull($options['release']);


### PR DESCRIPTION
If you build the container on a server and then move it to a different server (this can appends easily on PaaS or with Docker), the `server_name` will always be the hostname, of the build server instead of the hostname of the server the application is running on.

By setting the `name` to `null` in the options we allow the hostname to always be fetched at runtime.