### PR TITLE
Improve class_alias robustness

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,6 +17,12 @@ parameters:
          -
              message: '/Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent.$/'
              path: src/EventListener/ErrorListener.php
+         -
+             message: '/Sentry\\SentryBundle\\EventListener\\RequestListener(Request|Controller)Event( not found)?.$/'
+             path: src/EventListener/RequestListener.php
+         -
+             message: '/Sentry\\SentryBundle\\EventListener\\SubRequestListenerRequestEvent( not found)?.$/'
+             path: src/EventListener/SubRequestListener.php
 
 includes:
 	- vendor/jangregor/phpstan-prophecy/src/extension.neon

--- a/src/EventListener/RequestListener.php
+++ b/src/EventListener/RequestListener.php
@@ -14,19 +14,11 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 use Symfony\Component\Security\Core\User\UserInterface;
 
 if (Kernel::MAJOR_VERSION >= 5) {
-    if (! class_exists('Sentry\SentryBundle\EventListener\UserContextRequestEvent')) {
-        class_alias(RequestEvent::class, 'Sentry\SentryBundle\EventListener\UserContextRequestEvent');
-    }
-    if (! class_exists('Sentry\SentryBundle\EventListener\UserContextControllerEvent')) {
-        class_alias(ControllerEvent::class, 'Sentry\SentryBundle\EventListener\UserContextControllerEvent');
-    }
+    class_alias(RequestEvent::class, RequestListenerRequestEvent::class);
+    class_alias(ControllerEvent::class, RequestListenerControllerEvent::class);
 } else {
-    if (! class_exists('Sentry\SentryBundle\EventListener\UserContextRequestEvent')) {
-        class_alias(GetResponseEvent::class, 'Sentry\SentryBundle\EventListener\UserContextRequestEvent');
-    }
-    if (! class_exists('Sentry\SentryBundle\EventListener\UserContextControllerEvent')) {
-        class_alias(FilterControllerEvent::class, 'Sentry\SentryBundle\EventListener\UserContextControllerEvent');
-    }
+    class_alias(GetResponseEvent::class, RequestListenerRequestEvent::class);
+    class_alias(FilterControllerEvent::class, RequestListenerControllerEvent::class);
 }
 
 /**
@@ -57,9 +49,9 @@ final class RequestListener
     /**
      * Set the username from the security context by listening on core.request
      *
-     * @param UserContextRequestEvent $event
+     * @param RequestListenerRequestEvent $event
      */
-    public function onKernelRequest(UserContextRequestEvent $event): void
+    public function onKernelRequest(RequestListenerRequestEvent $event): void
     {
         if (! $event->isMasterRequest()) {
             return;
@@ -94,7 +86,7 @@ final class RequestListener
             });
     }
 
-    public function onKernelController(UserContextControllerEvent $event): void
+    public function onKernelController(RequestListenerControllerEvent $event): void
     {
         if (! $event->isMasterRequest()) {
             return;

--- a/src/EventListener/SubRequestListener.php
+++ b/src/EventListener/SubRequestListener.php
@@ -9,13 +9,9 @@ use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Kernel;
 
 if (Kernel::MAJOR_VERSION >= 5) {
-    if (! class_exists('Sentry\SentryBundle\EventListener\UserContextRequestEvent')) {
-        class_alias(RequestEvent::class, 'Sentry\SentryBundle\EventListener\UserContextRequestEvent');
-    }
+    class_alias(RequestEvent::class, SubRequestListenerRequestEvent::class);
 } else {
-    if (! class_exists('Sentry\SentryBundle\EventListener\UserContextRequestEvent')) {
-        class_alias(GetResponseEvent::class, 'Sentry\SentryBundle\EventListener\UserContextRequestEvent');
-    }
+    class_alias(GetResponseEvent::class, SubRequestListenerRequestEvent::class);
 }
 
 final class SubRequestListener
@@ -23,9 +19,9 @@ final class SubRequestListener
     /**
      * Pushes a new {@see Scope} for each SubRequest
      *
-     * @param UserContextRequestEvent $event
+     * @param SubRequestListenerRequestEvent $event
      */
-    public function onKernelRequest(UserContextRequestEvent $event): void
+    public function onKernelRequest(SubRequestListenerRequestEvent $event): void
     {
         if ($event->isMasterRequest()) {
             return;


### PR DESCRIPTION
- Use `::class` rather than string literal, to avoid problems like #313
- Use distinct alias names (concatenate current file class + external class) rather than `class_exists`, to avoid conflicts without triggering autoload looking for nonexistent files like "src/EventListener/UserContextRequestEvent.php"