### PR TITLE
Messenger: capture_soft_fails:false doesn't work

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -241,6 +241,11 @@ parameters:
 			path: test/End2End/End2EndTest.php
 
 		-
+			message: "#^Comparison operation \"\\<\" between 50102 and 40300 is always false\\.$#"
+			count: 1
+			path: test/End2End/End2EndTest.php
+
+		-
 			message: "#^Method Sentry\\\\SentryBundle\\\\Test\\\\ErrorTypesParserTest\\:\\:testParse\\(\\) has parameter \\$value with no typehint specified\\.$#"
 			count: 1
 			path: test/ErrorTypesParserTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -226,7 +226,7 @@ parameters:
 			path: test/DependencyInjection/SentryExtensionTest.php
 
 		-
-			message: "#^Method Sentry\\\\SentryBundle\\\\Test\\\\End2End\\\\App\\\\Kernel\\:\\:build\\(\\) has no return typehint specified\\.$#"
+			message: "#^Comparison operation \"\\>\\=\" between 50102 and 40300 is always true\\.$#"
 			count: 1
 			path: test/End2End/App/Kernel.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -226,11 +226,6 @@ parameters:
 			path: test/DependencyInjection/SentryExtensionTest.php
 
 		-
-			message: "#^Method Sentry\\\\SentryBundle\\\\Test\\\\DependencyInjection\\\\ClientMock\\:\\:captureEvent\\(\\) has parameter \\$payload with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: test/DependencyInjection/SentryExtensionTest.php
-
-		-
 			message: "#^Method Sentry\\\\SentryBundle\\\\Test\\\\End2End\\\\App\\\\Kernel\\:\\:build\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: test/End2End/App/Kernel.php

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -143,7 +143,7 @@ class Configuration implements ConfigurationInterface
         $listenerPriorities->scalarNode('console_error')
             ->defaultValue(128);
         $listenerPriorities->scalarNode('worker_error')
-            ->defaultValue(128);
+            ->defaultValue(99);
 
         // Monolog handler configuration
         $monologConfiguration = $rootNode->children()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -2,9 +2,7 @@
 
 namespace Sentry\SentryBundle\DependencyInjection;
 
-use Composer\InstalledVersions;
 use Jean85\PrettyVersions;
-use PackageVersions\Versions;
 use Sentry\Options;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;

--- a/test/DependencyInjection/ConfigurationTest.php
+++ b/test/DependencyInjection/ConfigurationTest.php
@@ -51,7 +51,7 @@ class ConfigurationTest extends BaseTestCase
                 'console' => 1,
                 'request_error' => 128,
                 'console_error' => 128,
-                'worker_error' => 128,
+                'worker_error' => 99,
             ],
             'options' => [
                 'class_serializers' => [],

--- a/test/End2End/App/Controller/MessengerController.php
+++ b/test/End2End/App/Controller/MessengerController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Sentry\SentryBundle\Test\End2End\App\Controller;
+
+use Sentry\SentryBundle\Test\End2End\App\Messenger\FooMessage;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+class MessengerController
+{
+    /** @var MessageBusInterface */
+    private $messenger;
+
+    public function __construct(MessageBusInterface $messenger)
+    {
+        $this->messenger = $messenger;
+    }
+
+    public function dispatchMessage(): Response
+    {
+        $this->messenger->dispatch(new FooMessage());
+
+        return new Response('Success');
+    }
+}

--- a/test/End2End/App/Controller/MessengerController.php
+++ b/test/End2End/App/Controller/MessengerController.php
@@ -22,4 +22,11 @@ class MessengerController
 
         return new Response('Success');
     }
+
+    public function dispatchUnrecoverableMessage(): Response
+    {
+        $this->messenger->dispatch(new FooMessage(false));
+
+        return new Response('Success');
+    }
 }

