### PR TITLE
Add silenced errors option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,18 @@ update-submodules:
 	git submodule update
 
 cs:
-	vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff
+	vendor/bin/php-cs-fixer fix --verbose
 
 cs-dry-run:
-	vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff --dry-run
+	vendor/bin/php-cs-fixer fix --verbose --dry-run
+
+phpstan:
+	vendor/bin/phpstan analyze
 
 test:
 	vendor/bin/phpunit
+
+pre-commit-check: cs phpstan test
 
 setup-git:
 	git config branch.autosetuprebase always

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,8 +5,7 @@ parameters:
         - test/
     ignoreErrors:
          - "/Call to function method_exists.. with 'Symfony.+' and 'getProjectDir' will always evaluate to false./"
-    excludes_analyse:
-         - '%currentWorkingDirectory%/src/DependencyInjection/Configuration.php'
+         - "/Call to function method_exists.. with 'Symfony.+' and 'getRootNode' will always evaluate to false./"
 
 includes:
 	- vendor/jangregor/phpstan-prophecy/src/extension.neon

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -24,17 +24,17 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('sentry');
         /** @var ArrayNodeDefinition $rootNode */
-        $rootNode = \method_exists(TreeBuilder::class, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('sentry');
+        $rootNode = \method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('sentry');
 
         // Basic Sentry configuration
         $rootNode->children()
             ->scalarNode('dsn')
-                ->beforeNormalization()
-                    ->ifString()
-                    ->then($this->getTrimClosure())
-                ->end()
-                ->defaultNull()
-            ->end();
+            ->defaultNull()
+            ->beforeNormalization()
+            ->ifString()
+            ->then($this->getTrimClosure());
 
         // Options array (to be passed to Sentry\Options constructor) -- please keep alphabetical order!
         $optionsNode = $rootNode->children()
@@ -42,110 +42,85 @@ class Configuration implements ConfigurationInterface
             ->addDefaultsIfNotSet();
 
         $defaultValues = new Options();
+        $optionsChildNodes = $optionsNode->children();
 
-        $optionsNode
-            ->children()
-            ->booleanNode('attach_stacktrace')->end()
-            ->variableNode('before_breadcrumb')
-                ->validate()
-                    ->ifTrue($this->isNotAValidCallback())
-                    ->thenInvalid('Expecting callable or service reference, got %s')
-                ->end()
-            ->end()
-            ->variableNode('before_send')
-                ->validate()
-                    ->ifTrue($this->isNotAValidCallback())
-                    ->thenInvalid('Expecting callable or service reference, got %s')
-                ->end()
-            ->end()
-            ->booleanNode('default_integrations')->end()
-            ->integerNode('context_lines')
-                ->min(0)
-                ->max(99)
-            ->end()
-            ->booleanNode('enable_compression')->end()
-            ->scalarNode('environment')
-                ->defaultValue('%kernel.environment%')
-                ->cannotBeEmpty()
-            ->end()
-            ->scalarNode('error_types')
-            ->end()
-            ->arrayNode('in_app_exclude')
-                ->defaultValue([
-                    '%kernel.cache_dir%',
-                    $this->getProjectRoot() . '/vendor',
-                ])
-                ->prototype('scalar')->end()
-            ->end()
-            ->arrayNode('excluded_exceptions')
-                ->defaultValue($defaultValues->getExcludedExceptions())
-                ->prototype('scalar')->end()
-            ->end()
-            ->scalarNode('http_proxy')
-            ->end()
-            ->arrayNode('integrations')
-                ->prototype('scalar')
-                    ->validate()
-                        ->ifTrue(function ($value): bool {
-                            if (! is_string($value)) {
-                                return true;
-                            }
+        $optionsChildNodes->booleanNode('attach_stacktrace');
+        $optionsChildNodes->variableNode('before_breadcrumb')
+            ->validate()
+            ->ifTrue($this->isNotAValidCallback())
+            ->thenInvalid('Expecting callable or service reference, got %s');
+        $optionsChildNodes->variableNode('before_send')
+            ->validate()
+            ->ifTrue($this->isNotAValidCallback())
+            ->thenInvalid('Expecting callable or service reference, got %s');
+        $optionsChildNodes->integerNode('context_lines')
+            ->min(0)
+            ->max(99);
+        $optionsChildNodes->booleanNode('default_integrations');
+        $optionsChildNodes->booleanNode('enable_compression');
+        $optionsChildNodes->scalarNode('environment')
+            ->defaultValue('%kernel.environment%')
+            ->cannotBeEmpty();
+        $optionsChildNodes->scalarNode('error_types');
+        $optionsChildNodes->arrayNode('in_app_exclude')
+            ->defaultValue([
+                '%kernel.cache_dir%',
+                $this->getProjectRoot() . '/vendor',
+            ])
+            ->prototype('scalar');
+        $optionsChildNodes->arrayNode('excluded_exceptions')
+            ->defaultValue($defaultValues->getExcludedExceptions())
+            ->prototype('scalar');
+        $optionsChildNodes->scalarNode('http_proxy');
+        $optionsChildNodes->arrayNode('integrations')
+            ->prototype('scalar')
+            ->validate()
+            ->ifTrue(function ($value): bool {
+                if (! is_string($value)) {
+                    return true;
+                }
 
-                            return '@' !== substr($value, 0, 1);
-                        })
-                    ->thenInvalid('Expecting service reference, got %s')
-                    ->end()
-                ->end()
-            ->end()
-            ->scalarNode('logger')
-            ->end()
-            ->integerNode('max_breadcrumbs')
-                ->min(1)
-            ->end()
-            ->integerNode('max_value_length')
-                ->min(1)
-            ->end()
-            ->arrayNode('prefixes')
-                ->defaultValue($defaultValues->getPrefixes())
-                ->prototype('scalar')->end()
-            ->end()
-            ->scalarNode('project_root')
-                ->defaultValue($this->getProjectRoot())
-            ->end()
-            ->scalarNode('release')
-            ->end()
-            ->floatNode('sample_rate')
-                ->min(0.0)
-                ->max(1.0)
-            ->end()
-            ->integerNode('send_attempts')
-                ->min(1)
-            ->end()
-            ->booleanNode('send_default_pii')->end()
-            ->scalarNode('server_name')
-            ->end()
-            ->arrayNode('tags')
-                ->normalizeKeys(false)
-                ->prototype('scalar')
-            ->end()
-        ;
+                return '@' !== substr($value, 0, 1);
+            })
+            ->thenInvalid('Expecting service reference, got %s');
+        $optionsChildNodes->scalarNode('logger');
+        $optionsChildNodes->integerNode('max_breadcrumbs')
+            ->min(1);
+        $optionsChildNodes->integerNode('max_value_length')
+            ->min(1);
+        $optionsChildNodes->arrayNode('prefixes')
+            ->defaultValue($defaultValues->getPrefixes())
+            ->prototype('scalar');
+        $optionsChildNodes->scalarNode('project_root')
+            ->defaultValue($this->getProjectRoot());
+        $optionsChildNodes->scalarNode('release');
+        $optionsChildNodes->floatNode('sample_rate')
+            ->min(0.0)
+            ->max(1.0);
+        $optionsChildNodes->integerNode('send_attempts')
+            ->min(1);
+        $optionsChildNodes->booleanNode('send_default_pii');
+        $optionsChildNodes->scalarNode('server_name');
+        $optionsChildNodes->arrayNode('tags')
+            ->normalizeKeys(false)
+            ->prototype('scalar');
 
         // Bundle-specific configuration
-        $rootNode->children()
+        $listenerPriorities = $rootNode->children()
             ->arrayNode('listener_priorities')
-                ->addDefaultsIfNotSet()
-                ->children()
-                    ->scalarNode('request')->defaultValue(1)->end()
-                    ->scalarNode('console')->defaultValue(1)->end()
-                ->end()
-            ->end();
+            ->addDefaultsIfNotSet()
+            ->children();
+        $listenerPriorities->scalarNode('request')
+            ->defaultValue(1);
+        $listenerPriorities->scalarNode('console')
+            ->defaultValue(1);
 
         return $treeBuilder;
     }
 
