### PR TITLE
Fix ErrorListener not capturing events when Hub is not instantiated yet

### DIFF
--- a/src/EventListener/ErrorListener.php
+++ b/src/EventListener/ErrorListener.php
@@ -2,12 +2,25 @@
 
 namespace Sentry\SentryBundle\EventListener;
 
+use Sentry\State\HubInterface;
 use Symfony\Component\Console\Event\ConsoleErrorEvent;
 use Symfony\Component\Console\Event\ConsoleExceptionEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 
 final class ErrorListener
 {
+    /** @var HubInterface */
+    private $hub;
+
+    /**
+     * ErrorListener constructor.
+     * @param HubInterface $hub
+     */
+    public function __construct(HubInterface $hub)
+    {
+        $this->hub = $hub; // not used, needed to trigger instantiation
+    }
+
     public function onKernelException(GetResponseForExceptionEvent $event): void
     {
         \Sentry\captureException($event->getException());

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -31,6 +31,7 @@
         </service>
 
         <service id="Sentry\SentryBundle\EventListener\ErrorListener" class="Sentry\SentryBundle\EventListener\ErrorListener" public="false">
+            <argument type="service" id="Sentry\State\HubInterface" />
             <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" priority="%sentry.listener_priorities.request_error%" />
             <!-- The following tag is done manually in PHP for BC with Symfony < 3.3 -->
 <!--            <tag name="kernel.event_listener" event="console.error" method="onConsoleError" priority="%sentry.listener_priorities.console_error%" />-->


### PR DESCRIPTION
Fixes #242