### PR TITLE
Change the priorities of the RequestListener and SubRequestListener listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [BC BREAK] Remove the `monolog` configuration option. Instead, register the service manually (#406)
 - [BC BREAK] Remove the `listener_priorities` configuration option. Instead, use a compiler pass to change the priority of the listeners (#407)
 - Prefer usage of the existing `Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface` service for the `RequestFetcher` class (#409)
+- [BC BREAK] Change the priorities of the `RequestListener` and `SubRequestListener` listeners (#414)
 
 ## 3.5.3 (2020-10-13)
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -77,6 +77,10 @@
 - Changed the priority of the `ConsoleCommandListener::handleConsoleErrorEvent` listener to `-64`.
 - Changed the priority of the `ConsoleCommandListener::::handleConsoleCommandEvent` listener to `128`.
 - Changed the priority of the `MessengerListener::handleWorkerMessageFailedEvent` listener to `50`.
+- Changed the priority of the `RequestListener::handleKernelRequestEvent` listener to `5`.
+- Changed the priority of the `RequestListener::handleKernelControllerEvent` listener to `10`.
+- Changed the priority of the `SubRequestListener::handleKernelRequestEvent` listener to `3`.
+- Changed the priority of the `SubRequestListener::handleKernelFinishRequestEvent` listener to `5`.
 - Changed the type of the `sentry.options.before_send` configuration option from `scalar` to `string`. The value must always be the name of the container service to call without the `@` prefix.
 
   Before

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -41,15 +41,15 @@
             <argument type="service" id="Sentry\State\HubInterface" />
             <argument type="service" id="security.token_storage" on-invalid="ignore" />
 
-            <tag name="kernel.event_listener" event="kernel.request" method="handleKernelRequestEvent" priority="1" />
-            <tag name="kernel.event_listener" event="kernel.controller" method="handleKernelControllerEvent" priority="1" />
+            <tag name="kernel.event_listener" event="kernel.request" method="handleKernelRequestEvent" priority="5" />
+            <tag name="kernel.event_listener" event="kernel.controller" method="handleKernelControllerEvent" priority="10" />
         </service>
 
         <service id="Sentry\SentryBundle\EventListener\SubRequestListener" class="Sentry\SentryBundle\EventListener\SubRequestListener">
             <argument type="service" id="Sentry\State\HubInterface" />
 
-            <tag name="kernel.event_listener" event="kernel.request" method="handleKernelRequestEvent" priority="1" />
-            <tag name="kernel.event_listener" event="kernel.finish_request" method="handleKernelFinishRequestEvent" priority="1" />
+            <tag name="kernel.event_listener" event="kernel.request" method="handleKernelRequestEvent" priority="3" />
+            <tag name="kernel.event_listener" event="kernel.finish_request" method="handleKernelFinishRequestEvent" priority="5" />
         </service>
 
         <service id="Sentry\SentryBundle\EventListener\MessengerListener" class="Sentry\SentryBundle\EventListener\MessengerListener">

--- a/tests/DependencyInjection/SentryExtensionTest.php
+++ b/tests/DependencyInjection/SentryExtensionTest.php
@@ -125,12 +125,12 @@ abstract class SentryExtensionTest extends TestCase
                 [
                     'event' => KernelEvents::REQUEST,
                     'method' => 'handleKernelRequestEvent',
-                    'priority' => 1,
+                    'priority' => 5,
                 ],
                 [
                     'event' => KernelEvents::CONTROLLER,
                     'method' => 'handleKernelControllerEvent',
-                    'priority' => 1,
+                    'priority' => 10,
                 ],
             ],
         ], $definition->getTags());
@@ -147,12 +147,12 @@ abstract class SentryExtensionTest extends TestCase
                 [
                     'event' => KernelEvents::REQUEST,
                     'method' => 'handleKernelRequestEvent',
-                    'priority' => 1,
+                    'priority' => 3,
                 ],
                 [
                     'event' => KernelEvents::FINISH_REQUEST,
                     'method' => 'handleKernelFinishRequestEvent',
-                    'priority' => 1,
+                    'priority' => 5,
                 ],
             ],
         ], $definition->getTags());


### PR DESCRIPTION
As per title, let's make more space between our `RequestListener` and `SubRequestListener` listeners and the default priority assigned by the [`EventDispatcher`](https://symfony.com/doc/current/components/event_dispatcher.html) component of Symfony. This will make it easier both for third parties and ourselves to introduce new listeners, e.g. the one related to the [Distributed Tracing](https://docs.sentry.io/product/performance/distributed-tracing/) feature