### PR TITLE
Fix: Remove version constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Press `y` and return to allow the installation.
 You can install this bundle using Composer: 
 
 ```bash
-composer require sentry/sentry-symfony:^3.0
+composer require sentry/sentry-symfony
 ```
 
 ### Step 2: Enable the Bundle


### PR DESCRIPTION

This PR

* [x] removes the version constraint from installation instructions in `README.md`

![CleanShot 2020-12-10 at 23 30 01](https://user-images.githubusercontent.com/605483/101837701-bfb1a180-3b3f-11eb-9468-6077e1a2d2cc.png)
