### PR TITLE
Remove "conflict" section from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,9 +48,6 @@
         "symfony/process": "^3.4||^4.0||^5.0",
         "symfony/yaml": "^3.4||^4.0||^5.0"
     },
-    "conflict": {
-        "ocramius/package-versions": "<1.3"
-    },
     "suggest": {
         "monolog/monolog": "Required to use the Monolog handler"
     },


### PR DESCRIPTION
This line is not required because the conflicting package is already in the "require" section.

Moreover, this line creates issue #346 

In practice, this line makes this package conflict with `jean85/pretty-package-versions` v1.3.*, which means it's not possible to generate a composer.lock file that is compatible with both composer 1 and composer 2.

:bomb: :boom: 