### PR TITLE
Fix OutOfBoundsException on getting default version

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -45,6 +45,12 @@ class Configuration implements ConfigurationInterface
             ->arrayNode('options')
             ->addDefaultsIfNotSet();
 
+        try {
+            $defaultReleaseVersion = Versions::getVersion(Versions::ROOT_PACKAGE_NAME);
+        } catch (\OutOfBoundsException $exception) {
+            $defaultReleaseVersion = 'unknown';
+        }
+
         $defaultValues = new Options();
         $optionsChildNodes = $optionsNode->children();
 
@@ -113,7 +119,7 @@ class Configuration implements ConfigurationInterface
             ->prototype('scalar');
         $optionsChildNodes->scalarNode('project_root');
         $optionsChildNodes->scalarNode('release')
-            ->defaultValue(Versions::getVersion(Versions::ROOT_PACKAGE_NAME))
+            ->defaultValue($defaultReleaseVersion)
             ->info('Release version to be reported to sentry, see https://docs.sentry.io/workflow/releases/?platform=php')
             ->example('my/application@ff11bb');
         $optionsChildNodes->floatNode('sample_rate')


### PR DESCRIPTION
it happens in the package that use "sentry-symfony".
When i run
```php
composer install --no-scripts
```

and then try to use any application command, exception occurs:
```
In FallbackVersions.php line 34:
                                                                                               
  [OutOfBoundsException]                                                                       
  Required package "unknown/root-package@UNKNOWN" is not installed: cannot detect its version  
                                                                                               

Exception trace:
 () at /srv/api/vendor/ocramius/package-versions/src/PackageVersions/FallbackVersions.php:34
 PackageVersions\FallbackVersions::getVersion() at /srv/api/vendor/ocramius/package-versions/src/PackageVersions/Versions.php:28
 PackageVersions\Versions::getVersion() at /srv/api/vendor/sentry/sentry-symfony/src/DependencyInjection/Configuration.php:116
 Sentry\SentryBundle\DependencyInjection\Configuration->getConfigTreeBuilder() at /srv/api/vendor/symfony/config/Definition/Processor.php:52
 Symfony\Component\Config\Definition\Processor->processConfiguration() at /srv/api/vendor/symfony/dependency-injection/Extension/Extension.php:108
 Symfony\Component\DependencyInjection\Extension\Extension->processConfiguration() at /srv/api/vendor/sentry/sentry-symfony/src/DependencyInjection/SentryExtension.php:38
 Sentry\SentryBundle\DependencyInjection\SentryExtension->load() at /srv/api/vendor/symfony/dependency-injection/Compiler/MergeExtensionConfigurationPass.php:76
 Symfony\Component\DependencyInjection\Compiler\MergeExtensionConfigurationPass->process() at /srv/api/vendor/symfony/http-kernel/DependencyInjection/MergeExtensionConfigurationPass.php:39
 Symfony\Component\HttpKernel\DependencyInjection\MergeExtensionConfigurationPass->process() at /srv/api/vendor/symfony/dependency-injection/Compiler/Compiler.php:95
 Symfony\Component\DependencyInjection\Compiler\Compiler->compile() at /srv/api/vendor/symfony/dependency-injection/ContainerBuilder.php:750
 Symfony\Component\DependencyInjection\ContainerBuilder->compile() at /srv/api/vendor/symfony/http-kernel/Kernel.php:544
 Symfony\Component\HttpKernel\Kernel->initializeContainer() at /srv/api/vendor/symfony/http-kernel/Kernel.php:133
 Symfony\Component\HttpKernel\Kernel->boot() at /srv/api/vendor/symfony/http-kernel/Kernel.php:150
 Symfony\Component\HttpKernel\Kernel->reboot() at /srv/api/vendor/symfony/framework-bundle/Command/CacheClearCommand.php:187
 Symfony\Bundle\FrameworkBundle\Command\CacheClearCommand->warmup() at /srv/api/vendor/symfony/framework-bundle/Command/CacheClearCommand.php:129
 Symfony\Bundle\FrameworkBundle\Command\CacheClearCommand->execute() at /srv/api/vendor/symfony/console/Command/Command.php:255
 Symfony\Component\Console\Command\Command->run() at /srv/api/vendor/symfony/console/Application.php:919
 Symfony\Component\Console\Application->doRunCommand() at /srv/api/vendor/symfony/framework-bundle/Console/Application.php:89
 Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand() at /srv/api/vendor/symfony/console/Application.php:262
 Symfony\Component\Console\Application->doRun() at /srv/api/vendor/symfony/framework-bundle/Console/Application.php:75
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /srv/api/vendor/symfony/console/Application.php:145
 Symfony\Component\Console\Application->run() at /srv/api/bin/console:38

```

