### PR TITLE
Change include defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
- 
+ - Change default of `in_app_include` to empty, due to getsentry/sentry-php#958 (#311)
 
 ## 3.4.1 (2020-01-24)
  - Fix issue due to usage of `class_alias` to fix deprecations, which could break BC layers of third party packages (#309, thanks to @scheb)

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -71,9 +71,7 @@ class Configuration implements ConfigurationInterface
             ->cannotBeEmpty();
         $optionsChildNodes->scalarNode('error_types');
         $optionsChildNodes->arrayNode('in_app_include')
-            ->defaultValue([
-                '%kernel.project_dir%/src',
-            ])
+            ->defaultValue([])
             ->prototype('scalar');
         $optionsChildNodes->arrayNode('in_app_exclude')
             ->defaultValue([

--- a/test/DependencyInjection/ConfigurationTest.php
+++ b/test/DependencyInjection/ConfigurationTest.php
@@ -54,9 +54,7 @@ class ConfigurationTest extends BaseTestCase
             'options' => [
                 'class_serializers' => [],
                 'environment' => '%kernel.environment%',
-                'in_app_include' => [
-                    '%kernel.project_dir%/src',
-                ],
+                'in_app_include' => [],
                 'in_app_exclude' => [
                     '%kernel.cache_dir%',
                     '%kernel.project_dir%/vendor',

--- a/test/DependencyInjection/SentryExtensionTest.php
+++ b/test/DependencyInjection/SentryExtensionTest.php
@@ -59,12 +59,11 @@ class SentryExtensionTest extends BaseTestCase
         $container = $this->getContainer();
         $options = $this->getOptionsFrom($container);
 
-        $vendorDir = '/dir/project/root/vendor';
-        $this->assertContains('/dir/project/root/src', $options->getInAppIncludedPaths());
+        $this->assertEmpty($options->getInAppIncludedPaths());
 
         $this->assertNull($options->getDsn());
         $this->assertSame('test', $options->getEnvironment());
-        $this->assertSame([realpath('./var/cache'), $vendorDir], $options->getInAppExcludedPaths());
+        $this->assertSame([realpath('./var/cache'), '/dir/project/root/vendor'], $options->getInAppExcludedPaths());
 
         $this->assertSame(1, $container->getParameter('sentry.listener_priorities.request'));
         $this->assertSame(1, $container->getParameter('sentry.listener_priorities.sub_request'));


### PR DESCRIPTION
As noticed in https://github.com/getsentry/sentry-symfony/pull/298#discussion_r370930322, due to https://github.com/getsentry/sentry-php/pull/958 (which was released in `sentry/sentry` [2.3.1](https://github.com/getsentry/sentry-php/releases/tag/2.3.1)), it's sensible to use an empty default for `in_app_include`.

Thanks @micheh for noticing it.