### PR TITLE
Support sentry/sentry 2.3 and fix deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+ - ...
+ 
+## 3.4.0 (2020-01-17)
  - Add support for `sentry/sentry` 2.3 (#298)
  - Drop support for `sentry/sentry` < 2.3 (#298)
  - Add support to `in_app_include` client option (#298)
  - Remap `excluded_exception` option to use the new `IgnoreErrorIntegration` (#298)
 
 ## 3.3.2 (2020-01-16)
-- Fix issue with exception listener under Symfony 4.3 (#301)
+ - Fix issue with exception listener under Symfony 4.3 (#301)
 
 ## 3.3.1 (2020-01-14)
-- Fixed Release
+ - Fixed Release
 
 ## 3.3.0 (2020-01-14)
  - Add support for Symfony 5.0 (#266, thanks to @Big-Shark)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+ - Add support for `sentry/sentry` 2.3 (#298)
  - Drop support for `sentry/sentry` < 2.3 (#298)
  - Add support to `in_app_include` client option (#298)
  - Remap `excluded_exception` option to use the new `IgnoreErrorIntegration` (#298)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
- - ...
+ - Drop support for `sentry/sentry` < 2.3 (#298)
+ - Add support to `in_app_include` client option (#298)
+ - Remap `excluded_exception` option to use the new `IgnoreErrorIntegration` (#298)
 
 ## 3.3.0 (2020-01-14)
  - Add support for Symfony 5.0 (#266, thanks to @Big-Shark)

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": "^7.1",
         "jean85/pretty-package-versions": "^1.0",
         "ocramius/package-versions": "^1.3.0",
-        "sentry/sdk": "^2.0",
+        "sentry/sdk": "^2.1",
         "symfony/config": "^3.4||^4.0||^5.0",
         "symfony/console": "^3.4||^4.0||^5.0",
         "symfony/dependency-injection": "^3.4||^4.0||^5.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,8 +5,6 @@ parameters:
         - test/
     ignoreErrors:
          - "/Call to function method_exists.. with 'Symfony.+' and 'getRootNode' will always evaluate to false./"
-         - "/Call to function method_exists.. with 'Sentry..Options' and 'getClassSerializers' will always evaluate to false./"
-         - "/Call to function method_exists.. with 'Sentry..Options' and 'getMaxRequestBodySi...' will always evaluate to false./"
          - '/Class PHPUnit_Framework_TestCase not found/'
          - '/Symfony\\Component\\HttpKernel\\Event\\(GetResponse|FilterController)Event not found.$/'
          - 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,7 +6,6 @@
         backupGlobals="false"
         bootstrap="vendor/autoload.php"
         cacheResult="false"
-        processIsolation="true"
 >
     <php>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />

--- a/src/Command/SentryTestCommand.php
+++ b/src/Command/SentryTestCommand.php
@@ -2,7 +2,7 @@
 
 namespace Sentry\SentryBundle\Command;
 
-use Sentry\SentryBundle\SentryBundle;
+use Sentry\SentrySdk;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -16,7 +16,7 @@ class SentryTestCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $currentHub = SentryBundle::getCurrentHub();
+        $currentHub = SentrySdk::getCurrentHub();
         $client = $currentHub->getClient();
 
         if (! $client) {

--- a/src/DependencyInjection/ClientBuilderConfigurator.php
+++ b/src/DependencyInjection/ClientBuilderConfigurator.php
@@ -3,9 +3,6 @@
 namespace Sentry\SentryBundle\DependencyInjection;
 
 use Sentry\ClientBuilderInterface;
-use Sentry\Integration\ErrorListenerIntegration;
-use Sentry\Integration\ExceptionListenerIntegration;
-use Sentry\Integration\IntegrationInterface;
 use Sentry\SentryBundle\SentryBundle;
 
 class ClientBuilderConfigurator
@@ -14,23 +11,5 @@ class ClientBuilderConfigurator
     {
         $clientBuilder->setSdkIdentifier(SentryBundle::SDK_IDENTIFIER);
         $clientBuilder->setSdkVersion(SentryBundle::getSdkVersion());
-
-        $options = $clientBuilder->getOptions();
-        if (! $options->hasDefaultIntegrations()) {
-            return;
-        }
-
-        $integrations = $options->getIntegrations();
-        $options->setIntegrations(array_filter($integrations, static function (IntegrationInterface $integration): bool {
-            if ($integration instanceof ErrorListenerIntegration) {
-                return false;
-            }
-
-            if ($integration instanceof ExceptionListenerIntegration) {
-                return false;
-            }
-
-            return true;
-        }));
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -87,7 +87,7 @@ class Configuration implements ConfigurationInterface
             ])
             ->prototype('scalar');
         $optionsChildNodes->arrayNode('excluded_exceptions')
-            ->defaultValue($defaultValues->getExcludedExceptions())
+            ->defaultValue([])
             ->prototype('scalar');
         $optionsChildNodes->scalarNode('http_proxy');
         $optionsChildNodes->arrayNode('integrations')

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -75,6 +75,11 @@ class Configuration implements ConfigurationInterface
             ->defaultValue('%kernel.environment%')
             ->cannotBeEmpty();
         $optionsChildNodes->scalarNode('error_types');
+        $optionsChildNodes->arrayNode('in_app_include')
+            ->defaultValue([
+                '%kernel.project_dir%',
+            ])
+            ->prototype('scalar');
         $optionsChildNodes->arrayNode('in_app_exclude')
             ->defaultValue([
                 '%kernel.cache_dir%',
@@ -114,7 +119,7 @@ class Configuration implements ConfigurationInterface
             ->defaultValue($defaultValues->getPrefixes())
             ->prototype('scalar');
         $optionsChildNodes->scalarNode('project_root')
-            ->defaultValue('%kernel.project_dir%');
+            ->setDeprecated();
         $optionsChildNodes->scalarNode('release')
             ->defaultValue(Versions::getVersion(Versions::ROOT_PACKAGE_NAME))
             ->info('Release version to be reported to sentry, see https://docs.sentry.io/workflow/releases/?platform=php')

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -2,7 +2,6 @@
 
 namespace Sentry\SentryBundle\DependencyInjection;
 
-use Jean85\PrettyVersions;
 use PackageVersions\Versions;
 use Sentry\Options;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
@@ -58,14 +57,10 @@ class Configuration implements ConfigurationInterface
             ->validate()
             ->ifTrue($this->isNotAValidCallback())
             ->thenInvalid('Expecting callable or service reference, got %s');
-        if (PrettyVersions::getVersion('sentry/sentry')->getPrettyVersion() !== '2.0.0') {
-            $optionsChildNodes->booleanNode('capture_silenced_errors');
-        }
-        if ($this->classSerializersAreSupported()) {
-            $optionsChildNodes->arrayNode('class_serializers')
-                ->defaultValue([])
-                ->prototype('scalar');
-        }
+        $optionsChildNodes->booleanNode('capture_silenced_errors');
+        $optionsChildNodes->arrayNode('class_serializers')
+            ->defaultValue([])
+            ->prototype('scalar');
         $optionsChildNodes->integerNode('context_lines')
             ->min(0)
             ->max(99);
@@ -102,15 +97,13 @@ class Configuration implements ConfigurationInterface
             })
             ->thenInvalid('Expecting service reference, got "%s"');
         $optionsChildNodes->scalarNode('logger');
-        if ($this->maxRequestBodySizeIsSupported()) {
-            $optionsChildNodes->enumNode('max_request_body_size')
-                ->values([
-                    'none',
-                    'small',
-                    'medium',
-                    'always',
-                ]);
-        }
+        $optionsChildNodes->enumNode('max_request_body_size')
+            ->values([
+                'none',
+                'small',
+                'medium',
+                'always',
+            ]);
         $optionsChildNodes->integerNode('max_breadcrumbs')
             ->min(1);
         $optionsChildNodes->integerNode('max_value_length')
@@ -197,15 +190,5 @@ class Configuration implements ConfigurationInterface
 
             return true;
         };
-    }
-
-    private function classSerializersAreSupported(): bool
-    {
-        return method_exists(Options::class, 'getClassSerializers');
-    }
-
-    private function maxRequestBodySizeIsSupported(): bool
-    {
-        return method_exists(Options::class, 'getMaxRequestBodySize');
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -72,7 +72,7 @@ class Configuration implements ConfigurationInterface
         $optionsChildNodes->scalarNode('error_types');
         $optionsChildNodes->arrayNode('in_app_include')
             ->defaultValue([
-                '%kernel.project_dir%',
+                '%kernel.project_dir%/src',
             ])
             ->prototype('scalar');
         $optionsChildNodes->arrayNode('in_app_exclude')
@@ -111,8 +111,7 @@ class Configuration implements ConfigurationInterface
         $optionsChildNodes->arrayNode('prefixes')
             ->defaultValue($defaultValues->getPrefixes())
             ->prototype('scalar');
-        $optionsChildNodes->scalarNode('project_root')
-            ->setDeprecated();
+        $optionsChildNodes->scalarNode('project_root');
         $optionsChildNodes->scalarNode('release')
             ->defaultValue(Versions::getVersion(Versions::ROOT_PACKAGE_NAME))
             ->info('Release version to be reported to sentry, see https://docs.sentry.io/workflow/releases/?platform=php')

--- a/src/DependencyInjection/IntegrationFilterFactory.php
+++ b/src/DependencyInjection/IntegrationFilterFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Sentry\SentryBundle\DependencyInjection;
+
+use Sentry\Integration\ErrorListenerIntegration;
+use Sentry\Integration\ExceptionListenerIntegration;
+use Sentry\Integration\IntegrationInterface;
+
+class IntegrationFilterFactory
+{
+    public static function create(array $integrationsFromConfiguration): callable
+    {
+        return function (array $integrations) use ($integrationsFromConfiguration) {
+            $allIntegrations = array_merge($integrations, $integrationsFromConfiguration);
+
+            return array_filter(
+                $allIntegrations,
+                static function (IntegrationInterface $integration): bool {
+                    if ($integration instanceof ErrorListenerIntegration) {
+                        return false;
+                    }
+
+                    if ($integration instanceof ExceptionListenerIntegration) {
+                        return false;
+                    }
+
+                    return true;
+                }
+            );
+        };
+    }
+}

--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -4,6 +4,7 @@ namespace Sentry\SentryBundle\DependencyInjection;
 
 use Monolog\Logger as MonologLogger;
 use Sentry\ClientBuilderInterface;
+use Sentry\Integration\IgnoreErrorsIntegration;
 use Sentry\Monolog\Handler;
 use Sentry\Options;
 use Sentry\SentryBundle\ErrorTypesParser;
@@ -64,7 +65,6 @@ class SentryExtension extends Extension
             'default_integrations',
             'enable_compression',
             'environment',
-            'excluded_exceptions',
             'http_proxy',
             'logger',
             'max_request_body_size',
@@ -120,6 +120,14 @@ class SentryExtension extends Extension
             foreach ($processedOptions['integrations'] as $integrationName) {
                 $integrations[] = new Reference(substr($integrationName, 1));
             }
+        }
+
+        if (\array_key_exists('excluded_exceptions', $processedOptions) && $processedOptions['excluded_exceptions']) {
+            $ignoreOptions = [
+                'ignore_exceptions' => $processedOptions['excluded_exceptions'],
+            ];
+
+            $integrations[] = new Definition(IgnoreErrorsIntegration::class, [$ignoreOptions]);
         }
 
         $integrationsCallable = new Definition('callable', [$integrations]);

--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -91,6 +91,10 @@ class SentryExtension extends Extension
             $options->addMethodCall('setInAppExcludedPaths', [$processedOptions['in_app_exclude']]);
         }
 
+        if (\array_key_exists('in_app_include', $processedOptions)) {
+            $options->addMethodCall('setInAppIncludedPaths', [$processedOptions['in_app_include']]);
+        }
+
         if (\array_key_exists('error_types', $processedOptions)) {
             $parsedValue = (new ErrorTypesParser($processedOptions['error_types']))->parse();
             $options->addMethodCall('setErrorTypes', [$parsedValue]);

--- a/src/EventListener/ConsoleListener.php
+++ b/src/EventListener/ConsoleListener.php
@@ -2,7 +2,7 @@
 
 namespace Sentry\SentryBundle\EventListener;
 
-use Sentry\SentryBundle\SentryBundle;
+use Sentry\SentrySdk;
 use Sentry\State\HubInterface;
 use Sentry\State\Scope;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
@@ -38,7 +38,7 @@ final class ConsoleListener
             $commandName = $command->getName();
         }
 
-        SentryBundle::getCurrentHub()
+        SentrySdk::getCurrentHub()
             ->configureScope(static function (Scope $scope) use ($commandName): void {
                 $scope->setTag('command', $commandName ?? 'N/A');
             });

--- a/src/EventListener/RequestListener.php
+++ b/src/EventListener/RequestListener.php
@@ -2,7 +2,7 @@
 
 namespace Sentry\SentryBundle\EventListener;
 
-use Sentry\SentryBundle\SentryBundle;
+use Sentry\SentrySdk;
 use Sentry\State\HubInterface;
 use Sentry\State\Scope;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
@@ -56,7 +56,7 @@ final class RequestListener
             return;
         }
 
-        $currentClient = SentryBundle::getCurrentHub()->getClient();
+        $currentClient = SentrySdk::getCurrentHub()->getClient();
         if (null === $currentClient || ! $currentClient->getOptions()->shouldSendDefaultPii()) {
             return;
         }
@@ -79,7 +79,7 @@ final class RequestListener
 
         $userData['ip_address'] = $event->getRequest()->getClientIp();
 
-        SentryBundle::getCurrentHub()
+        SentrySdk::getCurrentHub()
             ->configureScope(function (Scope $scope) use ($userData): void {
                 $scope->setUser($userData, true);
             });
@@ -97,7 +97,7 @@ final class RequestListener
 
         $matchedRoute = (string) $event->getRequest()->attributes->get('_route');
 
-        SentryBundle::getCurrentHub()
+        SentrySdk::getCurrentHub()
             ->configureScope(function (Scope $scope) use ($matchedRoute): void {
                 $scope->setTag('route', $matchedRoute);
             });

--- a/src/EventListener/RequestListener.php
+++ b/src/EventListener/RequestListener.php
@@ -81,7 +81,7 @@ final class RequestListener
 
         SentryBundle::getCurrentHub()
             ->configureScope(function (Scope $scope) use ($userData): void {
-                $scope->setUser($userData);
+                $scope->setUser($userData, true);
             });
     }
 

--- a/src/EventListener/SubRequestListener.php
+++ b/src/EventListener/SubRequestListener.php
@@ -2,7 +2,7 @@
 
 namespace Sentry\SentryBundle\EventListener;
 
-use Sentry\SentryBundle\SentryBundle;
+use Sentry\SentrySdk;
 use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -24,7 +24,7 @@ final class SubRequestListener
             return;
         }
 
-        SentryBundle::getCurrentHub()->pushScope();
+        SentrySdk::getCurrentHub()->pushScope();
     }
 
     /**
@@ -38,6 +38,6 @@ final class SubRequestListener
             return;
         }
 
-        SentryBundle::getCurrentHub()->popScope();
+        SentrySdk::getCurrentHub()->popScope();
     }
 }

--- a/src/SentryBundle.php
+++ b/src/SentryBundle.php
@@ -4,7 +4,6 @@ namespace Sentry\SentryBundle;
 
 use Jean85\PrettyVersions;
 use Sentry\SentrySdk;
-use Sentry\State\Hub;
 use Sentry\State\HubInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -23,11 +22,7 @@ class SentryBundle extends Bundle
      */
     public static function getCurrentHub(): HubInterface
     {
-        if (class_exists(SentrySdk::class)) {
-            return SentrySdk::getCurrentHub();
-        }
-
-        return Hub::getCurrent();
+        return SentrySdk::getCurrentHub();
     }
 
     /**
@@ -35,12 +30,6 @@ class SentryBundle extends Bundle
      */
     public static function setCurrentHub(HubInterface $hub): void
     {
-        if (class_exists(SentrySdk::class)) {
-            SentrySdk::setCurrentHub($hub);
-
-            return;
-        }
-
-        Hub::setCurrent($hub);
+        SentrySdk::setCurrentHub($hub);
     }
 }

--- a/test/BaseTestCase.php
+++ b/test/BaseTestCase.php
@@ -3,10 +3,6 @@
 namespace Sentry\SentryBundle\Test;
 
 use PHPUnit\Framework\TestCase;
-use Sentry\Options;
-use Sentry\SentrySdk;
-use Sentry\State\Hub;
-use Sentry\State\HubInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -15,38 +11,9 @@ use Symfony\Component\HttpKernel\KernelInterface;
 
 abstract class BaseTestCase extends TestCase
 {
-    protected function classSerializersAreSupported(): bool
-    {
-        return method_exists(Options::class, 'getClassSerializers');
-    }
-
-    protected function maxRequestBodySizeIsSupported(): bool
-    {
-        return method_exists(Options::class, 'getMaxRequestBodySize');
-    }
-
     protected function getSupportedOptionsCount(): int
     {
-        $count = 24;
-
-        if ($this->classSerializersAreSupported()) {
-            ++$count;
-        }
-
-        if ($this->maxRequestBodySizeIsSupported()) {
-            ++$count;
-        }
-
-        return $count;
-    }
-
-    protected function setCurrentHub(HubInterface $hub): void
-    {
-        if (class_exists(SentrySdk::class)) {
-            SentrySdk::setCurrentHub($hub);
-        } else {
-            Hub::setCurrent($hub);
-        }
+        return 26;
     }
 
     protected function createRequestEvent(Request $request = null, int $type = KernelInterface::MASTER_REQUEST)

--- a/test/BaseTestCase.php
+++ b/test/BaseTestCase.php
@@ -27,7 +27,7 @@ abstract class BaseTestCase extends TestCase
 
     protected function getSupportedOptionsCount(): int
     {
-        $count = 23;
+        $count = 24;
 
         if ($this->classSerializersAreSupported()) {
             ++$count;

--- a/test/Command/SentryTestCommandTest.php
+++ b/test/Command/SentryTestCommandTest.php
@@ -7,6 +7,7 @@ use Sentry\ClientInterface;
 use Sentry\Options;
 use Sentry\SentryBundle\Command\SentryTestCommand;
 use Sentry\SentryBundle\Test\BaseTestCase;
+use Sentry\SentrySdk;
 use Sentry\State\HubInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -28,7 +29,7 @@ class SentryTestCommandTest extends BaseTestCase
             ->shouldBeCalled()
             ->willReturn($lastEventId);
 
-        $this->setCurrentHub($hub->reveal());
+        SentrySdk::setCurrentHub($hub->reveal());
 
         $commandTester = $this->executeCommand();
 
@@ -50,7 +51,7 @@ class SentryTestCommandTest extends BaseTestCase
         $hub->getClient()
             ->willReturn($client->reveal());
 
-        $this->setCurrentHub($hub->reveal());
+        SentrySdk::setCurrentHub($hub->reveal());
 
         $commandTester = $this->executeCommand();
 
@@ -74,7 +75,7 @@ class SentryTestCommandTest extends BaseTestCase
             ->shouldBeCalled()
             ->willReturn(null);
 
-        $this->setCurrentHub($hub->reveal());
+        SentrySdk::setCurrentHub($hub->reveal());
 
         $commandTester = $this->executeCommand();
 
@@ -91,7 +92,7 @@ class SentryTestCommandTest extends BaseTestCase
         $hub->getClient()
             ->willReturn(null);
 
-        $this->setCurrentHub($hub->reveal());
+        SentrySdk::setCurrentHub($hub->reveal());
 
         $commandTester = $this->executeCommand();
 

--- a/test/DependencyInjection/ConfigurationTest.php
+++ b/test/DependencyInjection/ConfigurationTest.php
@@ -64,7 +64,7 @@ class ConfigurationTest extends BaseTestCase
                     '%kernel.project_dir%/vendor',
                 ],
                 'integrations' => [],
-                'excluded_exceptions' => $defaultSdkValues->getExcludedExceptions(),
+                'excluded_exceptions' => [],
                 'prefixes' => $defaultSdkValues->getPrefixes(),
                 'tags' => [],
                 'release' => Versions::getVersion('sentry/sentry-symfony'),
@@ -88,7 +88,7 @@ class ConfigurationTest extends BaseTestCase
 
     /**
      * @group legacy
-     * 
+     *
      * @dataProvider optionValuesProvider
      */
     public function testOptionValuesProcessing(string $option, $value): void

--- a/test/DependencyInjection/ConfigurationTest.php
+++ b/test/DependencyInjection/ConfigurationTest.php
@@ -62,7 +62,7 @@ class ConfigurationTest extends BaseTestCase
                     '%kernel.cache_dir%',
                     '%kernel.project_dir%/vendor',
                 ],
-                'integrations' => $defaultSdkValues->getIntegrations(),
+                'integrations' => [],
                 'excluded_exceptions' => $defaultSdkValues->getExcludedExceptions(),
                 'prefixes' => $defaultSdkValues->getPrefixes(),
                 'project_root' => '%kernel.project_dir%',

--- a/test/DependencyInjection/ConfigurationTest.php
+++ b/test/DependencyInjection/ConfigurationTest.php
@@ -54,7 +54,9 @@ class ConfigurationTest extends BaseTestCase
             'options' => [
                 'class_serializers' => [],
                 'environment' => '%kernel.environment%',
-                'in_app_include' => ['%kernel.project_dir%'],
+                'in_app_include' => [
+                    '%kernel.project_dir%/src',
+                ],
                 'in_app_exclude' => [
                     '%kernel.cache_dir%',
                     '%kernel.project_dir%/vendor',

--- a/test/DependencyInjection/ConfigurationTest.php
+++ b/test/DependencyInjection/ConfigurationTest.php
@@ -58,6 +58,7 @@ class ConfigurationTest extends BaseTestCase
             ],
             'options' => [
                 'environment' => '%kernel.environment%',
+                'in_app_include' => ['%kernel.project_dir%'],
                 'in_app_exclude' => [
                     '%kernel.cache_dir%',
                     '%kernel.project_dir%/vendor',
@@ -65,7 +66,6 @@ class ConfigurationTest extends BaseTestCase
                 'integrations' => [],
                 'excluded_exceptions' => $defaultSdkValues->getExcludedExceptions(),
                 'prefixes' => $defaultSdkValues->getPrefixes(),
-                'project_root' => '%kernel.project_dir%',
                 'tags' => [],
                 'release' => Versions::getVersion('sentry/sentry-symfony'),
             ],
@@ -87,6 +87,8 @@ class ConfigurationTest extends BaseTestCase
     }
 
     /**
+     * @group legacy
+     * 
      * @dataProvider optionValuesProvider
      */
     public function testOptionValuesProcessing(string $option, $value): void
@@ -111,6 +113,7 @@ class ConfigurationTest extends BaseTestCase
             ['environment', 'staging'],
             ['error_types', E_ALL],
             ['http_proxy', '1.2.3.4:5678'],
+            ['in_app_include', ['some/path']],
             ['in_app_exclude', ['some/path']],
             ['integrations', []],
             ['excluded_exceptions', [\Throwable::class]],
@@ -181,6 +184,7 @@ class ConfigurationTest extends BaseTestCase
             ['error_types', []],
             ['excluded_exceptions', 'some-string'],
             ['http_proxy', []],
+            ['in_app_include', 'some/single/path'],
             ['in_app_exclude', 'some/single/path'],
             ['integrations', [1]],
             ['integrations', 'a string'],

--- a/test/DependencyInjection/SentryExtensionTest.php
+++ b/test/DependencyInjection/SentryExtensionTest.php
@@ -59,7 +59,7 @@ class SentryExtensionTest extends BaseTestCase
         $options = $this->getOptionsFrom($container);
 
         $vendorDir = '/dir/project/root/vendor';
-        $this->assertSame('/dir/project/root', $options->getProjectRoot());
+        $this->assertContains('/dir/project/root', $options->getInAppIncludedPaths());
 
         $this->assertNull($options->getDsn());
         $this->assertSame('test', $options->getEnvironment());
@@ -126,6 +126,7 @@ class SentryExtensionTest extends BaseTestCase
             ['enable_compression', false, 'isCompressionEnabled'],
             ['environment', 'staging'],
             ['error_types', E_ALL & ~E_NOTICE],
+            ['in_app_include', ['/some/path'], 'getInAppIncludedPaths'],
             ['in_app_exclude', ['/some/path'], 'getInAppExcludedPaths'],
             ['excluded_exceptions', [\Throwable::class]],
             ['http_proxy', '1.2.3.4'],

--- a/test/DependencyInjection/SentryExtensionTest.php
+++ b/test/DependencyInjection/SentryExtensionTest.php
@@ -128,7 +128,6 @@ class SentryExtensionTest extends BaseTestCase
             ['error_types', E_ALL & ~E_NOTICE],
             ['in_app_include', ['/some/path'], 'getInAppIncludedPaths'],
             ['in_app_exclude', ['/some/path'], 'getInAppExcludedPaths'],
-            ['excluded_exceptions', [\Throwable::class]],
             ['http_proxy', '1.2.3.4'],
             ['logger', 'sentry-logger'],
             ['max_breadcrumbs', 15],

--- a/test/DependencyInjection/SentryExtensionTest.php
+++ b/test/DependencyInjection/SentryExtensionTest.php
@@ -60,7 +60,7 @@ class SentryExtensionTest extends BaseTestCase
         $options = $this->getOptionsFrom($container);
 
         $vendorDir = '/dir/project/root/vendor';
-        $this->assertContains('/dir/project/root', $options->getInAppIncludedPaths());
+        $this->assertContains('/dir/project/root/src', $options->getInAppIncludedPaths());
 
         $this->assertNull($options->getDsn());
         $this->assertSame('test', $options->getEnvironment());

--- a/test/DependencyInjection/SentryExtensionTest.php
+++ b/test/DependencyInjection/SentryExtensionTest.php
@@ -15,8 +15,8 @@ use Sentry\Monolog\Handler;
 use Sentry\Options;
 use Sentry\SentryBundle\DependencyInjection\SentryExtension;
 use Sentry\SentryBundle\EventListener\ErrorListener;
-use Sentry\SentryBundle\SentryBundle;
 use Sentry\SentryBundle\Test\BaseTestCase;
+use Sentry\SentrySdk;
 use Sentry\Severity;
 use Sentry\State\HubInterface;
 use Sentry\State\Scope;
@@ -468,7 +468,7 @@ class SentryExtensionTest extends BaseTestCase
 
         $hub = $this->prophesize(HubInterface::class);
         $hub->bindClient(Argument::type(ClientMock::class));
-        SentryBundle::setCurrentHub($hub->reveal());
+        SentrySdk::setCurrentHub($hub->reveal());
 
         $containerBuilder->compile();
 

--- a/test/DependencyInjection/SentryExtensionTest.php
+++ b/test/DependencyInjection/SentryExtensionTest.php
@@ -41,6 +41,7 @@ class SentryExtensionTest extends BaseTestCase
 
         // subtracted one is `integration`, which cannot be tested with the provider
         $expectedCount = $this->getSupportedOptionsCount();
+        --$expectedCount; // excluded_exceptions is remapped to the new IgnoreErrorIntegration
 
         if (PrettyVersions::getVersion('sentry/sentry')->getPrettyVersion() === '2.0.0') {
             --$expectedCount;

--- a/test/DependencyInjection/SentryExtensionTest.php
+++ b/test/DependencyInjection/SentryExtensionTest.php
@@ -122,6 +122,13 @@ class SentryExtensionTest extends BaseTestCase
             ['attach_stacktrace', true, 'shouldAttachStacktrace'],
             ['before_breadcrumb', __NAMESPACE__ . '\mockBeforeBreadcrumb', 'getBeforeBreadcrumbCallback'],
             ['before_send', __NAMESPACE__ . '\mockBeforeSend', 'getBeforeSendCallback'],
+            [
+                'class_serializers',
+                [
+                    self::class => __NAMESPACE__ . '\mockClassSerializer',
+                ],
+                'getClassSerializers',
+            ],
             ['context_lines', 1],
             ['default_integrations', false, 'hasDefaultIntegrations'],
             ['enable_compression', false, 'isCompressionEnabled'],
@@ -132,6 +139,7 @@ class SentryExtensionTest extends BaseTestCase
             ['http_proxy', '1.2.3.4'],
             ['logger', 'sentry-logger'],
             ['max_breadcrumbs', 15],
+            ['max_request_body_size', 'always'],
             ['max_value_length', 1000],
             ['prefixes', ['/some/path/prefix/']],
             ['project_root', '/some/project/'],
@@ -145,20 +153,6 @@ class SentryExtensionTest extends BaseTestCase
 
         if (PrettyVersions::getVersion('sentry/sentry')->getPrettyVersion() !== '2.0.0') {
             $options[] = ['capture_silenced_errors', true, 'shouldCaptureSilencedErrors'];
-        }
-
-        if ($this->classSerializersAreSupported()) {
-            $options['class_serializer'] = [
-                'class_serializers',
-                [
-                    self::class => __NAMESPACE__ . '\mockClassSerializer',
-                ],
-                'getClassSerializers',
-            ];
-        }
-
-        if ($this->maxRequestBodySizeIsSupported()) {
-            $options[] = ['max_request_body_size', 'always'];
         }
 
         return $options;

--- a/test/DependencyInjection/SentryExtensionTest.php
+++ b/test/DependencyInjection/SentryExtensionTest.php
@@ -339,7 +339,7 @@ class SentryExtensionTest extends BaseTestCase
         $found = false;
         foreach ($integrations as $integration) {
             if ($integration instanceof ErrorListenerIntegration) {
-                $this->fail('Should not have FatalErrorListenerIntegration registered');
+                $this->fail('Should not have ErrorListenerIntegration registered');
             }
 
             if ($integration instanceof ExceptionListenerIntegration) {

--- a/test/End2End/End2EndTest.php
+++ b/test/End2End/End2EndTest.php
@@ -16,6 +16,9 @@ if (! class_exists(KernelBrowser::class)) {
     class_alias(Client::class, KernelBrowser::class);
 }
 
+/**
+ * @runTestsInSeparateProcesses
+ */
 class End2EndTest extends WebTestCase
 {
     protected static function getKernelClass(): string

--- a/test/EventListener/ConsoleListenerTest.php
+++ b/test/EventListener/ConsoleListenerTest.php
@@ -6,6 +6,7 @@ use Prophecy\Argument;
 use Sentry\Event;
 use Sentry\SentryBundle\EventListener\ConsoleListener;
 use Sentry\SentryBundle\Test\BaseTestCase;
+use Sentry\SentrySdk;
 use Sentry\State\HubInterface;
 use Sentry\State\Scope;
 use Symfony\Component\Console\Command\Command;
@@ -32,7 +33,7 @@ class ConsoleListenerTest extends BaseTestCase
                 $callable($scope);
             });
 
-        $this->setCurrentHub($this->currentHub->reveal());
+        SentrySdk::setCurrentHub($this->currentHub->reveal());
     }
 
     public function testOnConsoleCommandAddsCommandName(): void

--- a/test/EventListener/RequestListenerTest.php
+++ b/test/EventListener/RequestListenerTest.php
@@ -8,6 +8,7 @@ use Sentry\Event;
 use Sentry\Options;
 use Sentry\SentryBundle\EventListener\RequestListener;
 use Sentry\SentryBundle\Test\BaseTestCase;
+use Sentry\SentrySdk;
 use Sentry\State\HubInterface;
 use Sentry\State\Scope;
 use Symfony\Component\HttpFoundation\Request;
@@ -48,7 +49,7 @@ class RequestListenerTest extends BaseTestCase
                 $callable($scope);
             });
 
-        $this->setCurrentHub($this->currentHub->reveal());
+        SentrySdk::setCurrentHub($this->currentHub->reveal());
     }
 
     /**

--- a/test/EventListener/SubRequestListenerTest.php
+++ b/test/EventListener/SubRequestListenerTest.php
@@ -4,6 +4,7 @@ namespace Sentry\SentryBundle\Test\EventListener;
 
 use Sentry\SentryBundle\EventListener\SubRequestListener;
 use Sentry\SentryBundle\Test\BaseTestCase;
+use Sentry\SentrySdk;
 use Sentry\State\HubInterface;
 use Sentry\State\Scope;
 use Symfony\Component\HttpFoundation\Request;
@@ -18,7 +19,7 @@ class SubRequestListenerTest extends BaseTestCase
     {
         $this->currentHub = $this->prophesize(HubInterface::class);
 
-        $this->setCurrentHub($this->currentHub->reveal());
+        SentrySdk::setCurrentHub($this->currentHub->reveal());
     }
 
     public function testOnKernelRequestWithMasterRequest(): void

--- a/test/SentryBundleTest.php
+++ b/test/SentryBundleTest.php
@@ -13,7 +13,7 @@ use Sentry\SentryBundle\EventListener\ConsoleListener;
 use Sentry\SentryBundle\EventListener\ErrorListener;
 use Sentry\SentryBundle\EventListener\RequestListener;
 use Sentry\SentryBundle\EventListener\SubRequestListener;
-use Sentry\SentryBundle\SentryBundle;
+use Sentry\SentrySdk;
 use Sentry\State\Hub;
 use Sentry\State\HubInterface;
 use Symfony\Component\Console\ConsoleEvents;
@@ -151,7 +151,7 @@ class SentryBundleTest extends TestCase
         $extension = new SentryExtension();
         $extension->load(['sentry' => $configuration], $containerBuilder);
 
-        SentryBundle::setCurrentHub(new Hub());
+        SentrySdk::setCurrentHub(new Hub());
 
         return $containerBuilder;
     }

--- a/test/SentryBundleTest.php
+++ b/test/SentryBundleTest.php
@@ -97,7 +97,7 @@ class SentryBundleTest extends TestCase
 
         $consoleListener = $container->getDefinition(ErrorListener::class);
 
-        $method = class_exists(ExceptionEvent::class)
+        $method = class_exists(ExceptionEvent::class) && method_exists(ExceptionEvent::class, 'getThrowable')
             ? 'onException'
             : 'onKernelException';
         $expectedTag = [


### PR DESCRIPTION
This PR fixes the build and supports the 2.3 client correctly, avoiding all deprecations.