### PR TITLE
Enable the distributed tracing instrumentation by default

### DIFF
--- a/src/DependencyInjection/Compiler/DbalTracingPass.php
+++ b/src/DependencyInjection/Compiler/DbalTracingPass.php
@@ -31,15 +31,19 @@ final class DbalTracingPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container): void
     {
-        if (!$container->hasParameter('doctrine.connections')) {
+        if (!$container->hasParameter('doctrine.connections') || !$container->getParameter('sentry.tracing.dbal.enabled')) {
             return;
         }
 
-        /** @var string[] $connections */
-        $connections = $container->getParameter('doctrine.connections');
-
         /** @var string[] $connectionsToTrace */
         $connectionsToTrace = $container->getParameter('sentry.tracing.dbal.connections');
+
+        /** @var array<string, string> $connections */
+        $connections = $container->getParameter('doctrine.connections');
+
+        if (empty($connectionsToTrace)) {
+            $connectionsToTrace = array_keys($connections);
+        }
 
         foreach ($connectionsToTrace as $connectionName) {
             if (!\in_array(sprintf(self::CONNECTION_SERVICE_NAME_FORMAT, $connectionName), $connections, true)) {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -8,6 +8,7 @@ use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Jean85\PrettyVersions;
 use Sentry\Options;
 use Sentry\SentryBundle\ErrorTypesParser;
+use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -150,17 +151,16 @@ final class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->arrayNode('dbal')
-                            ->canBeEnabled()
+                            ->{class_exists(DoctrineBundle::class) ? 'canBeDisabled' : 'canBeEnabled'}()
                             ->fixXmlConfig('connection')
                             ->children()
                                 ->arrayNode('connections')
-                                    ->defaultValue(class_exists(DoctrineBundle::class) ? ['%doctrine.default_connection%'] : [])
                                     ->scalarPrototype()->end()
                                 ->end()
                             ->end()
                         ->end()
                         ->arrayNode('twig')
-                            ->canBeEnabled()
+                            ->{class_exists(TwigBundle::class) ? 'canBeDisabled' : 'canBeEnabled'}()
                         ->end()
                     ->end()
                 ->end()

--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -24,6 +24,7 @@ use Sentry\SentryBundle\Tracing\Twig\TwigTracingExtension;
 use Sentry\Serializer\RepresentationSerializer;
 use Sentry\Serializer\Serializer;
 use Sentry\Transport\TransportFactoryInterface;
+use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -52,8 +53,6 @@ final class SentryExtension extends ConfigurableExtension
 
     /**
      * @param array<string, mixed> $mergedConfig
-     *
-     * @psalm-suppress MoreSpecificImplementedParamType
      */
     protected function loadInternal(array $mergedConfig, ContainerBuilder $container): void
     {
@@ -167,9 +166,10 @@ final class SentryExtension extends ConfigurableExtension
         $isConfigEnabled = $this->isConfigEnabled($container, $config['dbal']);
 
         if ($isConfigEnabled && !class_exists(DoctrineBundle::class)) {
-            throw new LogicException('DBAL tracing support cannot be enabled as the DoctrineBundle bundle is not installed.');
+            throw new LogicException('DBAL tracing support cannot be enabled because the doctrine/doctrine-bundle Composer package is not installed.');
         }
 
+        $container->setParameter('sentry.tracing.dbal.enabled', $isConfigEnabled);
         $container->setParameter('sentry.tracing.dbal.connections', $isConfigEnabled ? $config['dbal']['connections'] : []);
 
         if (!$isConfigEnabled) {
@@ -184,6 +184,10 @@ final class SentryExtension extends ConfigurableExtension
     private function registerTwigTracingConfiguration(ContainerBuilder $container, array $config): void
     {
         $isConfigEnabled = $this->isConfigEnabled($container, $config['twig']);
+
+        if ($isConfigEnabled && !class_exists(TwigBundle::class)) {
+            throw new LogicException('Twig tracing support cannot be enabled because the symfony/twig-bundle Composer package is not installed.');
+        }
 
         if (!$isConfigEnabled) {
             $container->removeDefinition(TwigTracingExtension::class);

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -8,6 +8,7 @@ use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Jean85\PrettyVersions;
 use PHPUnit\Framework\TestCase;
 use Sentry\SentryBundle\DependencyInjection\Configuration;
+use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -16,13 +17,11 @@ final class ConfigurationTest extends TestCase
 {
     public function testProcessConfigurationWithDefaultConfiguration(): void
     {
-        $defaultPrefixes = array_filter(explode(\PATH_SEPARATOR, get_include_path() ?: ''));
-
         $expectedBundleDefaultConfig = [
             'register_error_listener' => true,
             'options' => [
                 'integrations' => [],
-                'prefixes' => array_merge(['%kernel.project_dir%'], $defaultPrefixes),
+                'prefixes' => array_merge(['%kernel.project_dir%'], array_filter(explode(\PATH_SEPARATOR, get_include_path() ?: ''))),
                 'environment' => '%kernel.environment%',
                 'release' => PrettyVersions::getRootPackageVersion()->getPrettyVersion(),
                 'tags' => [],
@@ -40,11 +39,11 @@ final class ConfigurationTest extends TestCase
             ],
             'tracing' => [
                 'dbal' => [
-                    'enabled' => false,
-                    'connections' => class_exists(DoctrineBundle::class) ? ['%doctrine.default_connection%'] : [],
+                    'enabled' => class_exists(DoctrineBundle::class),
+                    'connections' => [],
                 ],
                 'twig' => [
-                    'enabled' => false,
+                    'enabled' => class_exists(TwigBundle::class),
                 ],
             ],
         ];


### PR DESCRIPTION
As asked by @stayallive, this PR enables all the tracing instrumentation by default. Since the `traces_sample_rate` option can be configured using an environment variable, we have no way to know ahead of time if the tracing will be enabled or not: this has the consequence that we have to keep all services registered in the container and active with the negative note that the performance of the application will be slightly affected. I don't know how much loss we we're talking about, but some instrumentation is deeply integrated with low-level things like the driver's connection of the DBAL so I expect at least a bit.