### PR TITLE
Use PHPStan shim to anticipate 0.12 release and avoid require conflicts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "jangregor/phpstan-prophecy": "^0.3.0",
         "monolog/monolog": "^1.11||^2.0",
         "php-http/mock-client": "^1.0",
-        "phpstan/phpstan": "^0.11",
+        "phpstan/phpstan-shim": "^0.11",
         "phpstan/phpstan-phpunit": "^0.11",
         "phpunit/phpunit": "^7.5",
         "scrutinizer/ocular": "^1.4",


### PR DESCRIPTION
This will avoid blocking #266, because PHPStan normally requires some Symfony components, and it's not yet compatible with Symfony 5. Using the shim (and 0.12 when it will be released) PHPStan will run inside a PHAR, isolating his dependencies from the vendor.

PHPStan 0.12 will be released tomorrow, but the extension aren't yet ready for it, so I want to speed this up.