### PR TITLE
Track subrequests with scopes

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -120,6 +120,7 @@ class Configuration implements ConfigurationInterface
                 ->addDefaultsIfNotSet()
                 ->children()
                     ->scalarNode('request')->defaultValue(1)->end()
+                    ->scalarNode('sub_request')->defaultValue(1)->end()
                     ->scalarNode('console')->defaultValue(1)->end()
                 ->end()
             ->end();

--- a/src/EventListener/SubRequestListener.php
+++ b/src/EventListener/SubRequestListener.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Sentry\SentryBundle\EventListener;
+
+use Sentry\State\Hub;
+use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+
+final class SubRequestListener
+{
+    /**
+     * Pushes a new {@see Scope} for each SubRequest
+     *
+     * @param GetResponseEvent $event
+     */
+    public function onKernelRequest(GetResponseEvent $event): void
+    {
+        if ($event->isMasterRequest()) {
+            return;
+        }
+
+        Hub::getCurrent()->pushScope();
+    }
+
+    /**
+     * Pops a {@see Scope} for each finished SubRequest
+     *
+     * @param FinishRequestEvent $event
+     */
+    public function onKernelFinishRequest(FinishRequestEvent $event): void
+    {
+        if ($event->isMasterRequest()) {
+            return;
+        }
+
+        Hub::getCurrent()->popScope();
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -38,5 +38,10 @@
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="%sentry.listener_priorities.request%" />
             <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController" priority="%sentry.listener_priorities.request%" />
         </service>
+
+        <service id="Sentry\SentryBundle\EventListener\SubRequestListener" class="Sentry\SentryBundle\EventListener\SubRequestListener" public="false">
+            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="%sentry.listener_priorities.sub_request%" />
+            <tag name="kernel.event_listener" event="kernel.finish_request" method="onKernelFinishRequest" priority="%sentry.listener_priorities.sub_request%" />
+        </service>
     </services>
 </container>

--- a/test/DependencyInjection/ConfigurationTest.php
+++ b/test/DependencyInjection/ConfigurationTest.php
@@ -45,6 +45,7 @@ class ConfigurationTest extends TestCase
             'dsn' => null,
             'listener_priorities' => [
                 'request' => 1,
+                'sub_request' => 1,
                 'console' => 1,
             ],
             'options' => [

--- a/test/DependencyInjection/SentryExtensionTest.php
+++ b/test/DependencyInjection/SentryExtensionTest.php
@@ -7,8 +7,6 @@ use Sentry\Breadcrumb;
 use Sentry\Event;
 use Sentry\Options;
 use Sentry\SentryBundle\DependencyInjection\SentryExtension;
-use Sentry\SentryBundle\EventListener\ConsoleListener;
-use Sentry\SentryBundle\EventListener\RequestListener;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -19,8 +17,6 @@ use Symfony\Component\HttpKernel\Kernel;
 
 class SentryExtensionTest extends TestCase
 {
-    private const REQUEST_LISTENER_TEST_PUBLIC_ALIAS = 'sentry.request_listener.public_alias';
-    private const CONSOLE_LISTENER_TEST_PUBLIC_ALIAS = 'sentry.console_listener.public_alias';
     private const OPTIONS_TEST_PUBLIC_ALIAS = 'sentry.options.public_alias';
 
     public function testDataProviderIsMappingTheRightNumberOfOptions(): void
@@ -299,8 +295,6 @@ class SentryExtensionTest extends TestCase
         $containerBuilder->set('request_stack', $mockRequestStack);
         $containerBuilder->set('event_dispatcher', $mockEventDispatcher);
         $containerBuilder->setAlias(self::OPTIONS_TEST_PUBLIC_ALIAS, new Alias(Options::class, true));
-        $containerBuilder->setAlias(self::REQUEST_LISTENER_TEST_PUBLIC_ALIAS, new Alias(RequestListener::class, true));
-        $containerBuilder->setAlias(self::CONSOLE_LISTENER_TEST_PUBLIC_ALIAS, new Alias(ConsoleListener::class, true));
 
         $beforeSend = new Definition('callable');
         $beforeSend->setFactory([CallbackMock::class, 'createCallback']);

--- a/test/DependencyInjection/SentryExtensionTest.php
+++ b/test/DependencyInjection/SentryExtensionTest.php
@@ -49,7 +49,23 @@ class SentryExtensionTest extends TestCase
         $this->assertSame(['var/cache', $vendorDir], $options->getInAppExcludedPaths());
 
         $this->assertSame(1, $container->getParameter('sentry.listener_priorities.request'));
+        $this->assertSame(1, $container->getParameter('sentry.listener_priorities.sub_request'));
         $this->assertSame(1, $container->getParameter('sentry.listener_priorities.console'));
+    }
+
+    public function testListenerPriorities(): void
+    {
+        $container = $this->getContainer([
+            'listener_priorities' => [
+                'request' => 123,
+                'sub_request' => 456,
+                'console' => 789,
+            ],
+        ]);
+
+        $this->assertSame(123, $container->getParameter('sentry.listener_priorities.request'));
+        $this->assertSame(456, $container->getParameter('sentry.listener_priorities.sub_request'));
+        $this->assertSame(789, $container->getParameter('sentry.listener_priorities.console'));
     }
 
     /**

--- a/test/EventListener/SubRequestListenerTest.php
+++ b/test/EventListener/SubRequestListenerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Sentry\SentryBundle\Test\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\SentryBundle\EventListener\SubRequestListener;
+use Sentry\State\Hub;
+use Sentry\State\HubInterface;
+use Sentry\State\Scope;
+use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+
+class SubRequestListenerTest extends TestCase
+{
+    private $currentHub;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->currentHub = $this->prophesize(HubInterface::class);
+
+        Hub::setCurrent($this->currentHub->reveal());
+    }
+
+    public function testOnKernelRequestWithMasterRequest(): void
+    {
+        $listener = new SubRequestListener();
+
+        $subRequestEvent = $this->prophesize(GetResponseEvent::class);
+        $subRequestEvent->isMasterRequest()
+            ->willReturn(true);
+
+        $this->currentHub->pushScope()
+            ->shouldNotBeCalled();
+
+        $listener->onKernelRequest($subRequestEvent->reveal());
+    }
+
+    public function testOnKernelRequestWithSubRequest(): void
+    {
+        $listener = new SubRequestListener();
+
+        $subRequestEvent = $this->prophesize(GetResponseEvent::class);
+        $subRequestEvent->isMasterRequest()
+            ->willReturn(false);
+
+        $this->currentHub->pushScope()
+            ->shouldBeCalledTimes(1)
+            ->willReturn(new Scope());
+
+        $listener->onKernelRequest($subRequestEvent->reveal());
+    }
+
+    public function testOnKernelFinishRequestWithMasterRequest(): void
+    {
+        $listener = new SubRequestListener();
+
+        $subRequestEvent = $this->prophesize(FinishRequestEvent::class);
+        $subRequestEvent->isMasterRequest()
+            ->willReturn(true);
+
+        $this->currentHub->popScope()
+            ->shouldNotBeCalled();
+
+        $listener->onKernelFinishRequest($subRequestEvent->reveal());
+    }
+
+    public function testOnKernelFinishRequestWithSubRequest(): void
+    {
+        $listener = new SubRequestListener();
+
+        $subRequestEvent = $this->prophesize(FinishRequestEvent::class);
+        $subRequestEvent->isMasterRequest()
+            ->willReturn(false);
+
+        $this->currentHub->popScope()
+            ->shouldBeCalledTimes(1)
+            ->willReturn(true);
+
+        $listener->onKernelFinishRequest($subRequestEvent->reveal());
+    }
+}


### PR DESCRIPTION
This should resolve #186. I preferred to approach this with a separate listener, which seems a much cleaner solution.