### PR TITLE
Fix capture of console errors when the register_error_listener option is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add missing `capture-soft-fails` option to the XSD schema for the XML config (#417)
 - Fix regression that send PII even when the `send_default_pii` option is off (#425)
+- Fix capture of console errors when the `register_error_listener` option is disabled (#427)
 
 ## 4.0.0 (2021-01-19)
 

--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -12,6 +12,7 @@ use Sentry\Integration\IntegrationInterface;
 use Sentry\Integration\RequestFetcherInterface;
 use Sentry\Integration\RequestIntegration;
 use Sentry\Options;
+use Sentry\SentryBundle\EventListener\ConsoleCommandListener;
 use Sentry\SentryBundle\EventListener\ErrorListener;
 use Sentry\SentryBundle\EventListener\MessengerListener;
 use Sentry\SentryBundle\SentryBundle;
@@ -133,6 +134,8 @@ final class SentryExtension extends ConfigurableExtension
         if (!$config['register_error_listener']) {
             $container->removeDefinition(ErrorListener::class);
         }
+
+        $container->getDefinition(ConsoleCommandListener::class)->setArgument(1, $config['register_error_listener']);
     }
 
     /**

--- a/src/EventListener/ConsoleCommandListener.php
+++ b/src/EventListener/ConsoleCommandListener.php
@@ -22,13 +22,20 @@ final class ConsoleCommandListener
     private $hub;
 
     /**
+     * @var bool Whether to capture console errors
+     */
+    private $captureErrors;
+
+    /**
      * Constructor.
      *
-     * @param HubInterface $hub The current hub
+     * @param HubInterface $hub           The current hub
+     * @param bool         $captureErrors Whether to capture console errors
      */
-    public function __construct(HubInterface $hub)
+    public function __construct(HubInterface $hub, bool $captureErrors = true)
     {
         $this->hub = $hub;
+        $this->captureErrors = $captureErrors;
     }
 
     /**
@@ -66,7 +73,9 @@ final class ConsoleCommandListener
         $this->hub->configureScope(function (Scope $scope) use ($event): void {
             $scope->setTag('console.command.exit_code', (string) $event->getExitCode());
 
-            $this->hub->captureException($event->getError());
+            if ($this->captureErrors) {
+                $this->hub->captureException($event->getError());
+            }
         });
     }
 }

--- a/tests/DependencyInjection/SentryExtensionTest.php
+++ b/tests/DependencyInjection/SentryExtensionTest.php
@@ -79,6 +79,16 @@ abstract class SentryExtensionTest extends TestCase
                 ],
             ],
         ], $definition->getTags());
+
+        $this->assertTrue($definition->getArgument(1));
+    }
+
+    public function testConsoleCommandListenerDoesNotCaptureErrorsWhenErrorListenerIsDisabled(): void
+    {
+        $container = $this->createContainerFromFixture('error_listener_disabled');
+        $definition = $container->getDefinition(ConsoleCommandListener::class);
+
+        $this->assertFalse($definition->getArgument(1));
     }
 
     public function testMessengerListener(): void


### PR DESCRIPTION
Fixes #424: I made the `ConsoleErrorListener` listener configurable via constructor in regards to its ability of logging console errors. It's common in the Symfony world to use Monolog as logging tool, and if both this listener and the [`Monolog handler`](https://github.com/getsentry/sentry-php/blob/540fd64e20381feeb269e151eb7227fa3aecdb75/src/Monolog/Handler.php) provided by the main PHP SDK capture the errors then logging will be duplicated.