### PR TITLE
Improve symfony response times when tracing is enabled

### DIFF
--- a/src/EventListener/TracingRequestListener.php
+++ b/src/EventListener/TracingRequestListener.php
@@ -7,7 +7,7 @@ namespace Sentry\SentryBundle\EventListener;
 use Sentry\Tracing\Transaction;
 use Sentry\Tracing\TransactionContext;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
+use Symfony\Component\HttpKernel\Event\TerminateEvent;
 
 /**
  * This event listener acts on the master requests and starts a transaction
@@ -44,11 +44,11 @@ final class TracingRequestListener extends AbstractTracingRequestListener
 
     /**
      * This method is called for each request handled by the framework and
-     * ends the tracing.
+     * ends the tracing on terminate after the client received the response.
      *
-     * @param FinishRequestEvent $event The event
+     * @param TerminateEvent $event The event
      */
-    public function handleKernelFinishRequestEvent(FinishRequestEvent $event): void
+    public function handleKernelTerminateEvent(TerminateEvent $event): void
     {
         if (!$event->isMasterRequest()) {
             return;

--- a/src/EventListener/TracingRequestListener.php
+++ b/src/EventListener/TracingRequestListener.php
@@ -7,7 +7,6 @@ namespace Sentry\SentryBundle\EventListener;
 use Sentry\Tracing\Transaction;
 use Sentry\Tracing\TransactionContext;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Event\TerminateEvent;
 
 /**
  * This event listener acts on the master requests and starts a transaction
@@ -46,14 +45,10 @@ final class TracingRequestListener extends AbstractTracingRequestListener
      * This method is called for each request handled by the framework and
      * ends the tracing on terminate after the client received the response.
      *
-     * @param TerminateEvent $event The event
+     * @param RequestListenerTerminateEvent $event The event
      */
-    public function handleKernelTerminateEvent(TerminateEvent $event): void
+    public function handleKernelTerminateEvent(RequestListenerTerminateEvent $event): void
     {
-        if (!$event->isMasterRequest()) {
-            return;
-        }
-
         $transaction = $this->hub->getTransaction();
 
         if (null === $transaction) {

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -58,8 +58,8 @@
             <argument type="service" id="Sentry\State\HubInterface" />
 
             <tag name="kernel.event_listener" event="kernel.request" method="handleKernelRequestEvent" priority="4" />
-            <tag name="kernel.event_listener" event="kernel.finish_request" method="handleKernelFinishRequestEvent" priority="5" />
             <tag name="kernel.event_listener" event="kernel.response" method="handleKernelResponseEvent" priority="15" />
+            <tag name="kernel.event_listener" event="kernel.terminate" method="handleKernelTerminateEvent" priority="5" />
         </service>
 
         <service id="Sentry\SentryBundle\EventListener\TracingSubRequestListener" class="Sentry\SentryBundle\EventListener\TracingSubRequestListener">


### PR DESCRIPTION
Improve symfony response times when tracing is enabled by sending
the tracing results on kernel terminate. Kernel terminate happens
after rendering and sending the response to the client so clients
won't notice any delay.

Fixes: https://github.com/getsentry/sentry-symfony/issues/464

Before change:
![Screenshot from 2021-03-13 13-21-59](https://user-images.githubusercontent.com/160743/111029857-460ba700-83ff-11eb-9d07-901520a2f7b8.png)

After change:
![Screenshot from 2021-03-13 13-22-37](https://user-images.githubusercontent.com/160743/111029865-4f950f00-83ff-11eb-8a5f-4dc9d30ef551.png)
