### PR TITLE
Make command lazily loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
- - ...
+ - CLI commands registration policy changed to lazy load
 
 ## 3.5.2 (2020-07-08)
  - Use `jean85/pretty-package-versions` `^1.5` to leverage the new `getRootPackageVersion` method (c8799ac)

--- a/src/Command/SentryTestCommand.php
+++ b/src/Command/SentryTestCommand.php
@@ -9,10 +9,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SentryTestCommand extends Command
 {
-    public function __construct()
-    {
-        parent::__construct('sentry:test');
-    }
+    protected static $defaultName = 'sentry:test';
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {


### PR DESCRIPTION
Hi there.
Since Symfony 3.4^ [allows us to provide console command name for compile-time registration](https://github.com/symfony/symfony/pull/23887) all console command should be registered by this way, if not
every time when someone run ./bin/console Symfony should compile all container to fetch command name and [set parameter manually ](https://github.com/symfony/symfony/blob/6f81e033312f5feb744507766d02f2e8cae01e9b/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php#L96)

Also here is a way to check if on your Symfony project some commands register not properly
```bash
bin/console debug:container --parameter=console.command.ids
```
Example output from my project now
``` --------------------- ----------------------------------------------------------------- 
  Parameter             Value                                                            
 --------------------- ----------------------------------------------------------------------------- ------------ 
  console.command.ids   ["console.command.public_alias.Sentry\SentryBundle\Command\SentryTestCommand
 --------------------- ------------------------------------------------------------------------------------------
```
we are using        
``` "sentry/sentry-symfony": "^3.0" // 3.5.2 ```
This is the simple fix which not breaking BC because BC layer already on [\Symfony\Component\Console\Command\Command](https://github.com/symfony/symfony/pull/23887/files#diff-8e80595663798837db1b033187835535R75)

Also here some ref where the same problem was fixed by this way

- https://github.com/doctrine/migrations/pull/839
- https://github.com/doctrine/DoctrineMongoDBBundle/pull/642

btw, I'm not sure about the target branch, should be 3.5 instead? 