### PR TITLE
Add Symfony Flex recipe to Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,23 @@ Use sentry-symfony for:
    - app path
    - excluded paths (cache and vendor)
 
-## Installation
+## Installation for Symfony 4 or newest:
+### Step 1: Install the sentry-symfony flex recipe:
+You can install this recipe using Composer: 
 
+```bash
+composer require sentry/sentry-symfony
+```
+This could show a message similar to this:
+```
+   The recipe for this package comes from the "contrib" repository, which is open to community contributions.
+    Review the recipe at https://github.com/symfony/recipes-contrib/tree/master/sentry/sentry-symfony/3.0
+
+    Do you want to execute this recipe?
+```
+Press `y` and return to allow the installation.
+
+## Installation for Symfony 3.4:
 ### Step 1: Download the Bundle
 You can install this bundle using Composer: 
 
@@ -49,8 +64,6 @@ composer require sentry/sentry-symfony:^3.0 sentry/sentry:^2.0 php-http/guzzle6-
 
 The `sentry/sentry` package is required directly to override `sentry/sdk`, and the other two packages are up to your choice;
 in the current example, we're using both Guzzle's components (client and message factory).
-
-> TODO: Flex recipe
 
 ### Step 2: Enable the Bundle
 
@@ -80,10 +93,10 @@ class AppKernel extends Kernel
 Note that, unlike before in version 3, the bundle will be enabled in all environments; event reporting, instead, is enabled
 only when providing a DSN (see the next step).
 
-### Step 3: Configure the SDK
+### Configuration of the SDK
 
-Add your [Sentry DSN](https://docs.sentry.io/quickstart/#configure-the-dsn) value of your project to ``app/config/config_prod.yml``.
-Leaving this value empty (or undeclared) in other environments will effectively disable Sentry reporting.
+Add your [Sentry DSN](https://docs.sentry.io/quickstart/#configure-the-dsn) value of your project, if you have Symfony 3.4 add it to ``app/config/config_prod.yml`` for Symfony 4 or newest add the value to `config/packages/sentry.yaml`.
+Keep in mind that leaving the `dsn` value empty (or undeclared) in other environments will effectively disable Sentry reporting.
 
 ```yaml
 sentry:

--- a/README.md
+++ b/README.md
@@ -21,10 +21,8 @@ Use sentry-symfony for:
    - app path
    - excluded paths (cache and vendor)
 
-## Installation for Symfony 4 or newest:
-### Step 1: Install the sentry-symfony flex recipe:
-You can install this recipe using Composer: 
-
+## Installation with Symfony Flex (Symfony 4 or newer):
+If you're using the [Symfony Flex](https://symfony.com/doc/current/setup/flex.html) Composer plugin, you can install this bundle in a single, easy step: 
 ```bash
 composer require sentry/sentry-symfony
 ```
@@ -37,33 +35,13 @@ This could show a message similar to this:
 ```
 Press `y` and return to allow the installation.
 
-## Installation for Symfony 3.4:
+## Installation without Symfony Flex:
 ### Step 1: Download the Bundle
 You can install this bundle using Composer: 
 
 ```bash
 composer require sentry/sentry-symfony:^3.0
 ```
-
-#### Optional: use custom HTTP factory/transport
-*Note: this step is optional*
-
-Since SDK 2.0 uses HTTPlug to remain transport-agnostic, you need to have installed two packages that provides 
-[`php-http/async-client-implementation`](https://packagist.org/providers/php-http/async-client-implementation)
-and [`http-message-implementation`](https://packagist.org/providers/psr/http-message-implementation).
-
-This bundle depends on `sentry/sdk`, which is a metapackage that already solves this need, requiring our suggested HTTP
-packages: the Curl client and Guzzle's message factories.
-
-If instead you want to use a different HTTP client or message factory, you'll need to require manually those additional
-packages:
-
-```bash
-composer require sentry/sentry-symfony:^3.0 sentry/sentry:^2.0 php-http/guzzle6-adapter guzzlehttp/psr7
-```
-
-The `sentry/sentry` package is required directly to override `sentry/sdk`, and the other two packages are up to your choice;
-in the current example, we're using both Guzzle's components (client and message factory).
 
 ### Step 2: Enable the Bundle
 
@@ -93,9 +71,9 @@ class AppKernel extends Kernel
 Note that, unlike before in version 3, the bundle will be enabled in all environments; event reporting, instead, is enabled
 only when providing a DSN (see the next step).
 
-### Configuration of the SDK
+## Configuration of the SDK
 
-Add your [Sentry DSN](https://docs.sentry.io/quickstart/#configure-the-dsn) value of your project, if you have Symfony 3.4 add it to ``app/config/config_prod.yml`` for Symfony 4 or newest add the value to `config/packages/sentry.yaml`.
+Add your [Sentry DSN](https://docs.sentry.io/quickstart/#configure-the-dsn) value of your project, if you have Symfony 3.4 add it to ``app/config/config_prod.yml`` for Symfony 4 or newer add the value to `config/packages/sentry.yaml`.
 Keep in mind that leaving the `dsn` value empty (or undeclared) in other environments will effectively disable Sentry reporting.
 
 ```yaml
@@ -148,6 +126,29 @@ Additionally, you can register the `PsrLogMessageProcessor` to resolve PSR-3 pla
 services:
     Monolog\Processor\PsrLogMessageProcessor:
         tags: { name: monolog.processor, handler: sentry }
+```
+
+#### Optional: use custom HTTP factory/transport
+
+Since SDK 2.0 uses HTTPlug to remain transport-agnostic, you need to have installed two packages that provides 
+[`php-http/async-client-implementation`](https://packagist.org/providers/php-http/async-client-implementation)
+and [`http-message-implementation`](https://packagist.org/providers/psr/http-message-implementation).
+
+This bundle depends on `sentry/sdk`, which is a metapackage that already solves this need, requiring our suggested HTTP
+packages: the Curl client and Guzzle's message factories.
+
+If instead you want to use a different HTTP client or message factory, you can override the ``sentry/sdk`` package adding the following to your ``composer.json`` after the ``require`` section:
+```yaml
+    "replace": {
+        "sentry/sdk": "*"
+    }
+```
+This will prevent the installation of ``sentry/sdk`` package and will allow you to install through Composer the HTTP client or message factory of your choice.
+
+For example for using Guzzle's components: 
+
+```bash
+composer require php-http/guzzle6-adapter guzzlehttp/psr7
 ```
 
 ## Maintained versions


### PR DESCRIPTION
Attempt to fix the README documentation about the Installation in Symfony 4 or 5 reported in this issue: https://github.com/getsentry/sentry-symfony/issues/319