### PR TITLE
Implementation of optional sentry tracing with twig

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -104,7 +104,7 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.php }}-composer-${{ matrix.dependencies }}-
 
       - name: Remove optional packages
-        run: composer remove doctrine/dbal doctrine/doctrine-bundle symfony/messenger --dev --no-update
+        run: composer remove doctrine/dbal doctrine/doctrine-bundle symfony/messenger symfony/twig-bundle --dev --no-update
 
       - name: Install highest dependencies
         run: composer update --no-progress --no-interaction --prefer-dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add support for distributed tracing of Twig template rendering (#430)
 - Add support for distributed tracing of SQL queries while using Doctrine DBAL (#426)
 - Added missing `capture-soft-fails` config schema option (#417)
 - Deprecate the `Sentry\SentryBundle\EventListener\ConsoleCommandListener` class in favor of its parent class `Sentry\SentryBundle\EventListener\ConsoleListener` (#429)

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ psalm:
 test:
 	vendor/bin/phpunit
 
-pre-commit-check: cs phpstan test
+pre-commit-check: cs phpstan psalm test
 
 setup-git:
 	git config branch.autosetuprebase always

--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,13 @@
         "jean85/pretty-package-versions": "^1.5 || ^2.0",
         "php-http/discovery": "^1.11",
         "sentry/sdk": "^3.1",
-        "symfony/config": "^3.4.44||^4.4.11||^5.0.11",
-        "symfony/console": "^3.4.44||^4.4.11||^5.0.11",
-        "symfony/dependency-injection": "^3.4.44||^4.4.11||^5.0.11",
-        "symfony/event-dispatcher": "^3.4.44||^4.4.11||^5.0.11",
-        "symfony/http-kernel": "^3.4.44||^4.4.11||^5.0.11",
+        "symfony/config": "^3.4.44||^4.4.12||^5.0.11",
+        "symfony/console": "^3.4.44||^4.4.12||^5.0.11",
+        "symfony/dependency-injection": "^3.4.44||^4.4.12||^5.0.11",
+        "symfony/event-dispatcher": "^3.4.44||^4.4.12||^5.0.11",
+        "symfony/http-kernel": "^3.4.44||^4.4.12||^5.0.11",
         "symfony/psr-http-message-bridge": "^2.0",
-        "symfony/security-core": "^3.4.44||^4.4.11||^5.0.11"
+        "symfony/security-core": "^3.4.44||^4.4.12||^5.0.11"
     },
     "require-dev": {
         "doctrine/dbal": "^2.10||^3.0",
@@ -46,18 +46,18 @@
         "symfony/browser-kit": "^3.4.44||^4.4.12||^5.0.11",
         "symfony/dom-crawler": "^3.4.44||^4.4.12||^5.0.11",
         "symfony/framework-bundle": "^3.4.44||^4.4.12||^5.0.11",
-        "symfony/messenger": "^4.4.11||^5.0.11",
+        "symfony/messenger": "^4.4.12||^5.0.11",
         "symfony/monolog-bundle": "^3.4",
         "symfony/phpunit-bridge": "^5.0",
         "symfony/polyfill-php80": "^1.22",
         "symfony/twig-bundle": "^3.4.44||^4.4.12||^5.0.11",
-        "symfony/yaml": "^3.4.44||^4.4.11||^5.0.11",
+        "symfony/yaml": "^3.4.44||^4.4.12||^5.0.11",
         "vimeo/psalm": "^4.3"
     },
     "suggest": {
         "monolog/monolog": "Allow sending log messages to Sentry by using the included Monolog handler.",
         "doctrine/doctrine-bundle": "Allow distributed tracing of database queries using Sentry.",
-        "symfony/twig-bundle": "Allow distributed tracing of twig template rendering using Sentry."
+        "symfony/twig-bundle": "Allow distributed tracing of Twig template rendering using Sentry."
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -50,12 +50,14 @@
         "symfony/monolog-bundle": "^3.4",
         "symfony/phpunit-bridge": "^5.0",
         "symfony/polyfill-php80": "^1.22",
+        "symfony/twig-bundle": "^3.4.44||^4.4.12||^5.0.11",
         "symfony/yaml": "^3.4.44||^4.4.11||^5.0.11",
         "vimeo/psalm": "^4.3"
     },
     "suggest": {
         "monolog/monolog": "Allow sending log messages to Sentry by using the included Monolog handler.",
-        "doctrine/doctrine-bundle": "Allow distributed tracing of database queries using Sentry."
+        "doctrine/doctrine-bundle": "Allow distributed tracing of database queries using Sentry.",
+        "symfony/twig-bundle": "Allow distributed tracing of twig template rendering using Sentry."
     },
     "autoload": {
         "files": [

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -96,6 +96,16 @@ parameters:
 			path: src/Tracing/Doctrine/DBAL/TracingDriverConnection.php
 
 		-
+			message: "#^Method Sentry\\\\SentryBundle\\\\Tracing\\\\Twig\\\\TwigTracingExtension\\:\\:enter\\(\\) has parameter \\$profile with no value type specified in iterable type Twig\\\\Profiler\\\\Profile\\.$#"
+			count: 1
+			path: src/Tracing/Twig/TwigTracingExtension.php
+
+		-
+			message: "#^Method Sentry\\\\SentryBundle\\\\Tracing\\\\Twig\\\\TwigTracingExtension\\:\\:leave\\(\\) has parameter \\$profile with no value type specified in iterable type Twig\\\\Profiler\\\\Profile\\.$#"
+			count: 1
+			path: src/Tracing/Twig/TwigTracingExtension.php
+
+		-
 			message: "#^Class Symfony\\\\Component\\\\HttpKernel\\\\Event\\\\GetResponseForExceptionEvent not found\\.$#"
 			count: 1
 			path: src/aliases.php
@@ -219,4 +229,3 @@ parameters:
 			message: "#^Trying to mock an undefined method convertException\\(\\) on class Sentry\\\\SentryBundle\\\\Tests\\\\Tracing\\\\Doctrine\\\\DBAL\\\\StubExceptionConverterDriverInterface\\.$#"
 			count: 1
 			path: tests/Tracing/Doctrine/DBAL/TracingDriverTest.php
-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -96,16 +96,6 @@ parameters:
 			path: src/Tracing/Doctrine/DBAL/TracingDriverConnection.php
 
 		-
-			message: "#^Method Sentry\\\\SentryBundle\\\\Tracing\\\\Twig\\\\TwigTracingExtension\\:\\:enter\\(\\) has parameter \\$profile with no value type specified in iterable type Twig\\\\Profiler\\\\Profile\\.$#"
-			count: 1
-			path: src/Tracing/Twig/TwigTracingExtension.php
-
-		-
-			message: "#^Method Sentry\\\\SentryBundle\\\\Tracing\\\\Twig\\\\TwigTracingExtension\\:\\:leave\\(\\) has parameter \\$profile with no value type specified in iterable type Twig\\\\Profiler\\\\Profile\\.$#"
-			count: 1
-			path: src/Tracing/Twig/TwigTracingExtension.php
-
-		-
 			message: "#^Class Symfony\\\\Component\\\\HttpKernel\\\\Event\\\\GetResponseForExceptionEvent not found\\.$#"
 			count: 1
 			path: src/aliases.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,3 +11,5 @@ parameters:
     dynamicConstantNames:
         - Symfony\Component\HttpKernel\Kernel::VERSION
         - Doctrine\DBAL\Version::VERSION
+    stubFiles:
+        - tests/Stubs/Profile.phpstub

--- a/psalm.xml
+++ b/psalm.xml
@@ -13,6 +13,7 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
+
     <stubs>
         <file name="tests/Stubs/Profile.phpstub"/>
     </stubs>

--- a/psalm.xml
+++ b/psalm.xml
@@ -13,4 +13,7 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
+    <stubs>
+        <file name="tests/Stubs/Profile.phpstub"/>
+    </stubs>
 </psalm>

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -163,6 +163,9 @@ final class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                         ->end()
+                        ->arrayNode('twig')
+                            ->canBeEnabled()
+                        ->end()
                     ->end()
                 ->end()
             ->end();

--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -19,6 +19,7 @@ use Sentry\SentryBundle\EventListener\MessengerListener;
 use Sentry\SentryBundle\SentryBundle;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\ConnectionConfigurator;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverMiddleware;
+use Sentry\SentryBundle\Tracing\Twig\TwigTracingExtension;
 use Sentry\Serializer\RepresentationSerializer;
 use Sentry\Serializer\Serializer;
 use Sentry\Transport\TransportFactoryInterface;
@@ -62,6 +63,7 @@ final class SentryExtension extends ConfigurableExtension
         $this->registerErrorListenerConfiguration($container, $mergedConfig);
         $this->registerMessengerListenerConfiguration($container, $mergedConfig['messenger']);
         $this->registerTracingConfiguration($container, $mergedConfig['tracing']);
+        $this->registerTracingTwigExtensionConfiguration($container, $mergedConfig['tracing']);
     }
 
     /**
@@ -170,6 +172,18 @@ final class SentryExtension extends ConfigurableExtension
         if (!$isConfigEnabled) {
             $container->removeDefinition(ConnectionConfigurator::class);
             $container->removeDefinition(TracingDriverMiddleware::class);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function registerTracingTwigExtensionConfiguration(ContainerBuilder $container, array $config): void
+    {
+        $isConfigEnabled = $this->isConfigEnabled($container, $config['twig']);
+
+        if (!$isConfigEnabled) {
+            $container->removeDefinition(TwigTracingExtension::class);
         }
     }
 

--- a/src/Resources/config/schema/sentry-1.0.xsd
+++ b/src/Resources/config/schema/sentry-1.0.xsd
@@ -95,6 +95,7 @@
 
         <xsd:attribute name="enabled" type="xsd:boolean" />
     </xsd:complexType>
+
     <xsd:complexType name="tracing-twig">
         <xsd:attribute name="enabled" type="xsd:boolean" />
     </xsd:complexType>

--- a/src/Resources/config/schema/sentry-1.0.xsd
+++ b/src/Resources/config/schema/sentry-1.0.xsd
@@ -84,6 +84,7 @@
     <xsd:complexType name="tracing">
         <xsd:choice maxOccurs="unbounded">
             <xsd:element name="dbal" type="tracing-dbal" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="twig" type="tracing-twig" minOccurs="0" maxOccurs="1" />
         </xsd:choice>
     </xsd:complexType>
 
@@ -92,6 +93,9 @@
             <xsd:element name="connection" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
         </xsd:sequence>
 
+        <xsd:attribute name="enabled" type="xsd:boolean" />
+    </xsd:complexType>
+    <xsd:complexType name="tracing-twig">
         <xsd:attribute name="enabled" type="xsd:boolean" />
     </xsd:complexType>
 </xsd:schema>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -73,6 +73,11 @@
             <argument type="service" id="Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverMiddleware" />
         </service>
 
+        <service id="Sentry\SentryBundle\Tracing\Twig\TwigTracingExtension" class="Sentry\SentryBundle\Tracing\Twig\TwigTracingExtension">
+            <argument type="service" id="Sentry\State\HubInterface" />
+            <tag name="twig.extension" />
+        </service>
+
         <service id="Sentry\Integration\RequestFetcherInterface" class="Sentry\SentryBundle\Integration\RequestFetcher">
             <argument type="service" id="Symfony\Component\HttpFoundation\RequestStack" />
             <argument type="service" id="Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface" on-invalid="null" />

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -75,6 +75,7 @@
 
         <service id="Sentry\SentryBundle\Tracing\Twig\TwigTracingExtension" class="Sentry\SentryBundle\Tracing\Twig\TwigTracingExtension">
             <argument type="service" id="Sentry\State\HubInterface" />
+
             <tag name="twig.extension" />
         </service>
 

--- a/src/Tracing/Twig/TwigTracingExtension.php
+++ b/src/Tracing/Twig/TwigTracingExtension.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tracing\Twig;
+
+use Sentry\State\HubInterface;
+use Sentry\Tracing\SpanContext;
+use SplObjectStorage;
+use Twig\Extension\AbstractExtension;
+use Twig\Profiler\NodeVisitor\ProfilerNodeVisitor;
+use Twig\Profiler\Profile;
+
+final class TwigTracingExtension extends AbstractExtension
+{
+    /**
+     * @var HubInterface The current hub
+     */
+    private $hub;
+
+    /**
+     * @var SplObjectStorage<object, \Sentry\Tracing\Span>
+     */
+    private $events;
+
+    /**
+     * @param HubInterface $hub The current hub
+     */
+    public function __construct(HubInterface $hub)
+    {
+        $this->hub = $hub;
+        $this->events = new SplObjectStorage();
+    }
+
+    public function enter(Profile $profile): void
+    {
+        $transaction = $this->hub->getTransaction();
+
+        if (null === $transaction || !$profile->isTemplate()) {
+            return;
+        }
+
+        $spanContext = new SpanContext();
+        $spanContext->setOp('twig.template');
+        $spanContext->setDescription($profile->getName());
+
+        $this->events[$profile] = $transaction->startChild($spanContext);
+    }
+
+    public function leave(Profile $profile): void
+    {
+        if (empty($this->events[$profile]) || !$profile->isTemplate()) {
+            return;
+        }
+
+        $this->events[$profile]->finish();
+        unset($this->events[$profile]);
+    }
+
+    public function getNodeVisitors(): array
+    {
+        return [new ProfilerNodeVisitor(static::class)];
+    }
+}

--- a/src/Tracing/Twig/TwigTracingExtension.php
+++ b/src/Tracing/Twig/TwigTracingExtension.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sentry\SentryBundle\Tracing\Twig;
 
 use Sentry\State\HubInterface;
+use Sentry\Tracing\Span;
 use Sentry\Tracing\SpanContext;
 use SplObjectStorage;
 use Twig\Extension\AbstractExtension;
@@ -19,9 +20,9 @@ final class TwigTracingExtension extends AbstractExtension
     private $hub;
 
     /**
-     * @var SplObjectStorage<object, \Sentry\Tracing\Span>
+     * @var SplObjectStorage<object, Span> The currently active spans
      */
-    private $events;
+    private $spans;
 
     /**
      * @param HubInterface $hub The current hub
@@ -29,36 +30,73 @@ final class TwigTracingExtension extends AbstractExtension
     public function __construct(HubInterface $hub)
     {
         $this->hub = $hub;
-        $this->events = new SplObjectStorage();
+        $this->spans = new SplObjectStorage();
     }
 
+    /**
+     * This method is called before the execution of a block, a macro or a
+     * template.
+     *
+     * @param Profile $profile The profiling data
+     */
     public function enter(Profile $profile): void
     {
         $transaction = $this->hub->getTransaction();
 
-        if (null === $transaction || !$profile->isTemplate()) {
+        if (null === $transaction) {
             return;
         }
 
         $spanContext = new SpanContext();
-        $spanContext->setOp('twig.template');
-        $spanContext->setDescription($profile->getName());
+        $spanContext->setOp('view.render');
+        $spanContext->setDescription($this->getSpanDescription($profile));
 
-        $this->events[$profile] = $transaction->startChild($spanContext);
+        $this->spans[$profile] = $transaction->startChild($spanContext);
     }
 
+    /**
+     * This method is called when the execution of a block, a macro or a
+     * template is finished.
+     *
+     * @param Profile $profile The profiling data
+     */
     public function leave(Profile $profile): void
     {
-        if (empty($this->events[$profile]) || !$profile->isTemplate()) {
+        if (!isset($this->spans[$profile])) {
             return;
         }
 
-        $this->events[$profile]->finish();
-        unset($this->events[$profile]);
+        $this->spans[$profile]->finish();
+
+        unset($this->spans[$profile]);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getNodeVisitors(): array
     {
-        return [new ProfilerNodeVisitor(static::class)];
+        return [
+            new ProfilerNodeVisitor(self::class),
+        ];
+    }
+
+    /**
+     * Gets a short description for the span.
+     *
+     * @param Profile $profile The profiling data
+     */
+    private function getSpanDescription(Profile $profile): string
+    {
+        switch (true) {
+            case $profile->isRoot():
+                return $profile->getName();
+
+            case $profile->isTemplate():
+                return $profile->getTemplate();
+
+            default:
+                return sprintf('%s::%s(%s)', $profile->getTemplate(), $profile->getType(), $profile->getName());
+        }
     }
 }

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -41,6 +41,9 @@ final class ConfigurationTest extends TestCase
                     'enabled' => false,
                     'connections' => class_exists(DoctrineBundle::class) ? ['%doctrine.default_connection%'] : [],
                 ],
+                'twig' => [
+                    'enabled' => false,
+                ],
             ],
         ];
 

--- a/tests/DependencyInjection/Fixtures/php/full.php
+++ b/tests/DependencyInjection/Fixtures/php/full.php
@@ -47,5 +47,8 @@ $container->loadFromExtension('sentry', [
             'enabled' => false,
             'connections' => ['default'],
         ],
+        'twig' => [
+            'enabled' => false,
+        ],
     ],
 ]);

