### PR TITLE
Avoid class alias as a BC mechanism

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,6 +17,12 @@ parameters:
          -
              message: '/Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent.$/'
              path: src/EventListener/ErrorListener.php
+         -
+             message: '/(GetResponseEvent|FilterControllerEvent)/'
+             path: src/EventListener/RequestListener.php
+         -
+             message: '/GetResponseEvent/'
+             path: src/EventListener/SubRequestListener.php
 
 includes:
 	- vendor/jangregor/phpstan-prophecy/src/extension.neon

--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -19,6 +19,7 @@ use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -181,12 +182,18 @@ class SentryExtension extends Extension
         ]);
 
         $requestListener = $container->getDefinition(RequestListener::class);
-        $method = class_exists(RequestEvent::class)
-            ? 'onRequest'
-            : 'onKernelRequest';
         $requestListener->addTag(self::KERNEL_EVENT_LISTENER, [
             'event' => KernelEvents::REQUEST,
-            'method' => $method,
+            'method' => class_exists(RequestEvent::class)
+                ? 'onRequest'
+                : 'onKernelRequest',
+            'priority' => '%sentry.listener_priorities.request%',
+        ]);
+        $requestListener->addTag(self::KERNEL_EVENT_LISTENER, [
+            'event' => KernelEvents::CONTROLLER,
+            'method' => class_exists(ControllerEvent::class)
+                ? 'onController'
+                : 'onKernelController',
             'priority' => '%sentry.listener_priorities.request%',
         ]);
 

--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -200,7 +200,9 @@ class SentryExtension extends Extension
         $subrequestListener = $container->getDefinition(SubRequestListener::class);
         $subrequestListener->addTag(self::KERNEL_EVENT_LISTENER, [
             'event' => KernelEvents::REQUEST,
-            'method' => $method,
+            'method' => class_exists(RequestEvent::class)
+                ? 'onRequest'
+                : 'onKernelRequest',
             'priority' => '%sentry.listener_priorities.sub_request%',
         ]);
     }