-    private function getTrimClosure(): callable
+    private function getTrimClosure(): \Closure
     {
-        return function ($str) {
+        return function ($str): ?string {
             $value = trim($str);
             if ($value === '') {
                 return null;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -2,6 +2,7 @@
 
 namespace Sentry\SentryBundle\DependencyInjection;
 
+use Jean85\PrettyVersions;
 use Sentry\Options;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -53,6 +53,9 @@ class Configuration implements ConfigurationInterface
             ->validate()
             ->ifTrue($this->isNotAValidCallback())
             ->thenInvalid('Expecting callable or service reference, got %s');
+        if (PrettyVersions::getVersion('sentry/sentry')->getPrettyVersion() !== '2.0.0') {
+            $optionsChildNodes->booleanNode('capture_silenced_errors');
+        }
         $optionsChildNodes->integerNode('context_lines')
             ->min(0)
             ->max(99);

--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -52,6 +52,7 @@ class SentryExtension extends Extension
         $processedOptions = $processedConfiguration['options'];
         $mappableOptions = [
             'attach_stacktrace',
+            'capture_silenced_errors',
             'context_lines',
             'default_integrations',
             'enable_compression',

--- a/src/EventListener/RequestListener.php
+++ b/src/EventListener/RequestListener.php
@@ -54,6 +54,11 @@ final class RequestListener
             return;
         }
 
+        $currentClient = Hub::getCurrent()->getClient();
+        if (null === $currentClient || ! $currentClient->getOptions()->shouldSendDefaultPii()) {
+            return;
+        }
+
         $token = null;
 
         if ($this->tokenStorage instanceof TokenStorageInterface) {

--- a/test/DependencyInjection/ConfigurationTest.php
+++ b/test/DependencyInjection/ConfigurationTest.php
@@ -2,6 +2,7 @@
 
 namespace Sentry\SentryBundle\Test\DependencyInjection;
 
+use Jean85\PrettyVersions;
 use PHPUnit\Framework\TestCase;
 use Sentry\Options;
 use Sentry\SentryBundle\DependencyInjection\Configuration;
@@ -18,8 +19,14 @@ class ConfigurationTest extends TestCase
         $providerData = $this->optionValuesProvider();
         $supportedOptions = \array_unique(\array_column($providerData, 0));
 
+        $expectedCount = self::SUPPORTED_SENTRY_OPTIONS_COUNT;
+
+        if (PrettyVersions::getVersion('sentry/sentry')->getPrettyVersion() !== '2.0.0') {
+            ++$expectedCount;
+        }
+
         $this->assertCount(
-            self::SUPPORTED_SENTRY_OPTIONS_COUNT,
+            $expectedCount,
             $supportedOptions,
             'Provider for configuration options mismatch: ' . PHP_EOL . print_r($supportedOptions, true)
         );
@@ -83,7 +90,7 @@ class ConfigurationTest extends TestCase
 
     public function optionValuesProvider(): array
     {
-        return [
+        $options = [
             ['attach_stacktrace', true],
             ['before_breadcrumb', 'count'],
             ['before_send', 'count'],
@@ -112,6 +119,12 @@ class ConfigurationTest extends TestCase
             ['server_name', 'server001.example.com'],
             ['tags', ['tag-name' => 'value']],
         ];
+
+        if (PrettyVersions::getVersion('sentry/sentry')->getPrettyVersion() !== '2.0.0') {
+            $options[] = ['capture_silenced_errors', true];
+        }
+
+        return $options;
     }
 
     /**

--- a/test/DependencyInjection/SentryExtensionTest.php
+++ b/test/DependencyInjection/SentryExtensionTest.php
@@ -2,6 +2,7 @@
 
 namespace Sentry\SentryBundle\Test\DependencyInjection;
 
+use Jean85\PrettyVersions;
 use PHPUnit\Framework\TestCase;
 use Sentry\Breadcrumb;
 use Sentry\Event;
@@ -30,8 +31,14 @@ class SentryExtensionTest extends TestCase
         $supportedOptions = \array_unique(\array_column($providerData, 0));
 
         // subtracted one is `integration`, which cannot be tested with the provider
+        $expectedCount = ConfigurationTest::SUPPORTED_SENTRY_OPTIONS_COUNT - 1;
+
+        if (PrettyVersions::getVersion('sentry/sentry')->getPrettyVersion() !== '2.0.0') {
+            ++$expectedCount;
+        }
+
         $this->assertCount(
-            ConfigurationTest::SUPPORTED_SENTRY_OPTIONS_COUNT - 1,
+            $expectedCount,
             $supportedOptions,
             'Provider for configuration options mismatch: ' . PHP_EOL . print_r($supportedOptions, true)
         );
@@ -90,7 +97,7 @@ class SentryExtensionTest extends TestCase
 
     public function optionsValueProvider(): array
     {
-        return [
+        $options = [
             ['attach_stacktrace', true, 'shouldAttachStacktrace'],
             ['before_breadcrumb', __NAMESPACE__ . '\mockBeforeBreadcrumb', 'getBeforeBreadcrumbCallback'],
             ['before_send', __NAMESPACE__ . '\mockBeforeSend', 'getBeforeSendCallback'],
@@ -114,6 +121,12 @@ class SentryExtensionTest extends TestCase
             ['server_name', 'server.example.com'],
             ['tags', ['tag-name' => 'tag-value']],
         ];
+
+        if (PrettyVersions::getVersion('sentry/sentry')->getPrettyVersion() !== '2.0.0') {
+            $options[] = ['capture_silenced_errors', true, 'shouldCaptureSilencedErrors'];
+        }
+
+        return $options;
     }
 
     public function testErrorTypesAreParsed(): void


### PR DESCRIPTION
This adds the new option that was added in the SDK 2.0.1, see getsentry/sentry-php#785