--- a/tests/DependencyInjection/Fixtures/php/twig_tracing_enabled.php
+++ b/tests/DependencyInjection/Fixtures/php/twig_tracing_enabled.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/** @var ContainerBuilder $container */
+$container->loadFromExtension('sentry', [
+    'tracing' => [
+        'twig' => [
+            'enabled' => true,
+        ],
+    ],
+]);

--- a/tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/tests/DependencyInjection/Fixtures/xml/full.xml
@@ -41,6 +41,7 @@
             <sentry:dbal enabled="false">
                 <sentry:connection>default</sentry:connection>
             </sentry:dbal>
+            <sentry:twig enabled="false" />
         </sentry:tracing>
     </sentry:config>
 </container>

--- a/tests/DependencyInjection/Fixtures/xml/twig_tracing_enabled.xml
+++ b/tests/DependencyInjection/Fixtures/xml/twig_tracing_enabled.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:sentry="https://sentry.io/schema/dic/sentry-symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                               https://sentry.io/schema/dic/sentry-symfony https://sentry.io/schema/dic/sentry-symfony/sentry-1.0.xsd">
+
+    <sentry:config>
+        <sentry:tracing>
+            <sentry:twig enabled="true" />
+        </sentry:tracing>
+    </sentry:config>
+</container>

