### PR TITLE
Enable PsrLogMessageProcessor on MonologHandler

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -54,10 +54,15 @@
             <tag name="console.command" />
         </service>
 
+        <service id="sentry.monolog.psr_log_message_processor" class="Monolog\Processor\PsrLogMessageProcessor" public="false"/>
+
         <service id="Sentry\Monolog\Handler" class="Sentry\Monolog\Handler" public="false">
             <argument type="service" id="Sentry\State\HubInterface" />
             <argument key="$level" />
             <argument key="$bubble" />
+            <call method="pushProcessor">
+                <argument type="service" id="sentry.monolog.psr_log_message_processor" />
+            </call>
         </service>
     </services>
 </container>


### PR DESCRIPTION
This will make sure that parameters inside a log record string are interpolated with the values from the context.

Because Sentry reports like this are not very useful:
```
Payment failed with {exception}. Message: {message}
```

Also, everything that is logged as `context` will not be sent to Sentry at all... seems like a different issue.