### PR TITLE
Exposes Sentry\Monolog\Handler service for easier monolog configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,30 @@ sentry:
     dsn: "https://public:secret@sentry.example.com/1"
 ```
 
+#### Optional: use monolog handler provided by `sentry/sentry`
+*Note: this step is optional*
+
+If You're using `monolog` for logging e.g. in-app errors, You
+can use this handler in order for them to show up in Sentry. 
+
+First, define `Sentry\Monolog\Handler` as a service in `app/config/services.yml`
+
+```yaml
+services:
+    sentry.monolog.handler:
+        class: Sentry\Monolog\Handler
+```
+
+Then enable it in `monolog` config:
+
+```yaml
+monolog:
+    sentry:
+      type: service
+      id: sentry.monolog.handler
+      level: error 
+```
+
 ## Maintained versions
  * 3.x is actively maintained and developed on the master branch, and uses Sentry SDK 2.0;
  * 2.x is supported only for fixes; from this version onwards it requires Symfony 3+ and PHP 7.1+;


### PR DESCRIPTION
I ❤️ using this bundle.

This PR solves one problem that's still cumbersome to me.

`sentry/sentry` ships with `Sentry\Monolog\Handler` for smooth integration with `monolog`, however this bundle is not exposing it as a service making integration more difficult.

My PR configures `Sentry\Monolog\Handler` as a service, which - in theory - should simplify configuration.

I've updated example for reference, but it's commented out since not everyone might like it configured out-of-the-box. 