--- a/tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/tests/DependencyInjection/Fixtures/yml/full.yml
@@ -42,3 +42,5 @@ sentry:
             enabled: false
             connections:
                 - enabled
+        twig:
+            enabled: false

--- a/tests/DependencyInjection/Fixtures/yml/twig_tracing_enabled.yml
+++ b/tests/DependencyInjection/Fixtures/yml/twig_tracing_enabled.yml
@@ -1,0 +1,4 @@
+sentry:
+    tracing:
+        twig:
+            enabled: true

--- a/tests/DependencyInjection/SentryExtensionTest.php
+++ b/tests/DependencyInjection/SentryExtensionTest.php
@@ -19,6 +19,7 @@ use Sentry\SentryBundle\EventListener\SubRequestListener;
 use Sentry\SentryBundle\SentryBundle;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\ConnectionConfigurator;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverMiddleware;
+use Sentry\SentryBundle\Tracing\Twig\TwigTracingExtension;
 use Sentry\Serializer\RepresentationSerializer;
 use Sentry\Serializer\Serializer;
 use Sentry\Transport\TransportFactoryInterface;
@@ -284,6 +285,20 @@ abstract class SentryExtensionTest extends TestCase
         $this->assertFalse($container->hasDefinition(TracingDriverMiddleware::class));
         $this->assertFalse($container->hasDefinition(ConnectionConfigurator::class));
         $this->assertEmpty($container->getParameter('sentry.tracing.dbal.connections'));
