### PR TITLE
Options to disable error listener and/or enable Monolog handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Fix compatibility with sentry/sentry 2.2+ (#244)
  - Add support for `class_serializers` option (#245)
  - Add support for `max_request_body_size` option (#249)
+ - Add option to disable the error listener completely (#247, thanks to @HypeMC)
+ - Add options to register the Monolog Handler (#247, thanks to @HypeMC)
 
 ## 3.1.0 - 2019-07-02
  - Add support for Symfony 2.8 (#233, thanks to @nocive)

--- a/README.md
+++ b/README.md
@@ -103,17 +103,20 @@ the [PHP specific](https://docs.sentry.io/platforms/php/#php-specific-options) o
 #### Optional: use monolog handler provided by `sentry/sentry`
 *Note: this step is optional*
 
-If You're using `monolog` for logging e.g. in-app errors, You
+If you're using `monolog` for logging e.g. in-app errors, you
 can use this handler in order for them to show up in Sentry. 
 
-First, define `Sentry\Monolog\Handler` as a service in `config/services.yaml`
+First, enable & configure the `Sentry\Monolog\Handler`; you'll also need
+to disable the `Sentry\SentryBundle\EventListener\ErrorListener` to
+avoid having duplicate events in Sentry:
 
 ```yaml
-services:
-    sentry.monolog.handler:
-        class: Sentry\Monolog\Handler
-        arguments:
-            $level: 'error'
+sentry:
+    register_error_listener: false # Disables the ErrorListener
+    monolog:
+        error_handler:
+            enabled: true
+            level: error
 ```
 
 Then enable it in `monolog` config:
@@ -123,8 +126,7 @@ monolog:
     handlers:
         sentry:
             type: service
-            id: sentry.monolog.handler
-            level: error 
+            id: Sentry\Monolog\Handler
 ```
 
 ## Maintained versions

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.8",
         "jangregor/phpstan-prophecy": "^0.3.0",
+        "monolog/monolog": "^1.11||^2.0",
         "php-http/mock-client": "^1.0",
         "phpstan/phpstan": "^0.11",
         "phpstan/phpstan-phpunit": "^0.11",
@@ -39,13 +40,16 @@
         "scrutinizer/ocular": "^1.4",
         "symfony/expression-language": "^2.8||^3.0||^4.0"
     },
+    "suggest": {
+        "monolog/monolog": "Required to use the Monolog handler"
+    },
     "autoload": {
-        "psr-4" : {
+        "psr-4": {
             "Sentry\\SentryBundle\\": "src/"
         }
     },
     "autoload-dev": {
-        "psr-4" : {
+        "psr-4": {
             "Sentry\\SentryBundle\\Test\\": "test"
         }
     },

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -143,6 +143,24 @@ class Configuration implements ConfigurationInterface
         $listenerPriorities->scalarNode('console_error')
             ->defaultValue(128);
 
+        // Monolog handler configuration
+        $monologConfiguration = $rootNode->children()
+            ->arrayNode('monolog')
+            ->addDefaultsIfNotSet()
+            ->children();
+
+        $errorHandler = $monologConfiguration
+            ->arrayNode('error_handler')
+            ->addDefaultsIfNotSet()
+            ->children();
+        $errorHandler->booleanNode('enabled')
+            ->defaultFalse();
+        $errorHandler->scalarNode('level')
+            ->defaultValue('DEBUG')
+            ->cannotBeEmpty();
+        $errorHandler->booleanNode('bubble')
+            ->defaultTrue();
+
         return $treeBuilder;
     }
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -37,6 +37,10 @@ class Configuration implements ConfigurationInterface
             ->ifString()
             ->then($this->getTrimClosure());
 
+        $rootNode->children()
+            ->booleanNode('register_error_listener')
+            ->defaultTrue();
+
         // Options array (to be passed to Sentry\Options constructor) -- please keep alphabetical order!
         $optionsNode = $rootNode->children()
             ->arrayNode('options')

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -51,5 +51,11 @@
         <service id="Sentry\SentryBundle\Command\SentryTestCommand" class="Sentry\SentryBundle\Command\SentryTestCommand" public="false">
             <tag name="console.command" />
         </service>
+
+        <service id="Sentry\Monolog\Handler" class="Sentry\Monolog\Handler" public="false">
+            <argument type="service" id="Sentry\State\HubInterface" />
+            <argument key="$level" />
+            <argument key="$bubble" />
+        </service>
     </services>
 </container>

--- a/test/DependencyInjection/ConfigurationTest.php
+++ b/test/DependencyInjection/ConfigurationTest.php
@@ -48,6 +48,7 @@ class ConfigurationTest extends BaseTestCase
         $processed = $this->processConfiguration([]);
         $expectedDefaults = [
             'dsn' => null,
+            'register_error_listener' => true,
             'listener_priorities' => [
                 'request' => 1,
                 'sub_request' => 1,

--- a/test/DependencyInjection/ConfigurationTest.php
+++ b/test/DependencyInjection/ConfigurationTest.php
@@ -68,6 +68,13 @@ class ConfigurationTest extends BaseTestCase
                 'project_root' => '%kernel.root_dir%/..',
                 'tags' => [],
             ],
+            'monolog' => [
+                'error_handler' => [
+                    'enabled' => false,
+                    'level' => 'DEBUG',
+                    'bubble' => true,
+                ],
+            ],
         ];
 
         if (method_exists(Kernel::class, 'getProjectDir')) {


### PR DESCRIPTION
Resolves #232.

As mentioned in the issue, having both the Monolog handler & the ErrorListener installed results in having duplicate entries.

I added a configuration option to disable the ErrorListener. I also added the ability to configure the Monolog handler through the bundle.

I still need to add some tests as well, but I wanted to get some feedback first on whether or not this approach is good.