### PR TITLE
Add distributed tracing support for the Symfony Cache component

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -108,7 +108,7 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.php }}-composer-${{ matrix.dependencies }}-
 
       - name: Remove optional packages
-        run: composer remove doctrine/dbal doctrine/doctrine-bundle symfony/messenger symfony/twig-bundle --dev --no-update
+        run: composer remove doctrine/dbal doctrine/doctrine-bundle symfony/messenger symfony/twig-bundle symfony/cache --dev --no-update
 
       - name: Install highest dependencies
         run: composer update --no-progress --no-interaction --prefer-dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Add support for distributed tracing of Twig template rendering (#430)
 - Add support for distributed tracing of SQL queries while using Doctrine DBAL (#426)
 - Add support for distributed tracing when running a console command (#455)
-- Added missing `capture-soft-fails` config schema option (#417)
+- Add support for distributed tracing of cache pools (#)
 - Deprecate the `Sentry\SentryBundle\EventListener\ConsoleCommandListener` class in favor of its parent class `Sentry\SentryBundle\EventListener\ConsoleListener` (#429)
 - Lower the required version of `symfony/psr-http-message-bridge` to allow installing it on a project that uses Symfony `3.4.x` components only (#480)
 

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,8 @@
     "suggest": {
         "monolog/monolog": "Allow sending log messages to Sentry by using the included Monolog handler.",
         "doctrine/doctrine-bundle": "Allow distributed tracing of database queries using Sentry.",
-        "symfony/twig-bundle": "Allow distributed tracing of Twig template rendering using Sentry."
+        "symfony/twig-bundle": "Allow distributed tracing of Twig template rendering using Sentry.",
+        "symfony/cache": "Allow distributed tracing of cache pools using Sentry."
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
         "phpstan/phpstan-phpunit": "^0.12",
         "phpunit/phpunit": "^8.5||^9.0",
         "symfony/browser-kit": "^3.4.44||^4.4.20||^5.0.11",
+        "symfony/cache": "^3.4.44||^4.4.20||^5.0.11",
         "symfony/dom-crawler": "^3.4.44||^4.4.20||^5.0.11",
         "symfony/framework-bundle": "^3.4.44||^4.4.20||^5.0.11",
         "symfony/messenger": "^4.4.20||^5.0.11",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.6.1@e93e532e4eaad6d68c4d7b606853800eaceccc72">
+<files psalm-version="4.7.0@d4377c0baf3ffbf0b1ec6998e8d1be2a40971005">
   <file src="src/EventListener/ConsoleCommandListener.php">
     <InvalidExtendClass occurrences="1">
       <code>ConsoleListener</code>
     </InvalidExtendClass>
-    <MethodSignatureMismatch occurrences="1"/>
+    <MethodSignatureMismatch occurrences="1">
+      <code>public function __construct(HubInterface $hub, bool $captureErrors = true)</code>
+    </MethodSignatureMismatch>
+  </file>
+  <file src="src/Tracing/Cache/TraceableCacheAdapterTrait.php">
+    <InvalidReturnType occurrences="1">
+      <code>getItems</code>
+    </InvalidReturnType>
   </file>
 </files>

--- a/src/DependencyInjection/Compiler/CacheTracingPass.php
+++ b/src/DependencyInjection/Compiler/CacheTracingPass.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class CacheTracingPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->getParameter('sentry.tracing.cache.enabled')) {
+            return;
+        }
+
+        foreach ($container->findTaggedServiceIds('cache.pool') as $serviceId => $tags) {
+            $cachePoolDefinition = $container->getDefinition($serviceId);
+
+            if ($cachePoolDefinition->isAbstract()) {
+                continue;
+            }
+
+            if (is_subclass_of($cachePoolDefinition->getClass(), TagAwareAdapterInterface::class)) {
+                $traceableCachePoolDefinition = new ChildDefinition('sentry.tracing.traceable_tag_aware_cache_adapter');
+            } else {
+                $traceableCachePoolDefinition = new ChildDefinition('sentry.tracing.traceable_cache_adapter');
+            }
+
+            $traceableCachePoolDefinition->setDecoratedService($serviceId);
+            $traceableCachePoolDefinition->replaceArgument(1, new Reference($serviceId . '.traceable.inner'));
+
+            $container->setDefinition($serviceId . '.traceable', $traceableCachePoolDefinition);
+        }
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -13,6 +13,7 @@ use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Contracts\Cache\CacheInterface;
 
 final class Configuration implements ConfigurationInterface
 {
@@ -162,6 +163,9 @@ final class Configuration implements ConfigurationInterface
                         ->end()
                         ->arrayNode('twig')
                             ->{class_exists(TwigBundle::class) ? 'canBeDisabled' : 'canBeEnabled'}()
+                        ->end()
+                        ->arrayNode('cache')
+                            ->{interface_exists(CacheInterface::class) ? 'canBeDisabled' : 'canBeEnabled'}()
                         ->end()
                     ->end()
                 ->end()

--- a/src/Resources/config/schema/sentry-1.0.xsd
+++ b/src/Resources/config/schema/sentry-1.0.xsd
@@ -85,6 +85,7 @@
         <xsd:choice maxOccurs="unbounded">
             <xsd:element name="dbal" type="tracing-dbal" minOccurs="0" maxOccurs="1" />
             <xsd:element name="twig" type="tracing-twig" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="cache" type="tracing-cache" minOccurs="0" maxOccurs="1" />
         </xsd:choice>
 
         <xsd:attribute name="enabled" type="xsd:boolean" default="true"/>
@@ -99,6 +100,10 @@
     </xsd:complexType>
 
     <xsd:complexType name="tracing-twig">
+        <xsd:attribute name="enabled" type="xsd:boolean" />
+    </xsd:complexType>
+
+    <xsd:complexType name="tracing-cache">
         <xsd:attribute name="enabled" type="xsd:boolean" />
     </xsd:complexType>
 </xsd:schema>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -102,6 +102,16 @@
             <tag name="twig.extension" />
         </service>
 
+        <service id="sentry.tracing.traceable_cache_adapter" class="Sentry\SentryBundle\Tracing\Cache\TraceableCacheAdapter" abstract="true">
+            <argument type="service" id="Sentry\State\HubInterface" />
+            <argument /> <!-- $decoratedAdapter -->
+        </service>
+
+        <service id="sentry.tracing.traceable_tag_aware_cache_adapter" class="Sentry\SentryBundle\Tracing\Cache\TraceableTagAwareCacheAdapter" abstract="true">
+            <argument type="service" id="Sentry\State\HubInterface" />
+            <argument /> <!-- $decoratedAdapter -->
+        </service>
+
         <service id="Sentry\Integration\RequestFetcherInterface" class="Sentry\SentryBundle\Integration\RequestFetcher">
             <argument type="service" id="Symfony\Component\HttpFoundation\RequestStack" />
             <argument type="service" id="Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface" on-invalid="null" />

--- a/src/SentryBundle.php
+++ b/src/SentryBundle.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sentry\SentryBundle;
 
+use Sentry\SentryBundle\DependencyInjection\Compiler\CacheTracingPass;
 use Sentry\SentryBundle\DependencyInjection\Compiler\DbalTracingPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -17,5 +18,6 @@ final class SentryBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new DbalTracingPass());
+        $container->addCompilerPass(new CacheTracingPass());
     }
 }

--- a/src/Tracing/Cache/TraceableCacheAdapter.php
+++ b/src/Tracing/Cache/TraceableCacheAdapter.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tracing\Cache;
+
+use Sentry\State\HubInterface;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+use Symfony\Component\Cache\PruneableInterface;
+use Symfony\Component\Cache\ResettableInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+
+/**
+ * This implementation of a cache adapter supports the distributed tracing
+ * feature of Sentry.
+ */
+final class TraceableCacheAdapter implements AdapterInterface, CacheInterface, PruneableInterface, ResettableInterface
+{
+    /**
+     * @phpstan-use TraceableCacheAdapterTrait<AdapterInterface>
+     */
+    use TraceableCacheAdapterTrait;
+
+    /**
+     * @param HubInterface     $hub              The current hub
+     * @param AdapterInterface $decoratedAdapter The decorated cache adapter
+     */
+    public function __construct(HubInterface $hub, AdapterInterface $decoratedAdapter)
+    {
+        $this->hub = $hub;
+        $this->decoratedAdapter = $decoratedAdapter;
+    }
+}

--- a/src/Tracing/Cache/TraceableCacheAdapterTrait.php
+++ b/src/Tracing/Cache/TraceableCacheAdapterTrait.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tracing\Cache;
+
+use Psr\Cache\CacheItemInterface;
+use Sentry\State\HubInterface;
+use Sentry\Tracing\SpanContext;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
+use Symfony\Component\Cache\PruneableInterface;
+use Symfony\Component\Cache\ResettableInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+
+/**
+ * @internal
+ *
+ * @phpstan-template T of AdapterInterface
+ */
+trait TraceableCacheAdapterTrait
+{
+    /**
+     * @var HubInterface The current hub
+     */
+    private $hub;
+
+    /**
+     * @var AdapterInterface|TagAwareAdapterInterface The decorated adapter
+     *
+     * @phpstan-var T
+     */
+    private $decoratedAdapter;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItem($key)
+    {
+        return $this->traceFunction('cache.get_item', function () use ($key) {
+            return $this->decoratedAdapter->getItem($key);
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItems(array $keys = [])
+    {
+        return $this->traceFunction('cache.get_items', function () use ($keys) {
+            return $this->decoratedAdapter->getItems($keys);
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clear(string $prefix = ''): bool
+    {
+        return $this->traceFunction('cache.clear', function () use ($prefix): bool {
+            return $this->decoratedAdapter->clear($prefix);
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param mixed[] $metadata
+     */
+    public function get(string $key, callable $callback, float $beta = null, array &$metadata = null)
+    {
+        return $this->traceFunction('cache.get_item', function () use ($key, $callback, $beta, &$metadata) {
+            if (!$this->decoratedAdapter instanceof CacheInterface) {
+                throw new \BadMethodCallException(sprintf('The %s() method is not supported on an adapter that does not implement the "%s" interface.', __FUNCTION__, CacheInterface::class));
+            }
+
+            return $this->decoratedAdapter->get($key, $callback, $beta, $metadata);
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function delete(string $key): bool
+    {
+        return $this->traceFunction('cache.delete_item', function () use ($key) {
+            if (!$this->decoratedAdapter instanceof CacheInterface) {
+                throw new \BadMethodCallException(sprintf('The %s() method is not supported on an adapter that does not implement the "%s" interface.', __FUNCTION__, CacheInterface::class));
+            }
+
+            return $this->decoratedAdapter->delete($key);
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasItem($key): bool
+    {
+        return $this->traceFunction('cache.has_item', function () use ($key): bool {
+            return $this->decoratedAdapter->hasItem($key);
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteItem($key): bool
+    {
+        return $this->traceFunction('cache.delete_item', function () use ($key): bool {
+            return $this->decoratedAdapter->deleteItem($key);
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteItems(array $keys): bool
+    {
+        return $this->traceFunction('cache.delete_items', function () use ($keys): bool {
+            return $this->decoratedAdapter->deleteItems($keys);
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function save(CacheItemInterface $item): bool
+    {
+        return $this->traceFunction('cache.save', function () use ($item): bool {
+            return $this->decoratedAdapter->save($item);
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function saveDeferred(CacheItemInterface $item): bool
+    {
+        return $this->traceFunction('cache.save_deferred', function () use ($item): bool {
+            return $this->decoratedAdapter->saveDeferred($item);
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function commit(): bool
+    {
+        return $this->traceFunction('cache.commit', function (): bool {
+            return $this->decoratedAdapter->commit();
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prune(): bool
+    {
+        return $this->traceFunction('cache.prune', function (): bool {
+            if (!$this->decoratedAdapter instanceof PruneableInterface) {
+                throw new \BadMethodCallException(sprintf('The %s() method is not supported on an adapter that does not implement the "%s" interface.', __FUNCTION__, PruneableInterface::class));
+            }
+
+            return $this->decoratedAdapter->prune();
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset(): void
+    {
+        if (!$this->decoratedAdapter instanceof ResettableInterface) {
+            throw new \BadMethodCallException(sprintf('The %s() method is not supported on an adapter that does not implement the "%s" interface.', __FUNCTION__, ResettableInterface::class));
+        }
+
+        $this->decoratedAdapter->reset();
+    }
+
+    /**
+     * @phpstan-template TResult
+     *
+     * @phpstan-param \Closure(): TResult $callback
+     *
+     * @phpstan-return TResult
+     */
+    private function traceFunction(string $spanOperation, \Closure $callback)
+    {
+        $span = $this->hub->getSpan();
+
+        if (null !== $span) {
+            $spanContext = new SpanContext();
+            $spanContext->setOp($spanOperation);
+
+            $span = $span->startChild($spanContext);
+        }
+
+        try {
+            return $callback();
+        } finally {
+            if (null !== $span) {
+                $span->finish();
+            }
+        }
+    }
+}

--- a/src/Tracing/Cache/TraceableTagAwareCacheAdapter.php
+++ b/src/Tracing/Cache/TraceableTagAwareCacheAdapter.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tracing\Cache;
+
+use Sentry\State\HubInterface;
+use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
+use Symfony\Component\Cache\PruneableInterface;
+use Symfony\Component\Cache\ResettableInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+
+/**
+ * This implementation of a cache adapter aware of cache tags supports the
+ * distributed tracing feature of Sentry.
+ */
+final class TraceableTagAwareCacheAdapter implements TagAwareAdapterInterface, TagAwareCacheInterface, PruneableInterface, ResettableInterface
+{
+    /**
+     * @phpstan-use TraceableCacheAdapterTrait<TagAwareAdapterInterface>
+     */
+    use TraceableCacheAdapterTrait;
+
+    /**
+     * @param HubInterface             $hub              The current hub
+     * @param TagAwareAdapterInterface $decoratedAdapter The decorated cache adapter
+     */
+    public function __construct(HubInterface $hub, TagAwareAdapterInterface $decoratedAdapter)
+    {
+        $this->hub = $hub;
+        $this->decoratedAdapter = $decoratedAdapter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function invalidateTags(array $tags): bool
+    {
+        return $this->traceFunction('cache.invalidate_tags', function () use ($tags): bool {
+            return $this->decoratedAdapter->invalidateTags($tags);
+        });
+    }
+}

--- a/tests/DependencyInjection/Compiler/CacheTracingPassTest.php
+++ b/tests/DependencyInjection/Compiler/CacheTracingPassTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\SentryBundle\DependencyInjection\Compiler\CacheTracingPass;
+use Sentry\SentryBundle\Tracing\Cache\TraceableCacheAdapter;
+use Sentry\SentryBundle\Tracing\Cache\TraceableTagAwareCacheAdapter;
+use Sentry\State\HubInterface;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Contracts\Cache\CacheInterface;
+
+final class CacheTracingPassTest extends TestCase
+{
+    public function testProcess(): void
+    {
+        $cacheAdapter = $this->createMock(AdapterInterface::class);
+        $tagAwareCacheAdapter = $this->createMock(TagAwareAdapterInterface::class);
+        $container = $this->createContainerBuilder(true);
+
+        $container->register('app.cache.foo', \get_class($tagAwareCacheAdapter))
+            ->setPublic(true)
+            ->addTag('cache.pool');
+
+        $container->register('app.cache.bar', \get_class($cacheAdapter))
+            ->setPublic(true)
+            ->addTag('cache.pool');
+
+        $container->register('app.cache.baz', CacheInterface::class)
+            ->setPublic(true)
+            ->setAbstract(true)
+            ->addTag('cache.pool');
+
+        $container->compile();
+
+        $cacheTraceableDefinition = $container->findDefinition('app.cache.foo');
+
+        $this->assertSame(TraceableTagAwareCacheAdapter::class, $cacheTraceableDefinition->getClass());
+        $this->assertInstanceOf(Definition::class, $cacheTraceableDefinition->getArgument(1));
+        $this->assertSame(\get_class($tagAwareCacheAdapter), $cacheTraceableDefinition->getArgument(1)->getClass());
+
+        $cacheTraceableDefinition = $container->findDefinition('app.cache.bar');
+
+        $this->assertSame(TraceableCacheAdapter::class, $cacheTraceableDefinition->getClass());
+        $this->assertInstanceOf(Definition::class, $cacheTraceableDefinition->getArgument(1));
+        $this->assertSame(\get_class($cacheAdapter), $cacheTraceableDefinition->getArgument(1)->getClass());
+
+        $this->assertFalse($container->hasDefinition('app.cache.baz'));
+    }
+
+    public function testProcessDoesNothingIfConditionsForEnablingTracingAreMissing(): void
+    {
+        $container = $this->createContainerBuilder(false);
+        $container->register('app.cache', CacheInterface::class);
+        $container->compile();
+
+        $this->assertFalse($container->hasDefinition('app.cache.traceable.inner'));
+    }
+
+    private function createContainerBuilder(bool $isTracingActive): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $container->addCompilerPass(new CacheTracingPass());
+        $container->setParameter('sentry.tracing.cache.enabled', $isTracingActive);
+
+        $container->register(HubInterface::class, HubInterface::class);
+        $container->register('sentry.tracing.traceable_cache_adapter', TraceableCacheAdapter::class)
+            ->setAbstract(true)
+            ->setArgument(0, new Reference(HubInterface::class))
+            ->setArgument(1, null);
+
+        $container->register('sentry.tracing.traceable_tag_aware_cache_adapter', TraceableTagAwareCacheAdapter::class)
+            ->setAbstract(true)
+            ->setArgument(0, new Reference(HubInterface::class))
+            ->setArgument(1, null);
+
+        return $container;
+    }
+}

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -12,6 +12,7 @@ use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Contracts\Cache\CacheInterface;
 
 final class ConfigurationTest extends TestCase
 {
@@ -45,6 +46,9 @@ final class ConfigurationTest extends TestCase
                 ],
                 'twig' => [
                     'enabled' => class_exists(TwigBundle::class),
+                ],
+                'cache' => [
+                    'enabled' => interface_exists(CacheInterface::class),
                 ],
             ],
         ];

--- a/tests/DependencyInjection/Fixtures/php/full.php
+++ b/tests/DependencyInjection/Fixtures/php/full.php
@@ -50,5 +50,8 @@ $container->loadFromExtension('sentry', [
         'twig' => [
             'enabled' => false,
         ],
+        'cache' => [
+            'enabled' => false,
+        ],
     ],
 ]);

--- a/tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/tests/DependencyInjection/Fixtures/xml/full.xml
@@ -42,6 +42,7 @@
                 <sentry:connection>default</sentry:connection>
             </sentry:dbal>
             <sentry:twig enabled="false" />
+            <sentry:cache enabled="false" />
         </sentry:tracing>
     </sentry:config>
 </container>

--- a/tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/tests/DependencyInjection/Fixtures/yml/full.yml
@@ -44,3 +44,5 @@ sentry:
                 - default
         twig:
             enabled: false
+        cache:
+            enabled: false


### PR DESCRIPTION
Here we go with another instrumentation, this time for the [Cache](https://symfony.com/doc/current/components/cache.html) component. Its implementation is quite simple, and it resembles the one of the DBAL.