### PR TITLE
Restore ignoring default framework exceptions

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -217,12 +217,12 @@ class Configuration implements ConfigurationInterface
         return method_exists(Options::class, 'getMaxRequestBodySize');
     }
 
-    private function frameworkDefaultExceptions() : array
+    private function frameworkDefaultExceptions(): array
     {
         return [
             HttpExceptionInterface::class,
             AuthenticationException::class,
-            AccessDeniedException::class
+            AccessDeniedException::class,
         ];
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -7,7 +7,10 @@ use Sentry\Options;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 /**
  * This is the class that validates and merges configuration from your app/config files
@@ -48,6 +51,10 @@ class Configuration implements ConfigurationInterface
 
         $defaultValues = new Options();
         $optionsChildNodes = $optionsNode->children();
+
+        if (empty($defaultValues->getExcludedExceptions())) {
+            $defaultValues->setExcludedExceptions($this->frameworkDefaultExceptions());
+        }
 
         $optionsChildNodes->booleanNode('attach_stacktrace');
         $optionsChildNodes->variableNode('before_breadcrumb')
@@ -208,5 +215,14 @@ class Configuration implements ConfigurationInterface
     private function maxRequestBodySizeIsSupported(): bool
     {
         return method_exists(Options::class, 'getMaxRequestBodySize');
+    }
+
+    private function frameworkDefaultExceptions() : array
+    {
+        return [
+            HttpExceptionInterface::class,
+            AuthenticationException::class,
+            AccessDeniedException::class
+        ];
     }
 }

--- a/test/DependencyInjection/ConfigurationTest.php
+++ b/test/DependencyInjection/ConfigurationTest.php
@@ -8,7 +8,10 @@ use Sentry\SentryBundle\DependencyInjection\Configuration;
 use Sentry\SentryBundle\Test\BaseTestCase;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 class ConfigurationTest extends BaseTestCase
 {
@@ -63,7 +66,11 @@ class ConfigurationTest extends BaseTestCase
                     '%kernel.root_dir%/../vendor',
                 ],
                 'integrations' => $defaultSdkValues->getIntegrations(),
-                'excluded_exceptions' => $defaultSdkValues->getExcludedExceptions(),
+                'excluded_exceptions' => [
+                    HttpExceptionInterface::class,
+                    AuthenticationException::class,
+                    AccessDeniedException::class
+                ],
                 'prefixes' => $defaultSdkValues->getPrefixes(),
                 'project_root' => '%kernel.root_dir%/..',
                 'tags' => [],

--- a/test/DependencyInjection/ConfigurationTest.php
+++ b/test/DependencyInjection/ConfigurationTest.php
@@ -69,7 +69,7 @@ class ConfigurationTest extends BaseTestCase
                 'excluded_exceptions' => [
                     HttpExceptionInterface::class,
                     AuthenticationException::class,
-                    AccessDeniedException::class
+                    AccessDeniedException::class,
                 ],
                 'prefixes' => $defaultSdkValues->getPrefixes(),
                 'project_root' => '%kernel.root_dir%/..',


### PR DESCRIPTION
`sentry-symfony` started relying on the SDK's `excluded_exceptions` implementation, which is great but removes that the SDK is aware of Symfony exceptions that did get caught by default before.

We did not have any exceptions configured in `excluded_exceptions` yet, meaning that since `skip_capture` was removed in v3 the defaults the implementation used to rely on are gone. 

When upgrade to v3, Sentry starts capturing `HttpExceptionInterface` instances.

This PR adds the exceptions Sentry by default does not need to catch. Overriding them is as easy as before, by configuring `excluded_exceptions`.