--- a/src/EventListener/SubRequestListener.php
+++ b/src/EventListener/SubRequestListener.php
@@ -7,10 +7,6 @@ use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 
-if (! class_exists(RequestEvent::class)) {
-    class_alias(GetResponseEvent::class, RequestEvent::class);
-}
-
 final class SubRequestListener
 {
     /**
@@ -18,7 +14,19 @@ final class SubRequestListener
      *
      * @param RequestEvent $event
      */
-    public function onKernelRequest(RequestEvent $event): void
+    public function onRequest(RequestEvent $event): void
+    {
+        if ($event->isMasterRequest()) {
+            return;
+        }
+
+        SentrySdk::getCurrentHub()->pushScope();
+    }
+
+    /**
+     * BC layer for SF < 4.3
+     */
+    public function onKernelRequest(GetResponseEvent $event): void
     {
         if ($event->isMasterRequest()) {
             return;
@@ -32,7 +40,7 @@ final class SubRequestListener
      *
      * @param FinishRequestEvent $event
      */
-    public function onKernelFinishRequest(FinishRequestEvent $event): void
+    public function onFinishRequest(FinishRequestEvent $event): void
     {
         if ($event->isMasterRequest()) {
             return;

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -41,13 +41,15 @@
             <argument type="service" id="Sentry\State\HubInterface" />
             <argument type="service" id="security.token_storage" on-invalid="ignore" />
 
-            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="%sentry.listener_priorities.request%" />
-            <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController" priority="%sentry.listener_priorities.request%" />
+            <!-- The following tags are done manually in PHP for BC with Symfony < 4.3,  -->
+<!--            <tag name="kernel.event_listener" event="kernel.request" method="onRequest" priority="%sentry.listener_priorities.request%" />-->
+<!--            <tag name="kernel.event_listener" event="kernel.controller" method="onController" priority="%sentry.listener_priorities.request%" />-->
         </service>
 
         <service id="Sentry\SentryBundle\EventListener\SubRequestListener" class="Sentry\SentryBundle\EventListener\SubRequestListener" public="false">
-            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="%sentry.listener_priorities.sub_request%" />
-            <tag name="kernel.event_listener" event="kernel.finish_request" method="onKernelFinishRequest" priority="%sentry.listener_priorities.sub_request%" />
+            <!-- The following tag is done manually in PHP for BC with Symfony < 4.3,  -->
+<!--            <tag name="kernel.event_listener" event="kernel.request" method="onRequest" priority="%sentry.listener_priorities.sub_request%" />-->
+            <tag name="kernel.event_listener" event="kernel.finish_request" method="onFinishRequest" priority="%sentry.listener_priorities.sub_request%" />
         </service>
 
         <service id="Sentry\SentryBundle\Command\SentryTestCommand" class="Sentry\SentryBundle\Command\SentryTestCommand" public="false">

--- a/test/EventListener/RequestListenerTest.php
+++ b/test/EventListener/RequestListenerTest.php
@@ -14,7 +14,6 @@ use Sentry\State\Scope;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
-use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -330,10 +329,6 @@ class RequestListenerTest extends BaseTestCase
         return $event;
     }
 
-    /**
-     * @param RequestListener $listener
-     * @param KernelEvent $event
-     */
     private function callOnRequest(RequestListener $listener, $event): void
     {
         if (class_exists(RequestEvent::class)) {
@@ -343,10 +338,6 @@ class RequestListenerTest extends BaseTestCase
         }
     }
 
-    /**
-     * @param RequestListener $listener
-     * @param $event
-     */
     private function callOnKernel(RequestListener $listener, $event): void
     {
         if (class_exists(ControllerEvent::class)) {

--- a/test/EventListener/RequestListenerTest.php
+++ b/test/EventListener/RequestListenerTest.php
@@ -14,6 +14,8 @@ use Sentry\State\Scope;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -79,7 +81,7 @@ class RequestListenerTest extends BaseTestCase
             $tokenStorage->reveal()
         );
 
-        $listener->onKernelRequest($event);
+        $this->callOnRequest($listener, $event);
 
         $expectedUserData = [
             'ip_address' => '1.2.3.4',
@@ -110,7 +112,7 @@ class RequestListenerTest extends BaseTestCase
             $tokenStorage->reveal()
         );
 
-        $listener->onKernelRequest($event);
+        $this->callOnRequest($listener, $event);
 
         $this->assertEquals([], $this->getUserContext($this->currentScope));
     }
@@ -130,7 +132,7 @@ class RequestListenerTest extends BaseTestCase
             $tokenStorage->reveal()
         );
 
-        $listener->onKernelRequest($event);
+        $this->callOnRequest($listener, $event);
 
         $this->assertEquals([], $this->getUserContext($this->currentScope));
     }
@@ -148,7 +150,7 @@ class RequestListenerTest extends BaseTestCase
             null
         );
 
-        $listener->onKernelRequest($event);
+        $this->callOnRequest($listener, $event);
 
         $expectedUserData = [
             'ip_address' => '1.2.3.4',
@@ -173,7 +175,7 @@ class RequestListenerTest extends BaseTestCase
             $tokenStorage->reveal()
         );
 
-        $listener->onKernelRequest($event);
+        $this->callOnRequest($listener, $event);
 
         $expectedUserData = [
             'ip_address' => '1.2.3.4',
@@ -205,7 +207,7 @@ class RequestListenerTest extends BaseTestCase
             $tokenStorage->reveal()
         );
 
-        $listener->onKernelRequest($event);
+        $this->callOnRequest($listener, $event);
 
         $expectedUserData = [
             'ip_address' => '1.2.3.4',
@@ -230,7 +232,7 @@ class RequestListenerTest extends BaseTestCase
             $tokenStorage->reveal()
         );
 
-        $listener->onKernelRequest($event);
+        $this->callOnRequest($listener, $event);
 
         $expectedUserData = [
             'ip_address' => '1.2.3.4',
@@ -285,7 +287,7 @@ class RequestListenerTest extends BaseTestCase
             $tokenStorage->reveal()
         );
 
-        $listener->onKernelRequest($event);
+        $this->callOnRequest($listener, $event);
 
         $this->assertEmpty($this->getUserContext($this->currentScope));
         $this->assertEmpty($this->getTagsContext($this->currentScope));
@@ -326,6 +328,19 @@ class RequestListenerTest extends BaseTestCase
         }
 
         return $event;
+    }
+
+    /**
+     * @param RequestListener $listener
+     * @param KernelEvent $event
+     */
+    private function callOnRequest(RequestListener $listener, $event): void
+    {
+        if (class_exists(RequestEvent::class)) {
+            $listener->onRequest($event);
+        } else {
+            $listener->onKernelRequest($event);
+        }
     }
 }
 

--- a/test/EventListener/RequestListenerTest.php
+++ b/test/EventListener/RequestListenerTest.php
@@ -251,7 +251,7 @@ class RequestListenerTest extends BaseTestCase
             $this->prophesize(TokenStorageInterface::class)->reveal()
         );
 
