### PR TITLE
Make the RequestIntegration integration fetch the request from the request stack

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,7 +53,7 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: xdebug
       - run: |
-          sed -ri '/symfony\/(monolog-bundle|phpunit-bridge|messenger)/! s/"symfony\/(.+)": "(.+)"/"symfony\/\1": "'${{ matrix.symfony_constraint }}'"/' composer.json;
+          sed -ri '/symfony\/(monolog-bundle|phpunit-bridge|messenger|psr-http-message-bridge)/! s/"symfony\/(.+)": "(.+)"/"symfony\/\1": "'${{ matrix.symfony_constraint }}'"/' composer.json;
         if: matrix.symfony_constraint
       - run: composer remove --dev symfony/messenger --no-update
         if: matrix.symfony_constraint == '3.4.*' || matrix.composer_option == '--prefer-lowest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [BC BREAK] Refactorized the configuration tree and the definitions of some container services (#401)
 - Support the XML format for the bundle configuration (#401)
 - PHP 8 support (#399, thanks to @Yozhef)
+- Retrieve the request from the `RequestStack` when using the `RequestIntegration` integration (#361)
 
 ## 3.5.3 (2020-10-13)
 

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "symfony/dependency-injection": "^3.4.43||^4.4.11||^5.0.11",
         "symfony/event-dispatcher": "^3.4.43||^4.4.11||^5.0.11",
         "symfony/http-kernel": "^3.4.43||^4.4.11||^5.0.11",
+        "symfony/psr-http-message-bridge": "^2.0",
         "symfony/security-core": "^3.4.43||^4.4.11||^5.0.11"
     },
     "require-dev": {

--- a/src/Integration/RequestFetcher.php
+++ b/src/Integration/RequestFetcher.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Integration;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Sentry\Integration\RequestFetcherInterface;
+use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * This class fetches the server request from the request stack and converts it
+ * into a PSR-7 request that is suitable to be used by the {@see \Sentry\Integration\RequestIntegration}
+ * integration.
+ */
+final class RequestFetcher implements RequestFetcherInterface
+{
+    /**
+     * @var RequestStack The request stack
+     */
+    private $requestStack;
+
+    /**
+     * @var HttpMessageFactoryInterface The factory to convert Symfony requests to PSR-7 requests
+     */
+    private $httpMessageFactory;
+
+    /**
+     * Class constructor.
+     *
+     * @param RequestStack                $requestStack       The request stack
+     * @param HttpMessageFactoryInterface $httpMessageFactory The factory to convert Symfony requests to PSR-7 requests
+     */
+    public function __construct(RequestStack $requestStack, HttpMessageFactoryInterface $httpMessageFactory)
+    {
+        $this->requestStack = $requestStack;
+        $this->httpMessageFactory = $httpMessageFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchRequest(): ?ServerRequestInterface
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (null === $request) {
+            return null;
+        }
+
+        return $this->httpMessageFactory->createRequest($request);
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -66,5 +66,33 @@
         <service id="Sentry\Monolog\Handler" class="Sentry\Monolog\Handler">
             <argument type="service" id="Sentry\State\HubInterface" />
         </service>
+
+        <service id="Sentry\Integration\RequestFetcherInterface" class="Sentry\SentryBundle\Integration\RequestFetcher">
+            <argument type="service" id="Symfony\Component\HttpFoundation\RequestStack" />
+            <argument type="service">
+                <service class="Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory">
+                    <argument type="service">
+                        <service class="Psr\Http\Message\ServerRequestFactoryInterface">
+                            <factory class="Http\Discovery\Psr17FactoryDiscovery" method="findServerRequestFactory" />
+                        </service>
+                    </argument>
+                    <argument type="service">
+                        <service class="Psr\Http\Message\StreamFactoryInterface">
+                            <factory class="Http\Discovery\Psr17FactoryDiscovery" method="findStreamFactory" />
+                        </service>
+                    </argument>
+                    <argument type="service">
+                        <service class="Psr\Http\Message\UploadedFileFactoryInterface">
+                            <factory class="Http\Discovery\Psr17FactoryDiscovery" method="findUploadedFileFactory" />
+                        </service>
+                    </argument>
+                    <argument type="service">
+                        <service class="Psr\Http\Message\ResponseFactoryInterface">
+                            <factory class="Http\Discovery\Psr17FactoryDiscovery" method="findResponseFactory" />
+                        </service>
+                    </argument>
+                </service>
+            </argument>
+        </service>
     </services>
 </container>

--- a/test/DependencyInjection/Fixtures/php/ignore_errors_integration_overridden.php
+++ b/test/DependencyInjection/Fixtures/php/ignore_errors_integration_overridden.php
@@ -8,7 +8,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 $container->loadFromExtension('sentry', [
     'options' => [
         'integrations' => [
-            'App\\Sentry\\Integration\\FooIntegration',
             'Sentry\\Integration\\IgnoreErrorsIntegration',
         ],
     ],

--- a/test/DependencyInjection/Fixtures/xml/ignore_errors_integration_overridden.xml
+++ b/test/DependencyInjection/Fixtures/xml/ignore_errors_integration_overridden.xml
@@ -8,7 +8,6 @@
 
     <sentry:config>
         <sentry:options>
-            <sentry:integration>App\Sentry\Integration\FooIntegration</sentry:integration>
             <sentry:integration>Sentry\Integration\IgnoreErrorsIntegration</sentry:integration>
         </sentry:options>
     </sentry:config>

--- a/test/DependencyInjection/Fixtures/yml/ignore_errors_integration_overridden.yml
+++ b/test/DependencyInjection/Fixtures/yml/ignore_errors_integration_overridden.yml
@@ -1,5 +1,4 @@
 sentry:
     options:
         integrations:
-            - App\Sentry\Integration\FooIntegration
             - Sentry\Integration\IgnoreErrorsIntegration

--- a/test/Integration/RequestFetcherTest.php
+++ b/test/Integration/RequestFetcherTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Test\Integration;
+
+use GuzzleHttp\Psr7\ServerRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Sentry\SentryBundle\Integration\RequestFetcher;
+use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+final class RequestFetcherTest extends TestCase
+{
+    /**
+     * @var RequestStack&MockObject
+     */
+    private $requestStack;
+
+    /**
+     * @var HttpMessageFactoryInterface&MockObject
+     */
+    private $httpMessageFactory;
+
+    /**
+     * @var RequestFetcher
+     */
+    private $requestFetcher;
+
+    protected function setUp(): void
+    {
+        $this->requestStack = $this->createMock(RequestStack::class);
+        $this->httpMessageFactory = $this->createMock(HttpMessageFactoryInterface::class);
+        $this->requestFetcher = new RequestFetcher($this->requestStack, $this->httpMessageFactory);
+    }
+
+    /**
+     * @dataProvider fetchRequestDataProvider
+     */
+    public function testFetchRequest(?Request $request, ?ServerRequestInterface $expectedRequest): void
+    {
+        $this->requestStack->expects($this->once())
+            ->method('getCurrentRequest')
+            ->willReturn($request);
+
+        $this->httpMessageFactory->expects(null !== $expectedRequest ? $this->once() : $this->never())
+            ->method('createRequest')
+            ->with($request)
+            ->willReturn($expectedRequest);
+
+        $this->assertSame($expectedRequest, $this->requestFetcher->fetchRequest());
+    }
+
+    /**
+     * @return \Generator<mixed>
+     */
+    public function fetchRequestDataProvider(): \Generator
+    {
+        yield [
+            null,
+            null,
+        ];
+
+        yield [
+            Request::create('http://www.example.com'),
+            new ServerRequest('GET', 'http://www.example.com'),
+        ];
+    }
+}


### PR DESCRIPTION
With this PR the `RequestIntegration` integration now fetches the HTTP request from the request stack of Symfony instead of creating a new request from the PHP superglobals. This should (but I didn't test if it was really broken before) also solve the fact that in the context of a Symfony sub-request the request data attached to the event was referring to the main PHP request