+    }
+
+    public function testTwigTracingExtensionIsConfiguredWhenTwigTracingIsEnabled(): void
+    {
+        $container = $this->createContainerFromFixture('twig_tracing_enabled');
+
+        $this->assertTrue($container->hasDefinition(TwigTracingExtension::class));
+    }
+
+    public function testTwigTracingExtensionIsRemovedWhenTwigTracingIsDisabled(): void
+    {
+        $container = $this->createContainerFromFixture('full');
+
+        $this->assertFalse($container->hasDefinition(TwigTracingExtension::class));
     }
 
     private function createContainerFromFixture(string $fixtureFile): ContainerBuilder

--- a/tests/Stubs/Profile.phpstub
+++ b/tests/Stubs/Profile.phpstub
@@ -1,0 +1,9 @@
+<?php
+
+namespace Twig\Profiler;
+
+/**
+ * @template-implements \IteratorAggregate<Profile, Profile>
+ */
+final class Profile implements \IteratorAggregate, \Serializable
+{}

--- a/tests/Stubs/Profile.phpstub
+++ b/tests/Stubs/Profile.phpstub
@@ -6,4 +6,5 @@ namespace Twig\Profiler;
  * @template-implements \IteratorAggregate<Profile, Profile>
  */
 final class Profile implements \IteratorAggregate, \Serializable
