### PR TITLE
composer: allow PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "jean85/pretty-package-versions": "^1.5",
         "sentry/sdk": "^3.0",
         "symfony/config": "^3.4||^4.0||^5.0",


### PR DESCRIPTION
Hi,

this is one of last few blocker for our project to upgrade safely to PHP 8.0
What else needs to be done to allow it here?