### PR TITLE
#291 defaulting `release` config to detected root package version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
  - Add support for Symfony 5.0 (#266, thanks to @Big-Shark)
  - Drop support for Symfony < 3.4 (#277)
+ - Add default value for the `release` option, using the detected root package version (#291 #292, thanks to @Ocramius)
 
 ## 3.2.1 (2019-12-19)
  - Fix handling of command with no name on `ConsoleListener` (#261)

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "require": {
         "php": "^7.1",
         "jean85/pretty-package-versions": "^1.0",
+        "ocramius/package-versions": "^1.3.0",
         "sentry/sdk": "^2.0",
         "symfony/config": "^3.4||^4.0||^5.0",
         "symfony/console": "^3.4||^4.0||^5.0",

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -3,6 +3,7 @@
 namespace Sentry\SentryBundle\DependencyInjection;
 
 use Jean85\PrettyVersions;
+use PackageVersions\Versions;
 use Sentry\Options;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -114,7 +115,10 @@ class Configuration implements ConfigurationInterface
             ->prototype('scalar');
         $optionsChildNodes->scalarNode('project_root')
             ->defaultValue('%kernel.project_dir%');
-        $optionsChildNodes->scalarNode('release');
+        $optionsChildNodes->scalarNode('release')
+            ->defaultValue(Versions::getVersion(Versions::ROOT_PACKAGE_NAME))
+            ->info('Release version to be reported to sentry, see https://docs.sentry.io/workflow/releases/?platform=php')
+            ->example('my/application@ff11bb');
         $optionsChildNodes->floatNode('sample_rate')
             ->min(0.0)
             ->max(1.0);

--- a/test/DependencyInjection/ConfigurationTest.php
+++ b/test/DependencyInjection/ConfigurationTest.php
@@ -3,6 +3,7 @@
 namespace Sentry\SentryBundle\Test\DependencyInjection;
 
 use Jean85\PrettyVersions;
+use PackageVersions\Versions;
 use Sentry\Options;
 use Sentry\SentryBundle\DependencyInjection\Configuration;
 use Sentry\SentryBundle\Test\BaseTestCase;
@@ -66,6 +67,7 @@ class ConfigurationTest extends BaseTestCase
                 'prefixes' => $defaultSdkValues->getPrefixes(),
                 'project_root' => '%kernel.project_dir%',
                 'tags' => [],
+                'release' => Versions::getVersion('sentry/sentry-symfony'),
             ],
             'monolog' => [
                 'error_handler' => [


### PR DESCRIPTION
Effectively automates release tracking for the grand majority of
applications out there, without having to resort to to any `VERSION`
environment variables nor other custom approaches to be figured out
by the end consumer of the library.

Ref https://docs.sentry.io/workflow/releases/?platform=php

Fixes #291