### PR TITLE
Notice of monolog handler available since 3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The parameter `options` allows to fine-tune exceptions. To discover more options
 [the Unified APIs](https://docs.sentry.io/development/sdk-dev/unified-api/#options) options and
 the [PHP specific](https://docs.sentry.io/platforms/php/#php-specific-options) ones.
 
-#### Optional: use monolog handler provided by `sentry/sentry`
+#### Optional: use monolog handler provided by `sentry/sentry` (available since 3.2.0)
 *Note: this step is optional*
 
 If you're using `monolog` for logging e.g. in-app errors, you


### PR DESCRIPTION
I added a notice of the monolog handler available since the version 3.2.0  of the bundle to the README.md file.

I install this bundle following the Sentry guide offered in the docs an ended up with the 3.0 version and faced this problem. Finally i figure it out but i think it will be helpful for other developers to add this notice in the README.md

