### PR TITLE
Allow explicit null value for dsn configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## 4.0.3 (2021-03-03)
+- Fix regression from #454 for `null` value on DSN not disabling Sentry (#457)
+
 ## 4.0.2 (2021-03-03)
 
 - Add `kernel.project_dir` to `prefixes` default value to trim paths to the project root (#434)

--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -67,7 +67,7 @@ final class SentryExtension extends ConfigurableExtension
     {
         $options = $config['options'];
 
-        if (isset($config['dsn'])) {
+        if (\array_key_exists('dsn', $config)) {
             $options['dsn'] = $config['dsn'];
         }
 

--- a/tests/DependencyInjection/Fixtures/php/dsn_empty_string.php
+++ b/tests/DependencyInjection/Fixtures/php/dsn_empty_string.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/** @var ContainerBuilder $container */
+$container->loadFromExtension('sentry', [
+    'dsn' => '',
+]);

--- a/tests/DependencyInjection/Fixtures/php/dsn_false.php
+++ b/tests/DependencyInjection/Fixtures/php/dsn_false.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/** @var ContainerBuilder $container */
+$container->loadFromExtension('sentry', [
+    'dsn' => false,
+]);

--- a/tests/DependencyInjection/Fixtures/php/dsn_null.php
+++ b/tests/DependencyInjection/Fixtures/php/dsn_null.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/** @var ContainerBuilder $container */
+$container->loadFromExtension('sentry', [
+    'dsn' => null,
+]);

--- a/tests/DependencyInjection/Fixtures/xml/dsn_empty_string.xml
+++ b/tests/DependencyInjection/Fixtures/xml/dsn_empty_string.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:sentry="https://sentry.io/schema/dic/sentry-symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                               https://sentry.io/schema/dic/sentry-symfony https://sentry.io/schema/dic/sentry-symfony/sentry-1.0.xsd">
+
+    <sentry:config dsn="">
+    </sentry:config>
+</container>

--- a/tests/DependencyInjection/Fixtures/xml/dsn_false.xml
+++ b/tests/DependencyInjection/Fixtures/xml/dsn_false.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:sentry="https://sentry.io/schema/dic/sentry-symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                               https://sentry.io/schema/dic/sentry-symfony https://sentry.io/schema/dic/sentry-symfony/sentry-1.0.xsd">
+
+    <sentry:config dsn="false">
+    </sentry:config>
+</container>

--- a/tests/DependencyInjection/Fixtures/xml/dsn_null.xml
+++ b/tests/DependencyInjection/Fixtures/xml/dsn_null.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:sentry="https://sentry.io/schema/dic/sentry-symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                               https://sentry.io/schema/dic/sentry-symfony https://sentry.io/schema/dic/sentry-symfony/sentry-1.0.xsd">
+
+    <sentry:config dsn="null">
+    </sentry:config>
+</container>

--- a/tests/DependencyInjection/Fixtures/yml/dsn_empty_string.yml
+++ b/tests/DependencyInjection/Fixtures/yml/dsn_empty_string.yml
@@ -1,0 +1,2 @@
+sentry:
+  dsn: ''

--- a/tests/DependencyInjection/Fixtures/yml/dsn_false.yml
+++ b/tests/DependencyInjection/Fixtures/yml/dsn_false.yml
@@ -1,0 +1,2 @@
+sentry:
+  dsn: false

--- a/tests/DependencyInjection/Fixtures/yml/dsn_null.yml
+++ b/tests/DependencyInjection/Fixtures/yml/dsn_null.yml
@@ -1,0 +1,2 @@
+sentry:
+  dsn: ~

--- a/tests/DependencyInjection/SentryExtensionTest.php
+++ b/tests/DependencyInjection/SentryExtensionTest.php
@@ -263,6 +263,21 @@ abstract class SentryExtensionTest extends TestCase
         $this->assertSame(1, $ignoreErrorsIntegrationsCount);
     }
 
+    public function testEmptyDsnIsPropagatedToOptions(): void
+    {
+        $this->assertDsnPropagation('dsn_empty_string', '');
+    }
+
+    public function testFalseDsnIsPropagatedToOptions(): void
+    {
+        $this->assertDsnPropagation('dsn_false', false);
+    }
+
+    public function testNullDsnIsPropagatedToOptions(): void
+    {
+        $this->assertDsnPropagation('dsn_null', null);
+    }
+
     private function createContainerFromFixture(string $fixtureFile): ContainerBuilder
     {
         $container = new ContainerBuilder(new EnvPlaceholderParameterBag([
@@ -291,5 +306,18 @@ abstract class SentryExtensionTest extends TestCase
     {
         $this->assertSame($method, $methodCall[0]);
         $this->assertEquals($arguments, $methodCall[1]);
+    }
+
+    /**
+     * @param mixed $result
+     */
+    private function assertDsnPropagation(string $fixtureFile, $result): void
+    {
+        $container = $this->createContainerFromFixture($fixtureFile);
+        $optionsDefinition = $container->getDefinition('sentry.client.options');
+
+        $this->assertSame(Options::class, $optionsDefinition->getClass());
+        $this->assertTrue(\array_key_exists('dsn', $optionsDefinition->getArgument(0)));
+        $this->assertSame($result, $optionsDefinition->getArgument(0)['dsn']);
     }
 }


### PR DESCRIPTION
The fix in #454 missed this particular line: when the `dsn` configuration option was set to `null`, it was still not forwarded to the actual Sentry options.

Setting it to an empty string does work in 4.0.2, so that can be used as temporary workaround.