--- a/test/End2End/App/Kernel.php
+++ b/test/End2End/App/Kernel.php
@@ -6,6 +6,7 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\Kernel as SymfonyKernel;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 class Kernel extends SymfonyKernel
 {
@@ -26,6 +27,10 @@ class Kernel extends SymfonyKernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__ . '/config.yml');
+
+        if (interface_exists(MessageBusInterface::class)) {
+            $loader->load(__DIR__ . '/messenger.yml');
+        }
     }
 
     protected function build(ContainerBuilder $container)

--- a/test/End2End/App/Kernel.php
+++ b/test/End2End/App/Kernel.php
@@ -13,29 +13,28 @@ class Kernel extends SymfonyKernel
     /**
      * @return BundleInterface[]
      */
-    public function registerBundles()
+    public function registerBundles(): array
     {
-        $bundles = [
+        return [
             new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
             new \Symfony\Bundle\MonologBundle\MonologBundle(),
             new \Sentry\SentryBundle\SentryBundle(),
         ];
-
-        return $bundles;
     }
 
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__ . '/config.yml');
 
-        if (interface_exists(MessageBusInterface::class)) {
+        if (interface_exists(MessageBusInterface::class) && self::VERSION_ID >= 40300) {
             $loader->load(__DIR__ . '/messenger.yml');
         }
     }
 
-    protected function build(ContainerBuilder $container)
+    protected function build(ContainerBuilder $container): void
     {
         $container->setParameter('routing_config_dir', __DIR__);
+
         parent::build($container);
     }
 }

--- a/test/End2End/App/Messenger/FooMessage.php
+++ b/test/End2End/App/Messenger/FooMessage.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Sentry\SentryBundle\Test\End2End\App\Messenger;
+
+class FooMessage
+{
+    /** @var bool */
+    private $shouldRetry;
+
+    public function __construct(bool $shouldRetry = true)
+    {
+        $this->shouldRetry = $shouldRetry;
+    }
+
+    public function shouldRetry(): bool
+    {
+        return $this->shouldRetry;
+    }
+}

--- a/test/End2End/App/Messenger/FooMessageHandler.php
+++ b/test/End2End/App/Messenger/FooMessageHandler.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Sentry\SentryBundle\Test\End2End\App\Messenger;
+
+use Symfony\Component\Messenger\Exception\UnrecoverableExceptionInterface;
+use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+
+class FooMessageHandler implements MessageHandlerInterface
+{
+    public function __invoke(FooMessage $message): void
+    {
+        if (! $message->shouldRetry()) {
+            throw new class() extends \Exception implements UnrecoverableExceptionInterface {
+            };
+        }
+
+        throw new \Exception('This is an intentional failure while handling a message of class ' . get_class($message));
+    }
+}

