### PR TITLE
Fix regression that send PII even when the send_default_pii option is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Added missing `capture-soft-fails` config schema option (#417)
+- Add missing `capture-soft-fails` option to the XSD schema for the XML config (#417)
+- Fix regression that send PII even when the `send_default_pii` option is off (#425)
 
 ## 4.0.0 (2021-01-19)
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -82,7 +82,7 @@ parameters:
 
 		-
 			message: "#^Instantiated class Symfony\\\\Component\\\\HttpKernel\\\\Event\\\\GetResponseEvent not found\\.$#"
-			count: 6
+			count: 8
 			path: tests/EventListener/RequestListenerTest.php
 
 		-

--- a/src/EventListener/RequestListener.php
+++ b/src/EventListener/RequestListener.php
@@ -51,6 +51,12 @@ final class RequestListener
             return;
         }
 
+        $client = $this->hub->getClient();
+
+        if (null === $client || !$client->getOptions()->shouldSendDefaultPii()) {
+            return;
+        }
+
         $token = null;
         $userData = UserDataBag::createFromUserIpAddress($event->getRequest()->getClientIp());
 


### PR DESCRIPTION
This fixes #422: basically, during the refactoring of the `RequestListener` class that I did in #387 I forgot to consider the `send_default_pii` option when capturing the user data (IP address and username).