-{}
+{
+}

--- a/tests/Tracing/Twig/TwigTracingExtensionTest.php
+++ b/tests/Tracing/Twig/TwigTracingExtensionTest.php
@@ -10,6 +10,7 @@ use Sentry\SentryBundle\Tracing\Twig\TwigTracingExtension;
 use Sentry\State\HubInterface;
 use Sentry\Tracing\Transaction;
 use Sentry\Tracing\TransactionContext;
+use Symfony\Bundle\TwigBundle\TwigBundle;
 use Twig\Profiler\Profile;
 
 final class TwigTracingExtensionTest extends TestCase
@@ -23,6 +24,13 @@ final class TwigTracingExtensionTest extends TestCase
      * @var TwigTracingExtension
      */
     private $listener;
+
+    public static function setUpBeforeClass(): void
+    {
+        if (!self::isTwigBundlePackageInstalled()) {
+            self::markTestSkipped('This test requires the "symfony/twig-bundle" Composer package to be installed.');
+        }
+    }
 
     protected function setUp(): void
     {
@@ -112,5 +120,10 @@ final class TwigTracingExtensionTest extends TestCase
         $this->expectNotToPerformAssertions();
 
         $this->listener->leave(new Profile('main', Profile::TEMPLATE));
+    }
+
+    private static function isTwigBundlePackageInstalled(): bool
+    {
+        return class_exists(TwigBundle::class);
     }
 }

