### PR TITLE
Fix Codecov warning due to too low fetch depth

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,9 +1,9 @@
-minVersion: '0.9.0'
+minVersion: 0.9.0
 github:
   owner: getsentry
   repo: sentry-symfony
 changelogPolicy: simple
-statusProvider: 
+statusProvider:
   name: github
 artifactProvider:
   name: none

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+; top-most EditorConfig file
+root = true
+
+; Unix-style newlines
+[*]
+charset = utf-8
+end_of_line = LF
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.md]
+max_line_length = 80
+
+[*.{yml, yaml}]
+indent_size = 2
+
+[COMMIT_EDITMSG]
+max_line_length = 0

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -1,29 +1,29 @@
 name: Prepare Release
 
 on:
-    workflow_dispatch:
-        inputs:
-            version:
-                description: Version to release
-                required: true
-            force:
-                description: Force a release even when there are release-blockers (optional)
-                required: false
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release
+        required: true
+      force:
+        description: Force a release even when there are release-blockers (optional)
+        required: false
 
 jobs:
-    release:
-        runs-on: ubuntu-latest
-        name: Release version
-        steps:
-            - uses: actions/checkout@v2
-              with:
-                  token: ${{ secrets.GH_RELEASE_PAT }}
-                  fetch-depth: 0
+  release:
+    runs-on: ubuntu-latest
+    name: Release version
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_RELEASE_PAT }}
+          fetch-depth: 0
 
-            - name: Prepare release
-              uses: getsentry/action-prepare-release@v1
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
-              with:
-                  version: ${{ github.event.inputs.version }}
-                  force: ${{ github.event.inputs.force }}
+      - name: Prepare release
+        uses: getsentry/action-prepare-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
+        with:
+          version: ${{ github.event.inputs.version }}
+          force: ${{ github.event.inputs.force }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,6 +44,8 @@ jobs:
     name: PHP ${{ matrix.php }} tests (${{ matrix.description }})
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
       - uses: actions/cache@v2
         with:
           path: ~/.composer/cache/files


### PR DESCRIPTION
Just a copy-paste of getsentry/sentry-php#1188, with the addition of the `.editorconfig` file and subsequent fix of the CS for some YAML files