### PR TITLE
Use injected Hub instead of SentrySdk::getCurrentHub

### DIFF
--- a/src/EventListener/RequestListener.php
+++ b/src/EventListener/RequestListener.php
@@ -2,7 +2,6 @@
 
 namespace Sentry\SentryBundle\EventListener;
 
-use Sentry\SentrySdk;
 use Sentry\State\HubInterface;
 use Sentry\State\Scope;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
@@ -65,7 +64,7 @@ final class RequestListener
             return;
         }
 
-        $currentClient = SentrySdk::getCurrentHub()->getClient();
+        $currentClient = $this->hub->getClient();
         if (null === $currentClient || ! $currentClient->getOptions()->shouldSendDefaultPii()) {
             return;
         }
@@ -88,7 +87,7 @@ final class RequestListener
 
         $userData['ip_address'] = $event->getRequest()->getClientIp();
 
-        SentrySdk::getCurrentHub()
+        $this->hub
             ->configureScope(function (Scope $scope) use ($userData): void {
                 $scope->setUser($userData, true);
             });
@@ -106,7 +105,7 @@ final class RequestListener
 
         $matchedRoute = (string) $event->getRequest()->attributes->get('_route');
 
-        SentrySdk::getCurrentHub()
+        $this->hub
             ->configureScope(function (Scope $scope) use ($matchedRoute): void {
                 $scope->setTag('route', $matchedRoute);
             });

--- a/src/EventListener/RequestListener.php
+++ b/src/EventListener/RequestListener.php
@@ -49,7 +49,7 @@ final class RequestListener
         HubInterface $hub,
         ?TokenStorageInterface $tokenStorage
     ) {
-        $this->hub = $hub; // not used, needed to trigger instantiation
+        $this->hub = $hub;
         $this->tokenStorage = $tokenStorage;
     }
 


### PR DESCRIPTION
Fixes #275.

Considering that `HubInterface` is injected anyway, it should be used instead of the global singleton.