### PR TITLE
fix PHPUnit 9 deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,12 +44,13 @@ jobs:
         - composer remove --dev friendsofphp/php-cs-fixer phpstan/phpstan phpstan/phpstan-phpunit jangregor/phpstan-prophecy --no-update
         - travis_retry travis_wait composer update --no-interaction --prefer-dist --prefer-stable --prefer-lowest
     - stage: Code style and static analysis
+      name: PHPStan
+      php: 7.4
       script:
         - composer phpstan
-      env: PHPSTAN=true
     - script: 
         - composer cs-check
-      env: CS-FIXER=true
+      name: PHP-CS-Fixer
     - stage: coverage
       script: 
         - phpdbg -qrr vendor/bin/phpunit --coverage-clover clover.xml

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,14 +4,20 @@ parameters:
         - src/
         - test/
     ignoreErrors:
-         - "/Call to function method_exists.. with 'Symfony.+' and 'getProjectDir' will always evaluate to false./"
          - "/Call to function method_exists.. with 'Symfony.+' and 'getRootNode' will always evaluate to false./"
          - "/Call to function method_exists.. with 'Sentry..Options' and 'getClassSerializers' will always evaluate to false./"
          - "/Call to function method_exists.. with 'Sentry..Options' and 'getMaxRequestBodySi...' will always evaluate to false./"
-         - '/Parameter \$.+ of method Sentry\\SentryBundle\\EventListener\\ErrorListener::onConsoleException\(\) has invalid typehint type Symfony\\Component\\Console\\Event\\ConsoleExceptionEvent./'
-         - '/Call to method getException\(\) on an unknown class Symfony\\Component\\Console\\Event\\ConsoleExceptionEvent./'
-         - '/Access to undefined constant Symfony\\Component\\Console\\ConsoleEvents::EXCEPTION./'
          - '/Class PHPUnit_Framework_TestCase not found/'
+         - '/Symfony\\Component\\HttpKernel\\Event\\(GetResponse|FilterController)Event not found.$/'
+         - 
+             message: '/Symfony\\Bundle\\FrameworkBundle\\Client/'
+             path: test/End2End/End2EndTest.php
+         - 
+             message: '/^Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder::root...$/'
+             path: src/DependencyInjection/Configuration.php
+         -
+             message: '/Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent.$/'
+             path: src/EventListener/ErrorListener.php
 
 includes:
 	- vendor/jangregor/phpstan-prophecy/src/extension.neon

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit 
+<phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/8.5/phpunit.xsd"
         colors="true"
@@ -8,6 +8,9 @@
         cacheResult="false"
         processIsolation="true"
 >
+    <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
+    </php>
 
     <testsuites>
         <testsuite name="SentryBundle test suite">

--- a/test/BaseTestCase.php
+++ b/test/BaseTestCase.php
@@ -49,9 +49,6 @@ abstract class BaseTestCase extends TestCase
         }
     }
 
-    /**
-     * @return GetResponseEvent|RequestEvent
-     */
     protected function createRequestEvent(Request $request = null, int $type = KernelInterface::MASTER_REQUEST)
     {
         if ($request === null) {
@@ -62,8 +59,7 @@ abstract class BaseTestCase extends TestCase
             $event = new RequestEvent(
                 $this->prophesize(KernelInterface::class)->reveal(),
                 $request,
-                $type,
-                $this->prophesize(Response::class)->reveal()
+                $type
             );
         } else {
             $event = new GetResponseEvent(

--- a/test/Command/SentryTestCommandTest.php
+++ b/test/Command/SentryTestCommandTest.php
@@ -33,10 +33,10 @@ class SentryTestCommandTest extends BaseTestCase
         $commandTester = $this->executeCommand();
 
         $output = $commandTester->getDisplay();
-        $this->assertContains('DSN correctly configured', $output);
-        $this->assertContains('Sending test message', $output);
-        $this->assertContains('Message sent', $output);
-        $this->assertContains($lastEventId, $output);
+        $this->assertStringContainsString('DSN correctly configured', $output);
+        $this->assertStringContainsString('Sending test message', $output);
+        $this->assertStringContainsString('Message sent', $output);
+        $this->assertStringContainsString($lastEventId, $output);
         $this->assertSame(0, $commandTester->getStatusCode());
     }
 
@@ -56,8 +56,8 @@ class SentryTestCommandTest extends BaseTestCase
 
         $this->assertNotSame(0, $commandTester->getStatusCode());
         $output = $commandTester->getDisplay();
-        $this->assertContains('No DSN configured', $output);
-        $this->assertContains('try bin/console debug:config sentry', $output);
+        $this->assertStringContainsString('No DSN configured', $output);
+        $this->assertStringContainsString('try bin/console debug:config sentry', $output);
     }
 
     public function testExecuteFailsDueToMessageNotSent(): void
@@ -80,9 +80,9 @@ class SentryTestCommandTest extends BaseTestCase
 
         $this->assertNotSame(0, $commandTester->getStatusCode());
         $output = $commandTester->getDisplay();
-        $this->assertContains('DSN correctly configured', $output);
-        $this->assertContains('Sending test message', $output);
-        $this->assertContains('Message not sent', $output);
+        $this->assertStringContainsString('DSN correctly configured', $output);
+        $this->assertStringContainsString('Sending test message', $output);
+        $this->assertStringContainsString('Message not sent', $output);
     }
 
     public function testExecuteFailsDueToMissingClient(): void
@@ -97,8 +97,8 @@ class SentryTestCommandTest extends BaseTestCase
 
         $this->assertNotSame(0, $commandTester->getStatusCode());
         $output = $commandTester->getDisplay();
