### PR TITLE
Fix exception listener with Symfony 4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ jobs:
       - SYMFONY_VERSION: 3.4.*
       - SYMFONY_DEPRECATIONS_HELPER: disabled
     - php: 7.3
+      env: SYMFONY_VERSION=4.3.*
+    - php: 7.3
       env: SYMFONY_VERSION=4.4.*
     - php: 7.4
       env: SYMFONY_VERSION=5.0.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
  - ...
 
-## 3.3.1 (2020-01-14)
+## 3.3.1 (2020-01-16)
+- Fix issue with exception listener under Symfony 4.3 (#301)
 
+## 3.3.1 (2020-01-14)
 - Fixed Release
 
 ## 3.3.0 (2020-01-14)
@@ -22,7 +24,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Fixed undefined variable in `RequestListener` (#263)
 
 ## 3.2.0 (2019-10-04)
-
  - Add forward compatibility with Symfony 5 (#235, thanks to @garak)
  - Fix Hub initialization for `ErrorListener` (#243, thanks to @teohhanhui)
  - Fix compatibility with sentry/sentry 2.2+ (#244)
@@ -32,20 +33,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Add options to register the Monolog Handler (#247, thanks to @HypeMC)
 
 ## 3.1.0 (2019-07-02)
-
  - Add support for Symfony 2.8 (#233, thanks to @nocive)
  - Fix handling of ESI requests (#213, thanks to @franmomu)
 
 ## 3.0.0 (2019-05-10)
-
  - Add the `sentry:test` command, to test if the Sentry SDK is functioning properly.
 
 ## 3.0.0-beta2 (2019-03-22)
-
  - Disable Sentry's ErrorHandler, and report all errors using Symfony's events (#204)
 
 ## 3.0.0-beta1 (2019-03-06)
-
 The 3.0 major release has multiple breaking changes. The most notable one is the upgrade to the 2.0 base SDK client.
 Refer to the [UPGRADE-3.0.md](https://github.com/getsentry/sentry-symfony/blob/master/UPGRADE-3.0.md) document for a
 detailed explanation.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,7 @@ parameters:
         - test/
     ignoreErrors:
          - "/Call to function method_exists.. with 'Symfony.+' and 'getRootNode' will always evaluate to false./"
+         - "/Call to function method_exists.. with 'Symfony.+' and 'getThrowable' will always evaluate to false./"
          - "/Call to function method_exists.. with 'Sentry..Options' and 'getClassSerializers' will always evaluate to false./"
          - "/Call to function method_exists.. with 'Sentry..Options' and 'getMaxRequestBodySi...' will always evaluate to false./"
          - '/Class PHPUnit_Framework_TestCase not found/'

--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -150,7 +150,7 @@ class SentryExtension extends Extension
     private function tagExceptionListener(ContainerBuilder $container): void
     {
         $listener = $container->getDefinition(ErrorListener::class);
-        $method = class_exists(ExceptionEvent::class)
+        $method = class_exists(ExceptionEvent::class) && method_exists(ExceptionEvent::class, 'getThrowable')
             ? 'onException'
             : 'onKernelException';
 


### PR DESCRIPTION
This should fix #300, and should be released as a 3.3.x patch.