### PR TITLE
Prefer usage of the existing HttpMessageFactoryInterface service for the RequestFetcher class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Reorganize the folder structure and change CS standard (#405)
 - [BC BREAK] Remove the `monolog` configuration option. Instead, register the service manually (#406)
 - [BC BREAK] Remove the `listener_priorities` configuration option. Instead, use a compiler pass to change the priority of the listeners (#407)
+- Prefer usage of the existing `Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface` service for the `RequestFetcher` class (#409)
 
 ## 3.5.3 (2020-10-13)
 

--- a/src/Integration/RequestFetcher.php
+++ b/src/Integration/RequestFetcher.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Sentry\SentryBundle\Integration;
 
+use Http\Discovery\Psr17FactoryDiscovery;
 use Psr\Http\Message\ServerRequestInterface;
 use Sentry\Integration\RequestFetcherInterface;
+use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -29,13 +31,18 @@ final class RequestFetcher implements RequestFetcherInterface
     /**
      * Class constructor.
      *
-     * @param RequestStack                $requestStack       The request stack
-     * @param HttpMessageFactoryInterface $httpMessageFactory The factory to convert Symfony requests to PSR-7 requests
+     * @param RequestStack                     $requestStack       The request stack
+     * @param HttpMessageFactoryInterface|null $httpMessageFactory The factory to convert Symfony requests to PSR-7 requests
      */
-    public function __construct(RequestStack $requestStack, HttpMessageFactoryInterface $httpMessageFactory)
+    public function __construct(RequestStack $requestStack, ?HttpMessageFactoryInterface $httpMessageFactory = null)
     {
         $this->requestStack = $requestStack;
-        $this->httpMessageFactory = $httpMessageFactory;
+        $this->httpMessageFactory = $httpMessageFactory ?? new PsrHttpFactory(
+            Psr17FactoryDiscovery::findServerRequestFactory(),
+            Psr17FactoryDiscovery::findStreamFactory(),
+            Psr17FactoryDiscovery::findUploadedFileFactory(),
+            Psr17FactoryDiscovery::findResponseFactory()
+        );
     }
 
     /**

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -65,30 +65,7 @@
 
         <service id="Sentry\Integration\RequestFetcherInterface" class="Sentry\SentryBundle\Integration\RequestFetcher">
             <argument type="service" id="Symfony\Component\HttpFoundation\RequestStack" />
-            <argument type="service">
-                <service class="Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory">
-                    <argument type="service">
-                        <service class="Psr\Http\Message\ServerRequestFactoryInterface">
-                            <factory class="Http\Discovery\Psr17FactoryDiscovery" method="findServerRequestFactory" />
-                        </service>
-                    </argument>
-                    <argument type="service">
-                        <service class="Psr\Http\Message\StreamFactoryInterface">
-                            <factory class="Http\Discovery\Psr17FactoryDiscovery" method="findStreamFactory" />
-                        </service>
-                    </argument>
-                    <argument type="service">
-                        <service class="Psr\Http\Message\UploadedFileFactoryInterface">
-                            <factory class="Http\Discovery\Psr17FactoryDiscovery" method="findUploadedFileFactory" />
-                        </service>
-                    </argument>
-                    <argument type="service">
-                        <service class="Psr\Http\Message\ResponseFactoryInterface">
-                            <factory class="Http\Discovery\Psr17FactoryDiscovery" method="findResponseFactory" />
-                        </service>
-                    </argument>
-                </service>
-            </argument>
+            <argument type="service" id="Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface" on-invalid="null" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
Really small change to make the `RequestFetcher` class to prefer the existing `Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface` service rather than using an anonymous service forcefully constructed on-the-fly