### PR TITLE
Add http proxy option

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -71,6 +71,8 @@ class Configuration implements ConfigurationInterface
                 ->defaultValue($defaultValues->getExcludedExceptions())
                 ->scalarPrototype()->end()
             ->end()
+            ->scalarNode('http_proxy')
+            ->end()
             // TODO -- integrations
             ->scalarNode('logger')
             ->end()

--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -55,6 +55,7 @@ class SentryExtension extends Extension
             'enable_compression',
             'environment',
             'excluded_exceptions',
+            'http_proxy',
             'logger',
             'max_breadcrumbs',
             'prefixes',

--- a/test/DependencyInjection/ConfigurationTest.php
+++ b/test/DependencyInjection/ConfigurationTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpKernel\Kernel;
 
 class ConfigurationTest extends TestCase
 {
-    public const SUPPORTED_SENTRY_OPTIONS_COUNT = 18;
+    public const SUPPORTED_SENTRY_OPTIONS_COUNT = 19;
 
     public function testDataProviderIsMappingTheRightNumberOfOptions(): void
     {
@@ -91,6 +91,7 @@ class ConfigurationTest extends TestCase
             ['enable_compression', false],
             ['environment', 'staging'],
             ['error_types', E_ALL],
+            ['http_proxy', '1.2.3.4:5678'],
             ['in_app_exclude', ['some/path']],
             ['excluded_exceptions', [\Throwable::class]],
             ['logger', 'some-logger'],
@@ -132,6 +133,7 @@ class ConfigurationTest extends TestCase
             ['enable_compression', 'string'],
             ['environment', ''],
             ['error_types', []],
+            ['http_proxy', []],
             ['in_app_exclude', 'some/single/path'],
             ['excluded_exceptions', 'some-string'],
             ['logger', []],

--- a/test/DependencyInjection/SentryExtensionTest.php
+++ b/test/DependencyInjection/SentryExtensionTest.php
@@ -94,6 +94,7 @@ class SentryExtensionTest extends TestCase
             ['error_types', E_ALL & ~E_NOTICE],
             ['in_app_exclude', ['/some/path'], 'getInAppExcludedPaths'],
             ['excluded_exceptions', [\Throwable::class]],
+            ['http_proxy', '1.2.3.4'],
             ['logger', 'sentry-logger'],
             ['max_breadcrumbs', 15],
             ['prefixes', ['/some/path/prefix/']],


### PR DESCRIPTION
~This includes #190, do not merge before it.~

This maps the `http_proxy` option, which was restored in https://github.com/getsentry/sentry-php/pull/775