### PR TITLE
Rename the ConsoleCommandListener class to ConsoleListener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added missing `capture-soft-fails` config schema option (#417)
+- Deprecate the `Sentry\SentryBundle\EventListener\ConsoleCommandListener` class in favor of its parent class `Sentry\SentryBundle\EventListener\ConsoleListener` (#429)
 
 ## 4.0.0 (2021-01-19)
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -36,11 +36,6 @@ parameters:
 			path: tests/End2End/End2EndTest.php
 
 		-
-			message: "#^Comparison operation \"\\<\" between 50201 and 40300 is always false\\.$#"
-			count: 1
-			path: tests/End2End/End2EndTest.php
-
-		-
 			message: "#^Parameter \\$event of method Sentry\\\\SentryBundle\\\\Tests\\\\EventListener\\\\ErrorListenerTest\\:\\:testHandleExceptionEvent\\(\\) has invalid typehint type Symfony\\\\Component\\\\HttpKernel\\\\Event\\\\GetResponseForExceptionEvent\\.$#"
 			count: 1
 			path: tests/EventListener/ErrorListenerTest.php

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,7 +7,7 @@
          beStrictAboutOutputDuringTests="true"
 >
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
     </php>
 
     <testsuites>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="4.4.1@9fd7a7d885b3a216cff8dec9d8c21a132f275224">
+  <file src="src/EventListener/ConsoleCommandListener.php">
+    <InvalidExtendClass occurrences="1">
+      <code>ConsoleListener</code>
+    </InvalidExtendClass>
+    <MethodSignatureMismatch occurrences="1">
+      <code>public function __construct(HubInterface $hub)</code>
+    </MethodSignatureMismatch>
+  </file>
+</files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <psalm
     errorLevel="4"
-    resolveFromConfigFile="true"
     memoizeMethodCallResults="true"
+    errorBaseline="psalm-baseline.xml"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/src/EventListener/ConsoleCommandListener.php
+++ b/src/EventListener/ConsoleCommandListener.php
@@ -4,69 +4,11 @@ declare(strict_types=1);
 
 namespace Sentry\SentryBundle\EventListener;
 
-use Sentry\State\HubInterface;
-use Sentry\State\Scope;
-use Symfony\Component\Console\Event\ConsoleCommandEvent;
-use Symfony\Component\Console\Event\ConsoleErrorEvent;
-use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+@trigger_error(sprintf('The "%s" class is deprecated since version 4.1 and will be removed in 5.0. Use "%s" instead.', ConsoleCommandListener::class, ConsoleListener::class), \E_USER_DEPRECATED);
 
 /**
- * This listener handles all errors thrown while running a console command and
- * logs them to Sentry.
+ * @deprecated since version 4.1, to be removed in 5.0
  */
-final class ConsoleCommandListener
+final class ConsoleCommandListener extends ConsoleListener
 {
-    /**
-     * @var HubInterface The current hub
-     */
-    private $hub;
-
-    /**
-     * Constructor.
-     *
-     * @param HubInterface $hub The current hub
-     */
-    public function __construct(HubInterface $hub)
-    {
-        $this->hub = $hub;
-    }
-
-    /**
-     * Handles the execution of a console command by pushing a new {@see Scope}.
-     *
-     * @param ConsoleCommandEvent $event The event
-     */
-    public function handleConsoleCommandEvent(ConsoleCommandEvent $event): void
-    {
-        $scope = $this->hub->pushScope();
-        $command = $event->getCommand();
-
-        if (null !== $command && null !== $command->getName()) {
-            $scope->setTag('console.command', $command->getName());
-        }
-    }
-
-    /**
-     * Handles the termination of a console command by popping the {@see Scope}.
-     *
-     * @param ConsoleTerminateEvent $event The event
-     */
-    public function handleConsoleTerminateEvent(ConsoleTerminateEvent $event): void
-    {
-        $this->hub->popScope();
-    }
-
-    /**
-     * Handles an error that happened while running a console command.
-     *
-     * @param ConsoleErrorEvent $event The event
-     */
-    public function handleConsoleErrorEvent(ConsoleErrorEvent $event): void
-    {
-        $this->hub->configureScope(function (Scope $scope) use ($event): void {
-            $scope->setTag('console.command.exit_code', (string) $event->getExitCode());
-
-            $this->hub->captureException($event->getError());
-        });
-    }
 }

--- a/src/EventListener/ConsoleCommandListener.php
+++ b/src/EventListener/ConsoleCommandListener.php
@@ -4,11 +4,17 @@ declare(strict_types=1);
 
 namespace Sentry\SentryBundle\EventListener;
 
-@trigger_error(sprintf('The "%s" class is deprecated since version 4.1 and will be removed in 5.0. Use "%s" instead.', ConsoleCommandListener::class, ConsoleListener::class), \E_USER_DEPRECATED);
+use Sentry\State\HubInterface;
 
 /**
  * @deprecated since version 4.1, to be removed in 5.0
  */
 final class ConsoleCommandListener extends ConsoleListener
 {
+    public function __construct(HubInterface $hub)
+    {
+        parent::__construct($hub);
+
+        @trigger_error(sprintf('The "%s" class is deprecated since version 4.1 and will be removed in 5.0. Use "%s" instead.', self::class, ConsoleListener::class), \E_USER_DEPRECATED);
+    }
 }

--- a/src/EventListener/ConsoleListener.php
+++ b/src/EventListener/ConsoleListener.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\EventListener;
+
+use Sentry\State\HubInterface;
+use Sentry\State\Scope;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Event\ConsoleErrorEvent;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+
+/**
+ * This listener handles all errors thrown while running a console command and
+ * logs them to Sentry.
+ *
+ * @final since version 4.1
+ */
+class ConsoleListener
+{
+    /**
+     * @var HubInterface The current hub
+     */
+    private $hub;
+
+    /**
+     * Constructor.
+     *
+     * @param HubInterface $hub The current hub
+     */
+    public function __construct(HubInterface $hub)
+    {
+        $this->hub = $hub;
+    }
+
+    /**
+     * Handles the execution of a console command by pushing a new {@see Scope}.
+     *
+     * @param ConsoleCommandEvent $event The event
+     */
+    public function handleConsoleCommandEvent(ConsoleCommandEvent $event): void
+    {
+        $scope = $this->hub->pushScope();
+        $command = $event->getCommand();
+
+        if (null !== $command && null !== $command->getName()) {
+            $scope->setTag('console.command', $command->getName());
+        }
+    }
+
+    /**
+     * Handles the termination of a console command by popping the {@see Scope}.
+     *
+     * @param ConsoleTerminateEvent $event The event
+     */
+    public function handleConsoleTerminateEvent(ConsoleTerminateEvent $event): void
+    {
+        $this->hub->popScope();
+    }
+
+    /**
+     * Handles an error that happened while running a console command.
+     *
+     * @param ConsoleErrorEvent $event The event
+     */
+    public function handleConsoleErrorEvent(ConsoleErrorEvent $event): void
+    {
+        $this->hub->configureScope(function (Scope $scope) use ($event): void {
+            $scope->setTag('console.command.exit_code', (string) $event->getExitCode());
+
+            $this->hub->captureException($event->getError());
+        });
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -23,7 +23,9 @@
             </call>
         </service>
 
-        <service id="Sentry\SentryBundle\EventListener\ConsoleCommandListener" class="Sentry\SentryBundle\EventListener\ConsoleCommandListener">
+        <service id="Sentry\SentryBundle\EventListener\ConsoleCommandListener" alias="Sentry\SentryBundle\EventListener\ConsoleListener" />
+
+        <service id="Sentry\SentryBundle\EventListener\ConsoleListener" class="Sentry\SentryBundle\EventListener\ConsoleListener">
             <argument type="service" id="Sentry\State\HubInterface" />
 
             <tag name="kernel.event_listener" event="console.command" method="handleConsoleCommandEvent" priority="128" />

--- a/tests/DependencyInjection/SentryExtensionTest.php
+++ b/tests/DependencyInjection/SentryExtensionTest.php
@@ -10,7 +10,7 @@ use Sentry\ClientInterface;
 use Sentry\Integration\IgnoreErrorsIntegration;
 use Sentry\Options;
 use Sentry\SentryBundle\DependencyInjection\SentryExtension;
-use Sentry\SentryBundle\EventListener\ConsoleCommandListener;
+use Sentry\SentryBundle\EventListener\ConsoleListener;
 use Sentry\SentryBundle\EventListener\ErrorListener;
 use Sentry\SentryBundle\EventListener\MessengerListener;
 use Sentry\SentryBundle\EventListener\RequestListener;
@@ -57,9 +57,9 @@ abstract class SentryExtensionTest extends TestCase
     public function testConsoleCommandListener(): void
     {
         $container = $this->createContainerFromFixture('full');
-        $definition = $container->getDefinition(ConsoleCommandListener::class);
+        $definition = $container->findDefinition(ConsoleListener::class);
 
-        $this->assertSame(ConsoleCommandListener::class, $definition->getClass());
+        $this->assertSame(ConsoleListener::class, $definition->getClass());
         $this->assertSame([
             'kernel.event_listener' => [
                 [

--- a/tests/End2End/End2EndTest.php
+++ b/tests/End2End/End2EndTest.php
@@ -255,7 +255,7 @@ class End2EndTest extends WebTestCase
 
     private function skipIfMessengerIsMissing(): void
     {
-        if (!interface_exists(MessageBusInterface::class) || Kernel::VERSION_ID < 40300) {
+        if (!interface_exists(MessageBusInterface::class)) {
             $this->markTestSkipped('Messenger missing');
         }
     }

--- a/tests/EventListener/AbstractConsoleListenerTest.php
+++ b/tests/EventListener/AbstractConsoleListenerTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\EventListener;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sentry\Event;
+use Sentry\SentryBundle\EventListener\ConsoleListener;
+use Sentry\State\HubInterface;
+use Sentry\State\Scope;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Event\ConsoleErrorEvent;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+abstract class AbstractConsoleListenerTest extends TestCase
+{
+    /**
+     * @var MockObject&HubInterface
+     */
+    private $hub;
+
+    /**
+     * @var ConsoleListener
+     */
+    private $listener;
+
+    protected function setUp(): void
+    {
+        $listenerClass = static::getListenerClass();
+
+        $this->hub = $this->createMock(HubInterface::class);
+        $this->listener = new $listenerClass($this->hub);
+    }
+
+    /**
+     * @dataProvider handleConsoleCommmandEventDataProvider
+     *
+     * @param array<string, string> $expectedTags
+     */
+    public function testHandleConsoleCommandEvent(ConsoleCommandEvent $consoleEvent, array $expectedTags): void
+    {
+        $scope = new Scope();
+
+        $this->hub->expects($this->once())
+            ->method('pushScope')
+            ->willReturn($scope);
+
+        $this->listener->handleConsoleCommandEvent($consoleEvent);
+
+        $event = $scope->applyToEvent(Event::createEvent());
+
+        $this->assertSame($expectedTags, $event->getTags());
+    }
+
+    /**
+     * @return \Generator<mixed>
+     */
+    public function handleConsoleCommmandEventDataProvider(): \Generator
+    {
+        yield [
+            new ConsoleCommandEvent(null, $this->createMock(InputInterface::class), $this->createMock(OutputInterface::class)),
+            [],
+        ];
+
+        yield [
+            new ConsoleCommandEvent(new Command(), $this->createMock(InputInterface::class), $this->createMock(OutputInterface::class)),
+            [],
+        ];
+
+        yield [
+            new ConsoleCommandEvent(new Command('foo:bar'), $this->createMock(InputInterface::class), $this->createMock(OutputInterface::class)),
+            ['console.command' => 'foo:bar'],
+        ];
+    }
+
+    public function testHandleConsoleTerminateEvent(): void
+    {
+        $this->hub->expects($this->once())
+            ->method('popScope');
+
+        $this->listener->handleConsoleTerminateEvent(new ConsoleTerminateEvent(new Command(), $this->createMock(InputInterface::class), $this->createMock(OutputInterface::class), 0));
+    }
+
+    public function testHandleConsoleErrorEvent(): void
+    {
+        $scope = new Scope();
+        $consoleEvent = new ConsoleErrorEvent($this->createMock(InputInterface::class), $this->createMock(OutputInterface::class), new \Exception());
+
+        $this->hub->expects($this->once())
+            ->method('configureScope')
+            ->willReturnCallback(static function (callable $callback) use ($scope): void {
+                $callback($scope);
+            });
+
+        $this->hub->expects($this->once())
+            ->method('captureException')
+            ->with($consoleEvent->getError());
+
+        $this->listener->handleConsoleErrorEvent($consoleEvent);
+
+        $event = $scope->applyToEvent(Event::createEvent());
+
+        $this->assertSame(['console.command.exit_code' => '1'], $event->getTags());
+    }
+
+    /**
+     * @return class-string<ConsoleListener>
+     */
+    abstract protected static function getListenerClass(): string;
+}

--- a/tests/EventListener/ConsoleCommandListenerTest.php
+++ b/tests/EventListener/ConsoleCommandListenerTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\EventListener;
+
+use Sentry\SentryBundle\EventListener\ConsoleCommandListener;
+
+/**
+ * @group legacy
+ *
+ * @deprecated since version 4.1, to be removed in 5.0
+ */
+final class ConsoleCommandListenerTest extends AbstractConsoleListenerTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected static function getListenerClass(): string
+    {
+        return ConsoleCommandListener::class;
+    }
+}

--- a/tests/EventListener/ConsoleListenerTest.php
+++ b/tests/EventListener/ConsoleListenerTest.php
@@ -7,7 +7,7 @@ namespace Sentry\SentryBundle\Tests\EventListener;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sentry\Event;
-use Sentry\SentryBundle\EventListener\ConsoleCommandListener;
+use Sentry\SentryBundle\EventListener\ConsoleListener;
 use Sentry\State\HubInterface;
 use Sentry\State\Scope;
 use Symfony\Component\Console\Command\Command;
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class ConsoleCommandListenerTest extends TestCase
+final class ConsoleListenerTest extends TestCase
 {
     /**
      * @var MockObject&HubInterface
@@ -25,14 +25,14 @@ final class ConsoleCommandListenerTest extends TestCase
     private $hub;
 
     /**
-     * @var ConsoleCommandListener
+     * @var ConsoleListener
      */
     private $listener;
 
     protected function setUp(): void
     {
         $this->hub = $this->createMock(HubInterface::class);
-        $this->listener = new ConsoleCommandListener($this->hub);
+        $this->listener = new ConsoleListener($this->hub);
     }
 
     /**

--- a/tests/EventListener/ConsoleListenerTest.php
+++ b/tests/EventListener/ConsoleListenerTest.php
@@ -4,105 +4,15 @@ declare(strict_types=1);
 
 namespace Sentry\SentryBundle\Tests\EventListener;
 
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
-use Sentry\Event;
 use Sentry\SentryBundle\EventListener\ConsoleListener;
-use Sentry\State\HubInterface;
-use Sentry\State\Scope;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Event\ConsoleCommandEvent;
-use Symfony\Component\Console\Event\ConsoleErrorEvent;
-use Symfony\Component\Console\Event\ConsoleTerminateEvent;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 
-final class ConsoleListenerTest extends TestCase
+final class ConsoleListenerTest extends AbstractConsoleListenerTest
 {
     /**
-     * @var MockObject&HubInterface
+     * {@inheritdoc}
      */
-    private $hub;
-
-    /**
-     * @var ConsoleListener
-     */
-    private $listener;
-
-    protected function setUp(): void
+    protected static function getListenerClass(): string
     {
-        $this->hub = $this->createMock(HubInterface::class);
-        $this->listener = new ConsoleListener($this->hub);
-    }
-
-    /**
-     * @dataProvider handleConsoleCommmandEventDataProvider
-     *
-     * @param array<string, string> $expectedTags
-     */
-    public function testHandleConsoleCommandEvent(ConsoleCommandEvent $consoleEvent, array $expectedTags): void
-    {
-        $scope = new Scope();
-
-        $this->hub->expects($this->once())
-            ->method('pushScope')
-            ->willReturn($scope);
-
-        $this->listener->handleConsoleCommandEvent($consoleEvent);
-
-        $event = $scope->applyToEvent(Event::createEvent());
-
-        $this->assertSame($expectedTags, $event->getTags());
-    }
-
-    /**
-     * @return \Generator<mixed>
-     */
-    public function handleConsoleCommmandEventDataProvider(): \Generator
-    {
-        yield [
-            new ConsoleCommandEvent(null, $this->createMock(InputInterface::class), $this->createMock(OutputInterface::class)),
-            [],
-        ];
-
-        yield [
-            new ConsoleCommandEvent(new Command(), $this->createMock(InputInterface::class), $this->createMock(OutputInterface::class)),
-            [],
-        ];
-
-        yield [
-            new ConsoleCommandEvent(new Command('foo:bar'), $this->createMock(InputInterface::class), $this->createMock(OutputInterface::class)),
-            ['console.command' => 'foo:bar'],
-        ];
-    }
-
-    public function testHandleConsoleTerminateEvent(): void
-    {
-        $this->hub->expects($this->once())
-            ->method('popScope');
-
-        $this->listener->handleConsoleTerminateEvent(new ConsoleTerminateEvent(new Command(), $this->createMock(InputInterface::class), $this->createMock(OutputInterface::class), 0));
-    }
-
-    public function testHandleConsoleErrorEvent(): void
-    {
-        $scope = new Scope();
-        $consoleEvent = new ConsoleErrorEvent($this->createMock(InputInterface::class), $this->createMock(OutputInterface::class), new \Exception());
-
-        $this->hub->expects($this->once())
-            ->method('configureScope')
-            ->willReturnCallback(static function (callable $callback) use ($scope): void {
-                $callback($scope);
-            });
-
-        $this->hub->expects($this->once())
-            ->method('captureException')
-            ->with($consoleEvent->getError());
-
-        $this->listener->handleConsoleErrorEvent($consoleEvent);
-
-        $event = $scope->applyToEvent(Event::createEvent());
-
-        $this->assertSame(['console.command.exit_code' => '1'], $event->getTags());
+        return ConsoleListener::class;
     }
 }


### PR DESCRIPTION
Small change that deprecates the `Sentry\SentryBundle\EventListener\ConsoleCommandListener` class (and service) in favor of `Sentry\SentryBundle\EventListener\ConsoleListener`. The reason behind it is that the event listener actually handles more than just an event related to the specific command