### PR TITLE
Force installing the same version for all Symfony components during the CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,6 +12,8 @@ jobs:
   Tests:
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental == true }}
+    env:
+      SYMFONY_REQUIRE: ${{matrix.symfony_constraint}}
     strategy:
       fail-fast: false
       matrix:
@@ -21,7 +23,7 @@ jobs:
           - '7.3'
           - '7.2'
         sentry_constraint: [false]
-        symfony_constraint: [false]
+        symfony_constraint: ['']
         experimental: [false]
         include:
 #          - description: 'sentry/sentry dev-develop'
@@ -55,9 +57,8 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug
-      - run: |
-          sed -ri '/symfony\/(monolog-bundle|phpunit-bridge|messenger|psr-http-message-bridge|polyfill-php80)/! s/"symfony\/(.+)": "(.+)"/"symfony\/\1": "'${{ matrix.symfony_constraint }}'"/' composer.json;
-        if: matrix.symfony_constraint
+      - name: Install Symfony Flex
+        run: composer global require --no-progress --no-scripts --no-plugins symfony/flex
       - run: composer remove --dev symfony/messenger --no-update
         if: matrix.symfony_constraint == '3.4.*' || matrix.composer_option == '--prefer-lowest'
       - run: composer update --no-progress --ansi ${{ matrix.composer_option }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add support for distributed tracing when running a console command (#455)
 - Added missing `capture-soft-fails` config schema option (#417)
 - Deprecate the `Sentry\SentryBundle\EventListener\ConsoleCommandListener` class in favor of its parent class `Sentry\SentryBundle\EventListener\ConsoleListener` (#429)
+- Lower the required version of `symfony/psr-http-message-bridge` to allow installing it on a project that uses Symfony `3.4.x` components only (#480)
 
 ## 4.0.3 (2021-03-03)
 - Fix regression from #454 for `null` value on DSN not disabling Sentry (#457)

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "symfony/event-dispatcher": "^3.4.44||^4.4.20||^5.0.11",
         "symfony/http-kernel": "^3.4.44||^4.4.20||^5.0.11",
         "symfony/polyfill-php80": "^1.22",
-        "symfony/psr-http-message-bridge": "^2.0",
+        "symfony/psr-http-message-bridge": "^1.2||^2.0",
         "symfony/security-core": "^3.4.44||^4.4.20||^5.0.11"
     },
     "require-dev": {


### PR DESCRIPTION
While trying to understand why some end-to-end tests recently started to fail during the CI due to deprecation notices coming from some Symfony components, I found out that components from different versions are installed at the same time. For example, let's suppose that we want to test the compatibility of our lib with Symfony `3.4`: what the current GitHub Action workflow does is replacing the version of all entries that start with `symfony/` in the `composer.json` with `3.4.x`.

https://github.com/getsentry/sentry-symfony/blob/43cd505db0a9e370326226467a8a61c7c7deb52f/.github/workflows/tests.yaml#L59

However, this does not guarante at all that the dependencies of those packages are installed at that version too. In fact, Symfony components often declare their compatibility with older or newer versions as well, but there is no guarantee that no deprecation is thrown if you mix two major versions. With this PR, I'm installing Flex globally and then using the `SYMFONY_REQUIRE` environment variable we force the same version for all components. I also discovered that apparently the `4.0` version of the SDK was uninstallable on Symfony `3.4` in certain cases because we were requiring `symfony/psr-http-message:^2.0` which needs some components from Symfony `4.x` instead, so I widened the Composer constraint to allow installing an older version of the package: this effectively allows installing our lib on a project that uses only components of the `3.4` version