### PR TITLE
Fix console listener nullable command name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+ - Fix handling of command with no name on `ConsoleListener` (#261)
 
 ## 3.2.0 (2019-10-04)
 

--- a/src/EventListener/ConsoleListener.php
+++ b/src/EventListener/ConsoleListener.php
@@ -33,9 +33,14 @@ final class ConsoleListener
     {
         $command = $event->getCommand();
 
+        $commandName = null;
+        if ($command) {
+            $commandName = $command->getName();
+        }
+
         SentryBundle::getCurrentHub()
-            ->configureScope(function (Scope $scope) use ($command): void {
-                $scope->setTag('command', $command ? $command->getName() : 'N/A');
+            ->configureScope(static function (Scope $scope) use ($commandName): void {
+                $scope->setTag('command', $commandName ?? 'N/A');
             });
     }
 }

--- a/test/EventListener/ConsoleListenerTest.php
+++ b/test/EventListener/ConsoleListenerTest.php
@@ -51,11 +51,28 @@ class ConsoleListenerTest extends TestCase
         $this->assertSame(['command' => 'sf:command:name'], $this->getTagsContext($this->currentScope));
     }
 
-    public function testOnConsoleCommandAddsPlaceholderCommandName(): void
+    public function testOnConsoleCommandWithNoCommandAddsPlaceholder(): void
     {
         $event = $this->prophesize(ConsoleCommandEvent::class);
         $event->getCommand()
             ->willReturn(null);
+
+        $listener = new ConsoleListener($this->currentHub->reveal());
+
+        $listener->onConsoleCommand($event->reveal());
+
+        $this->assertSame(['command' => 'N/A'], $this->getTagsContext($this->currentScope));
+    }
+
+    public function testOnConsoleCommandWithNoCommandNameAddsPlaceholder(): void
+    {
+        $command = $this->prophesize(Command::class);
+        $command->getName()
+            ->willReturn(null);
+
+        $event = $this->prophesize(ConsoleCommandEvent::class);
+        $event->getCommand()
+            ->willReturn($command->reveal());
 
         $listener = new ConsoleListener($this->currentHub->reveal());
 


### PR DESCRIPTION
#260 highlighted an issue with PHPStan: https://travis-ci.org/getsentry/sentry-symfony/jobs/598219253#L719-L724

Basically, the console command name is nullable, so we need to catch that.