### PR TITLE
Use dependency injection, in the Symfony style

### DIFF
--- a/src/EventListener/ConsoleListener.php
+++ b/src/EventListener/ConsoleListener.php
@@ -18,7 +18,7 @@ final class ConsoleListener
      */
     public function __construct(HubInterface $hub)
     {
-        $this->hub = $hub; // not used, needed to trigger instantiation
+        $this->hub = $hub;
     }
 
     /**
@@ -33,7 +33,7 @@ final class ConsoleListener
     {
         $command = $event->getCommand();
 
-        Hub::getCurrent()
+        $this->hub
             ->configureScope(function (Scope $scope) use ($command): void {
                 $scope->setTag('command', $command ? $command->getName() : 'N/A');
             });

--- a/src/EventListener/RequestListener.php
+++ b/src/EventListener/RequestListener.php
@@ -71,7 +71,7 @@ final class RequestListener
 
         $userData['ip_address'] = $event->getRequest()->getClientIp();
 
-        Hub::getCurrent()
+        $this->hub
             ->configureScope(function (Scope $scope) use ($userData): void {
                 $scope->setUser($userData);
             });
@@ -85,7 +85,7 @@ final class RequestListener
 
         $matchedRoute = $event->getRequest()->attributes->get('_route');
 
-        Hub::getCurrent()
+        $this->hub
             ->configureScope(function (Scope $scope) use ($matchedRoute): void {
                 $scope->setTag('route', $matchedRoute);
             });


### PR DESCRIPTION
This is clearly the approach chosen for v3 - I havent been following the development, but using a global static variable instead of DI, just seems like a massive step backwards. Using Symfony I'd expect everything to be using DI, and that if I want to replace the `HubInterface` service, its going to be replaced everywhere its used.

I'm also not going to use a global variable in my own code, I'm going to inject `HubInterface`