### PR TITLE
Support PHPUnit 9

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,7 +37,6 @@ jobs:
           - description: 'prefer lowest'
             php: '7.2'
             composer_option: '--prefer-lowest'
-            symfony_constraint: 3.4.*
             env:
               SYMFONY_DEPRECATIONS_HELPER: disabled
 
@@ -56,7 +55,7 @@ jobs:
           sed -ri '/symfony\/(monolog-bundle|phpunit-bridge|messenger)/! s/"symfony\/(.+)": "(.+)"/"symfony\/\1": "'${{ matrix.symfony_constraint }}'"/' composer.json;
         if: matrix.symfony_constraint
       - run: composer remove --dev symfony/messenger --no-update
-        if: matrix.symfony_constraint == '3.4.*'
+        if: matrix.symfony_constraint == '3.4.*' || matrix.composer_option == '--prefer-lowest'
       - run: composer update --no-progress --ansi ${{ matrix.composer_option }}
       - run: composer require sentry/sentry dev-develop
         if: matrix.sentry_constraint == 'dev-develop'

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "jean85/pretty-package-versions": "^1.5",
         "sentry/sdk": "^3.0",
         "symfony/config": "^3.4||^4.0||^5.0",

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "phpunit/phpunit": "^8.5||^9.0",
         "symfony/browser-kit": "^3.4||^4.0||^5.0",
         "symfony/expression-language": "^3.4||^4.0||^5.0",
-        "symfony/framework-bundle": "^3.4||^4.0||^5.0",
+        "symfony/framework-bundle": "^3.4.23||^4.0||^5.0",
         "symfony/messenger": "^4.3||^5.0",
         "symfony/monolog-bundle": "^3.4",
         "symfony/phpunit-bridge": "^5.0",

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^0.12",
         "phpstan/phpstan-phpunit": "^0.12",
-        "phpunit/phpunit": "^7.5||^8.5",
+        "phpunit/phpunit": "^8.5||^9.0",
         "symfony/browser-kit": "^3.4||^4.0||^5.0",
         "symfony/expression-language": "^3.4||^4.0||^5.0",
         "symfony/framework-bundle": "^3.4||^4.0||^5.0",

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "monolog/monolog": "^1.3||^2.0",
         "php-http/mock-client": "^1.4",
         "phpspec/prophecy": "!=1.11.0",
+        "phpspec/prophecy-phpunit": "^1.1||^2.0",
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^0.12",
         "phpstan/phpstan-phpunit": "^0.12",

--- a/test/BaseTestCase.php
+++ b/test/BaseTestCase.php
@@ -3,13 +3,26 @@
 namespace Sentry\SentryBundle\Test;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelInterface;
 
-abstract class BaseTestCase extends TestCase
+// Trait is available in phpspec/prophecy-phpunit:2.0 which requires at least PHP 7.3
+if (trait_exists(ProphecyTrait::class)) {
+    abstract class BaseProphecyTestCase extends TestCase
+    {
+        use ProphecyTrait;
+    }
+} else {
+    abstract class BaseProphecyTestCase extends TestCase
+    {
+    }
+}
+
+abstract class BaseTestCase extends BaseProphecyTestCase
 {
     protected function getSupportedOptionsCount(): int
     {

--- a/test/DependencyInjection/ConfigurationTest.php
+++ b/test/DependencyInjection/ConfigurationTest.php
@@ -91,7 +91,9 @@ class ConfigurationTest extends BaseTestCase
         $input = ['options' => [$option => $value]];
         $processed = $this->processConfiguration($input);
 
-        $this->assertContains($input, $processed);
+        $this->assertArrayHasKey('options', $processed);
+        $this->assertArrayHasKey($option, $processed['options']);
+        $this->assertEquals($value, $processed['options'][$option]);
     }
 
     public function optionValuesProvider(): array


### PR DESCRIPTION
One step closer towards PHP 8 support...

Related to https://github.com/getsentry/sentry-symfony/issues/364

* drop support for PHP 7.1
* add support for PHPUnit 9 which itself supports PHP 8