### PR TITLE
Replace the use of deprecated getException() by getThrowable()

### DIFF
--- a/src/EventListener/ErrorListener.php
+++ b/src/EventListener/ErrorListener.php
@@ -23,7 +23,14 @@ final class ErrorListener
 
     public function onKernelException(GetResponseForExceptionEvent $event): void
     {
-        \Sentry\captureException($event->getException());
+        if (method_exists($event, 'getThrowable')) {
+            $throwable = $event->getThrowable();
+        } else {
+            // Support for Symfony 4.3 and before
+            $throwable = $event->getException();
+        }
+
+        \Sentry\captureException($throwable);
     }
 
     public function onConsoleError(ConsoleErrorEvent $event): void


### PR DESCRIPTION
`getException()` on `GetResponseForExceptionEvent` are deprecated since Symfony 4.4.

This PR makes sure that `getThrowable()` is called instead. We use `method_exists()` to check if this method exists, and otherwise fallback to `getException()` to keep support for Symfony 4.3 and before.