--- a/tests/Tracing/Twig/TwigTracingExtensionTest.php
+++ b/tests/Tracing/Twig/TwigTracingExtensionTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\Tracing\Twig;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sentry\SentryBundle\Tracing\Twig\TwigTracingExtension;
+use Sentry\State\HubInterface;
+use Sentry\Tracing\Transaction;
+use Sentry\Tracing\TransactionContext;
+use Twig\Profiler\Profile;
+
+final class TwigTracingExtensionTest extends TestCase
+{
+    /**
+     * @var MockObject&HubInterface
+     */
+    private $hub;
+
+    /**
+     * @var TwigTracingExtension
+     */
+    private $listener;
+
+    protected function setUp(): void
+    {
+        $this->hub = $this->createMock(HubInterface::class);
+        $this->listener = new TwigTracingExtension($this->hub);
+    }
+
+    public function testThatTwigEnterProfileIgnoresTracingWhenTransactionIsNotStarted(): void
+    {
+        $this->hub->expects($this->once())
+            ->method('getTransaction')
+            ->willReturn(null);
+
+        $this->listener->enter(new Profile('main', Profile::TEMPLATE));
+    }
+
+    public function testThatTwigEnterProfileIgnoresTracingWhenNotATemplate(): void
+    {
+        $this->hub->expects($this->once())
+            ->method('getTransaction')
+            ->willReturn(new Transaction(new TransactionContext()));
+
+        $this->listener->enter(new Profile('main', Profile::ROOT));
+    }
+
+    public function testThatTwigLeaveProfileIgnoresTracingWhenTransactionIsNotStarted(): void
+    {
+        $this->hub->expects($this->once())
+            ->method('getTransaction')
+            ->willReturn(null);
+
+        $profile = new Profile('main', Profile::TEMPLATE);
+
+        $this->listener->enter($profile);
+        $this->listener->leave($profile);
+    }
+
+    public function testThatTwigLeaveProfileIgnoresTracingWhenNotATemplate(): void
+    {
+        $this->hub->expects($this->once())
+            ->method('getTransaction')
+            ->willReturn(new Transaction(new TransactionContext()));
+
+        $profile = new Profile('main', Profile::ROOT);
+
+        $this->listener->enter($profile);
+        $this->listener->leave($profile);
+    }
+
+    public function testThatTwigEnterProfileAttachesAChildSpanWhenTransactionStarted(): void
+    {
+        $transaction = new Transaction(new TransactionContext());
+        $transaction->initSpanRecorder();
+
+        $this->hub->expects($this->once())
+            ->method('getTransaction')
+            ->willReturn($transaction);
+
+        $this->listener->enter(new Profile('main', Profile::TEMPLATE));
+
+        $spans = $transaction->getSpanRecorder()->getSpans();
+
+        $this->assertCount(2, $spans);
+        $this->assertNull($spans[1]->getEndTimestamp());
+    }
+
+    public function testThatTwigLeaveProfileFinishesTheChildSpanWhenChildSpanStarted(): void
+    {
+        $transaction = new Transaction(new TransactionContext());
+        $transaction->initSpanRecorder();
+
+        $this->hub->expects($this->once())
+            ->method('getTransaction')
+            ->willReturn($transaction);
+
+        $profile = new Profile('main', Profile::TEMPLATE);
+
+        $this->listener->enter($profile);
+        $this->listener->leave($profile);
+
+        $spans = $transaction->getSpanRecorder()->getSpans();
+
+        $this->assertCount(2, $spans);
+        $this->assertNotNull($spans[1]->getEndTimestamp());
+    }
+}


### PR DESCRIPTION
At last ;), the Twig tracing with tests. This also includes the same suggested dependencies fix as the DbalListener. Hopefully git can figure out the merge conflicts :D.

To use Twig tracing you will have to enable the following options:

```
sentry:
    tracing:
        twig:
            enabled: true
```

Good luck!