### PR TITLE
Fix missing `sentry.tracing.enabled` service container parameter

### DIFF
--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -165,8 +165,10 @@ final class SentryExtension extends ConfigurableExtension
     /**
      * @param array<string, mixed> $config
      */
-    private function registerTracingConfiguration(ContainerBuilder $container, $config): void
+    private function registerTracingConfiguration(ContainerBuilder $container, array $config): void
     {
+        $container->setParameter('sentry.tracing.enabled', $config['enabled']);
+
         if (!$this->isConfigEnabled($container, $config)) {
             $container->removeDefinition(TracingRequestListener::class);
             $container->removeDefinition(TracingSubRequestListener::class);

--- a/tests/DependencyInjection/SentryExtensionTest.php
+++ b/tests/DependencyInjection/SentryExtensionTest.php
@@ -316,6 +316,7 @@ abstract class SentryExtensionTest extends TestCase
         $this->assertFalse($container->hasDefinition(TracingDriverMiddleware::class));
         $this->assertFalse($container->hasDefinition(ConnectionConfigurator::class));
         $this->assertFalse($container->hasDefinition(TwigTracingExtension::class));
+        $this->assertFalse($container->getParameter('sentry.tracing.enabled'));
         $this->assertEmpty($container->getParameter('sentry.tracing.dbal.connections'));
     }
 


### PR DESCRIPTION
Fixes #476 by adding the missing `sentry.tracing.enabled` parameter to the service container