-        $listener->onKernelController($event);
+        $this->callOnKernel($listener, $event);
 
         $this->assertSame(['route' => 'sf-route'], $this->getTagsContext($this->currentScope));
     }
@@ -268,7 +268,7 @@ class RequestListenerTest extends BaseTestCase
             $this->prophesize(TokenStorageInterface::class)->reveal()
         );
 
-        $listener->onKernelController($event);
+        $this->callOnKernel($listener, $event);
     }
 
     public function testOnKernelRequestUserDataAndTagsAreNotSetInSubRequest(): void
@@ -340,6 +340,19 @@ class RequestListenerTest extends BaseTestCase
             $listener->onRequest($event);
         } else {
             $listener->onKernelRequest($event);
+        }
+    }
+
+    /**
+     * @param RequestListener $listener
+     * @param $event
+     */
+    private function callOnKernel(RequestListener $listener, $event): void
+    {
+        if (class_exists(ControllerEvent::class)) {
+            $listener->onController($event);
+        } else {
+            $listener->onKernelController($event);
         }
     }
 }

--- a/test/EventListener/SubRequestListenerTest.php
+++ b/test/EventListener/SubRequestListenerTest.php
@@ -9,6 +9,7 @@ use Sentry\State\HubInterface;
 use Sentry\State\Scope;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 class SubRequestListenerTest extends BaseTestCase
@@ -31,7 +32,7 @@ class SubRequestListenerTest extends BaseTestCase
         $this->currentHub->pushScope()
             ->shouldNotBeCalled();
 
-        $listener->onKernelRequest($masterRequestEvent);
+        $this->callOnRequest($listener, $masterRequestEvent);
     }
 
     public function testOnKernelRequestWithSubRequest(): void
@@ -79,5 +80,18 @@ class SubRequestListenerTest extends BaseTestCase
             $this->prophesize(Request::class)->reveal(),
             $type
         );
+    }
+
+    /**
+     * @param SubRequestListener $listener
+     * @param $event
+     */
+    private function callOnRequest(SubRequestListener $listener, $event): void
+    {
+        if (class_exists(RequestEvent::class)) {
+            $listener->onRequest($event);
+        } else {
+            $listener->onKernelRequest($event);
+        }
     }
 }

--- a/test/EventListener/SubRequestListenerTest.php
+++ b/test/EventListener/SubRequestListenerTest.php
@@ -45,7 +45,7 @@ class SubRequestListenerTest extends BaseTestCase
             ->shouldBeCalledTimes(1)
             ->willReturn(new Scope());
 
-        $listener->onKernelRequest($subRequestEvent);
+        $this->callOnRequest($listener, $subRequestEvent);
     }
 
     public function testonFinishRequestWithMasterRequest(): void

--- a/test/EventListener/SubRequestListenerTest.php
+++ b/test/EventListener/SubRequestListenerTest.php
@@ -82,10 +82,6 @@ class SubRequestListenerTest extends BaseTestCase
         );
     }
 
-    /**
-     * @param SubRequestListener $listener
-     * @param $event
-     */
     private function callOnRequest(SubRequestListener $listener, $event): void
     {
         if (class_exists(RequestEvent::class)) {

--- a/test/EventListener/SubRequestListenerTest.php
+++ b/test/EventListener/SubRequestListenerTest.php
@@ -48,7 +48,7 @@ class SubRequestListenerTest extends BaseTestCase
         $listener->onKernelRequest($subRequestEvent);
     }
 
-    public function testOnKernelFinishRequestWithMasterRequest(): void
+    public function testonFinishRequestWithMasterRequest(): void
     {
         $listener = new SubRequestListener();
 
@@ -57,10 +57,10 @@ class SubRequestListenerTest extends BaseTestCase
         $this->currentHub->popScope()
             ->shouldNotBeCalled();
 
-        $listener->onKernelFinishRequest($masterRequestEvent);
+        $listener->onFinishRequest($masterRequestEvent);
     }
 
-    public function testOnKernelFinishRequestWithSubRequest(): void
+    public function testonFinishRequestWithSubRequest(): void
     {
         $listener = new SubRequestListener();
 
@@ -70,7 +70,7 @@ class SubRequestListenerTest extends BaseTestCase
             ->shouldBeCalledTimes(1)
             ->willReturn(true);
 
-        $listener->onKernelFinishRequest($subRequestEvent);
+        $listener->onFinishRequest($subRequestEvent);
     }
 
     private function createFinishRequestEvent(int $type): FinishRequestEvent


### PR DESCRIPTION
This fixes #307. Using `class_alias` as a BC detection mechanism may break BC for third party packages.