### PR TITLE
Capture all messenger exceptions

### DIFF
--- a/src/EventListener/MessengerListener.php
+++ b/src/EventListener/MessengerListener.php
@@ -41,14 +41,12 @@ final class MessengerListener
 
         $error = $event->getThrowable();
 
-        if (! $error instanceof HandlerFailedException) {
-            // All errors thrown during handling a command are captured by the HandleMessageMiddleware,
-            // and are raised inside a HandlerFailedException. Type check for safety.
-            return;
-        }
-
-        foreach ($error->getNestedExceptions() as $nestedException) {
-            $this->client->captureException($nestedException);
+        if ($error instanceof HandlerFailedException) {
+            foreach ($error->getNestedExceptions() as $nestedException) {
+                $this->client->captureException($nestedException);
+            }
+        } else {
+            $this->client->captureException($error);
         }
 
         $this->flush();

--- a/src/EventListener/MessengerListener.php
+++ b/src/EventListener/MessengerListener.php
@@ -51,7 +51,7 @@ final class MessengerListener
             $this->client->captureException($nestedException);
         }
 
-        $this->client->flush();
+        $this->flush();
     }
 
     /**
@@ -61,6 +61,11 @@ final class MessengerListener
     {
         // Flush normally happens at shutdown... which only happens in the worker if it is run with a lifecycle limit
         // such as --time=X or --limit=Y. Flush immediately in a background worker.
+        $this->flush();
+    }
+
+    private function flush(): void
+    {
         $this->client->flush();
     }
 }

--- a/src/EventListener/MessengerListener.php
+++ b/src/EventListener/MessengerListener.php
@@ -41,7 +41,7 @@ final class MessengerListener
 
         $error = $event->getThrowable();
 
-        if (!$error instanceof HandlerFailedException) {
+        if (! $error instanceof HandlerFailedException) {
             // All errors thrown during handling a command are captured by the HandleMessageMiddleware,
             // and are raised inside a HandlerFailedException. Type check for safety.
             return;

--- a/src/EventListener/MessengerListener.php
+++ b/src/EventListener/MessengerListener.php
@@ -41,12 +41,16 @@ final class MessengerListener
 
         $error = $event->getThrowable();
 
-        if ($error instanceof HandlerFailedException && null !== $error->getPrevious()) {
-            // Unwrap the messenger exception to get the original error
-            $error = $error->getPrevious();
+        if (!$error instanceof HandlerFailedException) {
+            // All errors thrown during handling a command are captured by the HandleMessageMiddleware,
+            // and are raised inside a HandlerFailedException. Type check for safety.
+            return;
         }
 
-        $this->client->captureException($error);
+        foreach ($error->getNestedExceptions() as $nestedException) {
+            $this->client->captureException($nestedException);
+        }
+
         $this->client->flush();
     }
 

--- a/test/EventListener/MessengerListenerTest.php
+++ b/test/EventListener/MessengerListenerTest.php
@@ -114,12 +114,14 @@ class MessengerListenerTest extends BaseTestCase
 
         $message = (object) ['foo' => 'bar'];
         $envelope = Envelope::wrap($message);
-        $error = new \RuntimeException();
-        $wrappedError = new HandlerFailedException($envelope, [$error]);
+        $error1 = new \RuntimeException();
+        $error2 = new \RuntimeException();
+        $wrappedError = new HandlerFailedException($envelope, [$error1, $error2]);
 
         $event = $this->getMessageFailedEvent($envelope, 'receiver', $wrappedError, false);
 
-        $this->client->captureException($error)->shouldBeCalled();
+        $this->client->captureException($error1)->shouldBeCalled();
+        $this->client->captureException($error2)->shouldBeCalled();
         $this->client->flush()->shouldBeCalled();
 
         $listener = new MessengerListener($this->client->reveal());

--- a/test/EventListener/MessengerListenerTest.php
+++ b/test/EventListener/MessengerListenerTest.php
@@ -28,15 +28,17 @@ class MessengerListenerTest extends BaseTestCase
             self::markTestSkipped('Messenger not supported in this environment.');
         }
 
+        $message = (object) ['foo' => 'bar'];
+        $envelope = Envelope::wrap($message);
+
         $error = new \RuntimeException();
+        $wrappedError = new HandlerFailedException($envelope, [$error]);
 
         $this->client->captureException($error)->shouldBeCalled();
         $this->client->flush()->shouldBeCalled();
 
         $listener = new MessengerListener($this->client->reveal(), true);
-        $message = (object) ['foo' => 'bar'];
-        $envelope = Envelope::wrap($message);
-        $event = $this->getMessageFailedEvent($envelope, 'receiver', $error, true);
+        $event = $this->getMessageFailedEvent($envelope, 'receiver', $wrappedError, true);
 
         $listener->onWorkerMessageFailed($event);
     }
@@ -47,15 +49,17 @@ class MessengerListenerTest extends BaseTestCase
             self::markTestSkipped('Messenger not supported in this environment.');
         }
 
+        $message = (object) ['foo' => 'bar'];
+        $envelope = Envelope::wrap($message);
+
         $error = new \RuntimeException();
+        $wrappedError = new HandlerFailedException($envelope, [$error]);
 
         $this->client->captureException($error)->shouldBeCalled();
         $this->client->flush()->shouldBeCalled();
 
         $listener = new MessengerListener($this->client->reveal(), true);
-        $message = (object) ['foo' => 'bar'];
-        $envelope = Envelope::wrap($message);
-        $event = $this->getMessageFailedEvent($envelope, 'receiver', $error, false);
+        $event = $this->getMessageFailedEvent($envelope, 'receiver', $wrappedError, false);
 
         $listener->onWorkerMessageFailed($event);
     }
@@ -66,15 +70,17 @@ class MessengerListenerTest extends BaseTestCase
             self::markTestSkipped('Messenger not supported in this environment.');
         }
 
+        $message = (object) ['foo' => 'bar'];
+        $envelope = Envelope::wrap($message);
+
         $error = new \RuntimeException();
+        $wrappedError = new HandlerFailedException($envelope, [$error]);
 
         $this->client->captureException($error)->shouldNotBeCalled();
         $this->client->flush()->shouldNotBeCalled();
 
         $listener = new MessengerListener($this->client->reveal(), false);
-        $message = (object) ['foo' => 'bar'];
-        $envelope = Envelope::wrap($message);
-        $event = $this->getMessageFailedEvent($envelope, 'receiver', $error, true);
+        $event = $this->getMessageFailedEvent($envelope, 'receiver', $wrappedError, true);
 
         $listener->onWorkerMessageFailed($event);
     }
@@ -85,15 +91,17 @@ class MessengerListenerTest extends BaseTestCase
             self::markTestSkipped('Messenger not supported in this environment.');
         }
 
+        $message = (object) ['foo' => 'bar'];
+        $envelope = Envelope::wrap($message);
+
         $error = new \RuntimeException();
+        $wrappedError = new HandlerFailedException($envelope, [$error]);
 
         $this->client->captureException($error)->shouldBeCalled();
         $this->client->flush()->shouldBeCalled();
 
         $listener = new MessengerListener($this->client->reveal(), false);
-        $message = (object) ['foo' => 'bar'];
-        $envelope = Envelope::wrap($message);
-        $event = $this->getMessageFailedEvent($envelope, 'receiver', $error, false);
+        $event = $this->getMessageFailedEvent($envelope, 'receiver', $wrappedError, false);
 
         $listener->onWorkerMessageFailed($event);
     }

--- a/test/EventListener/MessengerListenerTest.php
+++ b/test/EventListener/MessengerListenerTest.php
@@ -43,6 +43,26 @@ class MessengerListenerTest extends BaseTestCase
         $listener->onWorkerMessageFailed($event);
     }
 
+    public function testNonMessengerErrorsAreRecorded(): void
+    {
+        if (! $this->supportsMessenger()) {
+            self::markTestSkipped('Messenger not supported in this environment.');
+        }
+
+        $message = (object) ['foo' => 'bar'];
+        $envelope = Envelope::wrap($message);
+
+        $error = new \RuntimeException();
+
+        $this->client->captureException($error)->shouldBeCalled();
+        $this->client->flush()->shouldBeCalled();
+
+        $listener = new MessengerListener($this->client->reveal(), true);
+        $event = $this->getMessageFailedEvent($envelope, 'receiver', $error, false);
+
+        $listener->onWorkerMessageFailed($event);
+    }
+
     public function testHardFailsAreRecorded(): void
     {
         if (! $this->supportsMessenger()) {


### PR DESCRIPTION
When a command has multiple handlers, if any of those handlers throw an error, other handlers will continue. Multiple handlers may throw errors. This PR ensures all thrown errors are captured.

Addresses https://github.com/getsentry/sentry-symfony/issues/338