### PR TITLE
sentry.options.integrations expects the name of the service without the @ prefix

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -66,7 +66,7 @@ using an on-premise installation it requires Sentry version `>= v20.6.0` to work
   sentry:
       options:
           integrations:
-              - '@Sentry\Integration\IgnoreErrorsIntegration'
+              - 'Sentry\Integration\IgnoreErrorsIntegration'
   
   services:
       Sentry\Integration\IgnoreErrorsIntegration:


### PR DESCRIPTION
The UPGRADE-4.0.md contains also a change for the type of the sentry.options.integrations:

> Changed the type of the sentry.options.integrations configuration option from an array of scalar values to an array of string values. The value must always be the name of the container service to call without the @ prefix.