### PR TITLE
Add support for ignore_server_port sentry option

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -88,6 +88,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('mb_detect_order')->defaultNull()->end()
                         ->scalarNode('error_types')->defaultNull()->end()
                         ->scalarNode('app_path')->defaultValue('%kernel.root_dir%/..')->end()
+                        ->booleanNode('ignore_server_port')->defaultFalse()->end()
                         ->arrayNode('excluded_app_paths')
                             ->defaultValue(
                                 [

--- a/test/DependencyInjection/SentryExtensionTest.php
+++ b/test/DependencyInjection/SentryExtensionTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
 class SentryExtensionTest extends TestCase
 {
-    private const SUPPORTED_SENTRY_OPTIONS_COUNT = 35;
+    private const SUPPORTED_SENTRY_OPTIONS_COUNT = 36;
     private const LISTENER_TEST_PUBLIC_ALIAS = 'sentry.exception_listener.public_alias';
 
     public function test_that_configuration_uses_the_right_default_values()

--- a/test/DependencyInjection/SentryExtensionTest.php
+++ b/test/DependencyInjection/SentryExtensionTest.php
@@ -355,6 +355,7 @@ class SentryExtensionTest extends TestCase
                     'processorOption2' => 'asasdf',
                 ],
             ],
+            'ignore_server_port' => false,
         ];
 
         $this->assertCount(self::SUPPORTED_SENTRY_OPTIONS_COUNT, $options);

--- a/test/DependencyInjection/SentryExtensionTest.php
+++ b/test/DependencyInjection/SentryExtensionTest.php
@@ -355,7 +355,7 @@ class SentryExtensionTest extends TestCase
                     'processorOption2' => 'asasdf',
                 ],
             ],
-            'ignore_server_port' => false,
+            'ignore_server_port' => true,
         ];
 
         $this->assertCount(self::SUPPORTED_SENTRY_OPTIONS_COUNT, $options);


### PR DESCRIPTION
Adds support for the `ignore_server_port` option supported and documented by sentry.
First time contributing here, so please let me know if I'm missing something.

https://docs.sentry.io/clients/php/config/

> ignore_server_port
By default the server port will be added to the logged URL when it is a non standard port (80, 443). Setting this to true will ignore the server port altogether and will result in the server port never getting appended to the logged URL.