--- a/test/End2End/App/Messenger/StaticInMemoryTransport.php
+++ b/test/End2End/App/Messenger/StaticInMemoryTransport.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Sentry\SentryBundle\Test\End2End\App\Messenger;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\TransportInterface;
+
+/**
+ * @see \Symfony\Component\Messenger\Transport\InMemoryTransport
+ */
+class StaticInMemoryTransport implements TransportInterface
+{
+    /** @var Envelope[] */
+    private static $sent = [];
+
+    /** @var Envelope[] */
+    private static $acknowledged = [];
+
+    /** @var Envelope[] */
+    private static $rejected = [];
+
+    /** @var Envelope[] */
+    private static $queue = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get(): iterable
+    {
+        return array_values(self::$queue);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function ack(Envelope $envelope): void
+    {
+        self::$acknowledged[] = $envelope;
+        $id = spl_object_hash($envelope->getMessage());
+        unset(self::$queue[$id]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reject(Envelope $envelope): void
+    {
+        self::$rejected[] = $envelope;
+        $id = spl_object_hash($envelope->getMessage());
+        unset(self::$queue[$id]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function send(Envelope $envelope): Envelope
+    {
+        self::$sent[] = $envelope;
+        $id = spl_object_hash($envelope->getMessage());
+        self::$queue[$id] = $envelope;
+
+        return $envelope;
+    }
+
+    public static function reset(): void
+    {
+        self::$sent = self::$queue = self::$rejected = self::$acknowledged = [];
+    }
+
+    /**
+     * @return Envelope[]
+     */
+    public function getAcknowledged(): array
+    {
+        return self::$acknowledged;
+    }
+
+    /**
+     * @return Envelope[]
+     */
+    public function getRejected(): array
+    {
+        return self::$rejected;
+    }
+
+    /**
+     * @return Envelope[]
+     */
+    public function getSent(): array
+    {
+        return self::$sent;
+    }
+}

--- a/test/End2End/App/Messenger/StaticInMemoryTransportFactory.php
+++ b/test/End2End/App/Messenger/StaticInMemoryTransportFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Sentry\SentryBundle\Test\End2End\App\Messenger;
+
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
+use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
+use Symfony\Component\Messenger\Transport\TransportInterface;
+
+class StaticInMemoryTransportFactory implements TransportFactoryInterface
+{
+    /**
+     * @param mixed[] $options
+     */
+    public function createTransport(string $dsn, array $options, SerializerInterface $serializer): TransportInterface
+    {
+        return new StaticInMemoryTransport();
+    }
+
+    /**
+     * @param mixed[] $options
+     */
+    public function supports(string $dsn, array $options): bool
+    {
+        return 'static://' === $dsn;
+    }
+}

--- a/test/End2End/App/messenger.yml
+++ b/test/End2End/App/messenger.yml
@@ -1,0 +1,28 @@
+services:
+  _defaults:
+    autoconfigure: true
+
+  Sentry\SentryBundle\Test\End2End\App\Messenger\StaticInMemoryTransportFactory:
+    class: \Sentry\SentryBundle\Test\End2End\App\Messenger\StaticInMemoryTransportFactory
+
+  Sentry\SentryBundle\Test\End2End\App\Messenger\FooMessageHandler:
+    class: \Sentry\SentryBundle\Test\End2End\App\Messenger\FooMessageHandler
+
+  Sentry\SentryBundle\Test\End2End\App\Controller\MessengerController:
+    autowire: true
+    tags:
+      - controller.service_arguments
+
+framework:
+  messenger:
+    transports:
+      async:
+        dsn: 'static://'
+        retry_strategy:
+          max_retries: 1
+    routing:
+      '*': async
+
+sentry:
+  messenger:
+    capture_soft_fails: false

--- a/test/End2End/App/routing.yml
+++ b/test/End2End/App/routing.yml
@@ -13,3 +13,7 @@ secured200:
 subrequest:
   path:  /subrequest
   defaults: { _controller: 'Sentry\SentryBundle\Test\End2End\App\Controller\MainController::subrequest' }
+
+dispatch:
+  path: /dispatch-message
+  defaults: { _controller: 'Sentry\SentryBundle\Test\End2End\App\Controller\MessengerController::dispatchMessage' }

--- a/test/End2End/App/routing.yml
+++ b/test/End2End/App/routing.yml
@@ -17,3 +17,7 @@ subrequest:
 dispatch:
   path: /dispatch-message
   defaults: { _controller: 'Sentry\SentryBundle\Test\End2End\App\Controller\MessengerController::dispatchMessage' }
+
+dispatch_unrecoverable:
+  path: /dispatch-unrecoverable-message
+  defaults: { _controller: 'Sentry\SentryBundle\Test\End2End\App\Controller\MessengerController::dispatchUnrecoverableMessage' }

--- a/test/End2End/End2EndTest.php
+++ b/test/End2End/End2EndTest.php
@@ -117,6 +117,26 @@ class End2EndTest extends WebTestCase
         $this->assertLastEventIdIsNotNull($client);
     }
 
+    public function testMessengerCaptureHardFailure(): void
+    {
+        if (! interface_exists(MessageBusInterface::class)) {
+            $this->markTestSkipped('Messenger missing');
+        }
+
+        $client = static::createClient();
+
+        $client->request('GET', '/dispatch-unrecoverable-message');
+
+        $response = $client->getResponse();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $this->consumeOneMessage($client->getKernel());
+
+        $this->assertLastEventIdIsNotNull($client);
+    }
+
     public function testMessengerCaptureSoftFailCanBeDisabled(): void
     {
         if (! interface_exists(MessageBusInterface::class)) {

--- a/test/End2End/End2EndTest.php
+++ b/test/End2End/End2EndTest.php
@@ -6,10 +6,14 @@ use PHPUnit\Framework\TestCase;
 use Sentry\SentryBundle\Test\End2End\App\Kernel;
 use Sentry\State\HubInterface;
 use Symfony\Bundle\FrameworkBundle\Client;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 class_alias(TestCase::class, \PHPUnit_Framework_TestCase::class);
 if (! class_exists(KernelBrowser::class)) {
@@ -113,6 +117,42 @@ class End2EndTest extends WebTestCase
         $this->assertLastEventIdIsNotNull($client);
     }
 
+    public function testMessengerCaptureSoftFailCanBeDisabled(): void
+    {
+        if (! interface_exists(MessageBusInterface::class)) {
+            $this->markTestSkipped('Messenger missing');
+        }
+
+        $client = static::createClient();
+
+        $client->request('GET', '/dispatch-message');
+
+        $response = $client->getResponse();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $this->consumeOneMessage($client->getKernel());
+
+        $this->assertLastEventIdIsNull($client);
+    }
+
+    private function consumeOneMessage(KernelInterface $kernel): void
+    {
+        $application = new Application($kernel);
+
+        $command = $application->find('messenger:consume');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            'receivers' => ['async'],
+            '--limit' => 1,
+            '--time-limit' => 1,
+            '-vvv' => true,
+        ]);
+
+        $this->assertSame(0, $commandTester->getStatusCode());
+    }
+
     private function assertLastEventIdIsNotNull(KernelBrowser $client): void
     {
         $container = $client->getContainer();
@@ -122,5 +162,16 @@ class End2EndTest extends WebTestCase
         $this->assertInstanceOf(HubInterface::class, $hub);
 
         $this->assertNotNull($hub->getLastEventId(), 'Last error not captured');
+    }
+
+    private function assertLastEventIdIsNull(KernelBrowser $client): void
+    {
+        $container = $client->getContainer();
+        $this->assertNotNull($container);
+
+        $hub = $container->get('test.hub');
+        $this->assertInstanceOf(HubInterface::class, $hub);
+
+        $this->assertNull($hub->getLastEventId(), 'Some error was captured');
     }
 }

--- a/test/End2End/End2EndTest.php
+++ b/test/End2End/End2EndTest.php
@@ -119,9 +119,7 @@ class End2EndTest extends WebTestCase
 
     public function testMessengerCaptureHardFailure(): void
     {
-        if (! interface_exists(MessageBusInterface::class)) {
-            $this->markTestSkipped('Messenger missing');
-        }
+        $this->skipIfMessengerIsMissing();
 
         $client = static::createClient();
 
@@ -139,9 +137,7 @@ class End2EndTest extends WebTestCase
 
     public function testMessengerCaptureSoftFailCanBeDisabled(): void
     {
-        if (! interface_exists(MessageBusInterface::class)) {
-            $this->markTestSkipped('Messenger missing');
-        }
+        $this->skipIfMessengerIsMissing();
 
         $client = static::createClient();
 
@@ -193,5 +189,12 @@ class End2EndTest extends WebTestCase
         $this->assertInstanceOf(HubInterface::class, $hub);
 
         $this->assertNull($hub->getLastEventId(), 'Some error was captured');
+    }
+
+    private function skipIfMessengerIsMissing(): void
+    {
+        if (! interface_exists(MessageBusInterface::class) || Kernel::VERSION_ID < 40300) {
+            $this->markTestSkipped('Messenger missing');
+        }
     }
 }


### PR DESCRIPTION
This stems from https://github.com/getsentry/sentry-symfony/pull/326#issuecomment-653455458: I've noticed that the `capture_soft_fails` option is not working for me, because the `willRetry` flag is set later, in a different listener with a priority of 100, where our listener has a default priority of 128.