### PR TITLE
Fix handling ESI request

### DIFF
--- a/src/EventListener/RequestListener.php
+++ b/src/EventListener/RequestListener.php
@@ -88,7 +88,11 @@ final class RequestListener
             return;
         }
 
-        $matchedRoute = $event->getRequest()->attributes->get('_route');
+        if (! $event->getRequest()->attributes->has('_route')) {
+            return;
+        }
+
+        $matchedRoute = (string) $event->getRequest()->attributes->get('_route');
 
         Hub::getCurrent()
             ->configureScope(function (Scope $scope) use ($matchedRoute): void {

--- a/test/EventListener/RequestListenerTest.php
+++ b/test/EventListener/RequestListenerTest.php
@@ -355,6 +355,28 @@ class RequestListenerTest extends TestCase
         $this->assertSame(['route' => 'sf-route'], $this->currentScope->getTags());
     }
 
+    public function testOnKernelControllerRouteTagIsNotSetIfRequestDoesNotHaveARoute(): void
+    {
+        $this->currentHub->configureScope(Argument::type('callable'))
+            ->shouldNotBeCalled();
+
+        $request = new Request();
+        $event = $this->prophesize(FilterControllerEvent::class);
+
+        $event->isMasterRequest()
+            ->willReturn(true);
+        $event->getRequest()
+            ->willReturn($request);
+
+        $listener = new RequestListener(
+            $this->currentHub->reveal(),
+            $this->prophesize(TokenStorageInterface::class)->reveal(),
+            $this->prophesize(AuthorizationCheckerInterface::class)->reveal()
+        );
+
+        $listener->onKernelController($event->reveal());
+    }
+
     public function testOnKernelRequestUserDataAndTagsAreNotSetInSubRequest(): void
     {
         $this->currentHub->configureScope(Argument::type('callable'))


### PR DESCRIPTION
Hi!

When the RequestListener is handling a ESI request it fails because it has no `_route` defined in its attributes and it returns `null`, so the `Scope:: setTag` method fails because is expecting a `string`.