### PR TITLE
Use a FQCN for Sentry bundle in AppKernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ class AppKernel extends Kernel
     {
         $bundles = [
             // ...
-            new Sentry\SentryBundle\SentryBundle(),
+            new \Sentry\SentryBundle\SentryBundle(),
         ];
 
         // ...


### PR DESCRIPTION
Without the leading slash the import does not work when
the AppKernel class is in a non-root namespace.