-        $this->assertContains('No client found', $output);
-        $this->assertContains('DSN is probably missing', $output);
+        $this->assertStringContainsString('No client found', $output);
+        $this->assertStringContainsString('DSN is probably missing', $output);
     }
 
     private function executeCommand(): CommandTester

--- a/test/DependencyInjection/ConfigurationTest.php
+++ b/test/DependencyInjection/ConfigurationTest.php
@@ -92,7 +92,7 @@ class ConfigurationTest extends BaseTestCase
         $input = ['options' => [$option => $value]];
         $processed = $this->processConfiguration($input);
 
-        $this->assertArraySubset($input, $processed);
+        $this->assertContains($input, $processed);
     }
 
     public function optionValuesProvider(): array

--- a/test/DependencyInjection/SentryExtensionTest.php
+++ b/test/DependencyInjection/SentryExtensionTest.php
@@ -25,7 +25,6 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpKernel\Kernel;
 
 class SentryExtensionTest extends BaseTestCase
 {
@@ -57,13 +56,8 @@ class SentryExtensionTest extends BaseTestCase
         $container = $this->getContainer();
         $options = $this->getOptionsFrom($container);
 
-        if (method_exists(Kernel::class, 'getProjectDir')) {
-            $vendorDir = '/dir/project/root/vendor';
-            $this->assertSame('/dir/project/root', $options->getProjectRoot());
-        } else {
-            $vendorDir = 'kernel/root/../vendor';
-            $this->assertSame('kernel/root/..', $options->getProjectRoot());
-        }
+        $vendorDir = '/dir/project/root/vendor';
+        $this->assertSame('/dir/project/root', $options->getProjectRoot());
 
         $this->assertNull($options->getDsn());
         $this->assertSame('test', $options->getEnvironment());
@@ -421,9 +415,7 @@ class SentryExtensionTest extends BaseTestCase
     {
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->setParameter('kernel.cache_dir', 'var/cache');
-        if (method_exists(Kernel::class, 'getProjectDir')) {
-            $containerBuilder->setParameter('kernel.project_dir', '/dir/project/root');
-        }
+        $containerBuilder->setParameter('kernel.project_dir', '/dir/project/root');
         $containerBuilder->setParameter('kernel.environment', 'test');
 
         $mockEventDispatcher = $this->createMock(EventDispatcherInterface::class);

--- a/test/End2End/End2EndTest.php
+++ b/test/End2End/End2EndTest.php
@@ -98,7 +98,7 @@ class End2EndTest extends WebTestCase
 
             $this->assertInstanceOf(Response::class, $response);
             $this->assertSame(500, $response->getStatusCode());
-            $this->assertContains('intentional error', $response->getContent());
+            $this->assertStringContainsString('intentional error', $response->getContent());
         } catch (\Throwable $exception) {
             if (! $exception instanceof \RuntimeException) {
                 throw $exception;

--- a/test/End2End/End2EndTest.php
+++ b/test/End2End/End2EndTest.php
@@ -98,7 +98,7 @@ class End2EndTest extends WebTestCase
 
             $this->assertInstanceOf(Response::class, $response);
             $this->assertSame(500, $response->getStatusCode());
-            $this->assertStringContainsString('intentional error', $response->getContent());
+            $this->assertStringContainsString('intentional error', $response->getContent() ?: '');
         } catch (\Throwable $exception) {
             if (! $exception instanceof \RuntimeException) {
                 throw $exception;

--- a/test/ErrorTypesParserTest.php
+++ b/test/ErrorTypesParserTest.php
@@ -9,7 +9,6 @@ class ErrorTypesParserTest extends TestCase
 {
     /**
      * @dataProvider parsableValueProvider
-     * @param int|string $value
      */
     public function testParse($value, int $expected): void
     {

--- a/test/EventListener/ConsoleListenerTest.php
+++ b/test/EventListener/ConsoleListenerTest.php
@@ -84,10 +84,6 @@ class ConsoleListenerTest extends BaseTestCase
         return $event->getTagsContext()->toArray();
     }
 
-    /**
-     * @param $command
-     * @return ConsoleCommandEvent
-     */
     private function createConsoleCommandEvent(?Command $command): ConsoleCommandEvent
     {
         return new ConsoleCommandEvent(

--- a/test/EventListener/RequestListenerTest.php
+++ b/test/EventListener/RequestListenerTest.php
@@ -306,9 +306,6 @@ class RequestListenerTest extends BaseTestCase
         return $event->getTagsContext()->toArray();
     }
 
-    /**
-     * @return FilterControllerEvent|ControllerEvent
-     */
     private function createControllerEvent(Request $request)
     {
         if (class_exists(ControllerEvent::class)) {

--- a/test/SentryBundleTest.php
+++ b/test/SentryBundleTest.php
@@ -20,7 +20,6 @@ use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 class SentryBundleTest extends TestCase
@@ -144,9 +143,7 @@ class SentryBundleTest extends TestCase
     {
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->setParameter('kernel.cache_dir', 'var/cache');
-        if (method_exists(Kernel::class, 'getProjectDir')) {
-            $containerBuilder->setParameter('kernel.project_dir', '/dir/project/root');
-        }
+        $containerBuilder->setParameter('kernel.project_dir', '/dir/project/root');
 
         $containerBuilder->setParameter('kernel.environment', 'test');
         $containerBuilder->set('event_dispatcher', $this->prophesize(EventDispatcherInterface::class)->reveal());


### PR DESCRIPTION
After #266 was merged tests still were failing. Found out this was because of deprecation warnings on PHPUnit. This PR fixes these deprecations on the test suite.

PHPStan is the only test that's failing. What about not running PHPStan on the `/tests` folder?