### PR TITLE
Fix the conditions to automatically enable the tracing of the cache adapters

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -108,7 +108,7 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.php }}-composer-${{ matrix.dependencies }}-
 
       - name: Remove optional packages
-        run: composer remove doctrine/dbal doctrine/doctrine-bundle symfony/messenger symfony/twig-bundle symfony/cache --dev --no-update
+        run: composer remove doctrine/dbal doctrine/doctrine-bundle symfony/messenger symfony/twig-bundle symfony/cache symfony/cache-contracts --dev --no-update
 
       - name: Install highest dependencies
         run: composer update --no-progress --no-interaction --prefer-dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix the conditions to automatically enable the cache instrumentation when possible (#487)
+
 ## 4.1.0 (2021-04-19)
 
 - Avoid failures when the `RequestFetcher` fails to translate the `Request` (#472)
@@ -9,7 +11,7 @@
 - Add support for distributed tracing of Twig template rendering (#430)
 - Add support for distributed tracing of SQL queries while using Doctrine DBAL (#426)
 - Add support for distributed tracing when running a console command (#455)
-- Add support for distributed tracing of cache pools (#)
+- Add support for distributed tracing of cache pools (#477)
 - Add `Full command` to extras for CLI commands, which includes command with all arguments
 - Deprecate the `Sentry\SentryBundle\EventListener\ConsoleCommandListener` class in favor of its parent class `Sentry\SentryBundle\EventListener\ConsoleListener` (#429)
 - Lower the required version of `symfony/psr-http-message-bridge` to allow installing it on a project that uses Symfony `3.4.x` components only (#480)

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
         "phpunit/phpunit": "^8.5||^9.0",
         "symfony/browser-kit": "^3.4.44||^4.4.20||^5.0.11",
         "symfony/cache": "^3.4.44||^4.4.20||^5.0.11",
+        "symfony/cache-contracts": "^2.4",
         "symfony/dom-crawler": "^3.4.44||^4.4.20||^5.0.11",
         "symfony/framework-bundle": "^3.4.44||^4.4.20||^5.0.11",
         "symfony/messenger": "^4.4.20||^5.0.11",

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -9,11 +9,11 @@ use Jean85\PrettyVersions;
 use Sentry\Options;
 use Sentry\SentryBundle\ErrorTypesParser;
 use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Component\Cache\CacheItem;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Contracts\Cache\CacheInterface;
 
 final class Configuration implements ConfigurationInterface
 {
@@ -165,7 +165,7 @@ final class Configuration implements ConfigurationInterface
                             ->{class_exists(TwigBundle::class) ? 'canBeDisabled' : 'canBeEnabled'}()
                         ->end()
                         ->arrayNode('cache')
-                            ->{interface_exists(CacheInterface::class) ? 'canBeDisabled' : 'canBeEnabled'}()
+                            ->{interface_exists(CacheItem::class) ? 'canBeDisabled' : 'canBeEnabled'}()
                         ->end()
                     ->end()
                 ->end()

--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -28,6 +28,7 @@ use Sentry\Serializer\RepresentationSerializer;
 use Sentry\Serializer\Serializer;
 use Sentry\Transport\TransportFactoryInterface;
 use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Component\Cache\CacheItem;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -35,7 +36,6 @@ use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\ErrorHandler\Error\FatalError;
 use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
-use Symfony\Contracts\Cache\CacheInterface;
 
 final class SentryExtension extends ConfigurableExtension
 {
@@ -224,7 +224,7 @@ final class SentryExtension extends ConfigurableExtension
         $isConfigEnabled = $this->isConfigEnabled($container, $config)
             && $this->isConfigEnabled($container, $config['cache']);
 
-        if ($isConfigEnabled && !interface_exists(CacheInterface::class)) {
+        if ($isConfigEnabled && !interface_exists(CacheItem::class)) {
             throw new LogicException('Cache tracing support cannot be enabled because the symfony/cache Composer package is not installed.');
         }
 

--- a/tests/DependencyInjection/Compiler/CacheTracingPassTest.php
+++ b/tests/DependencyInjection/Compiler/CacheTracingPassTest.php
@@ -14,7 +14,6 @@ use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Contracts\Cache\CacheInterface;
 
 final class CacheTracingPassTest extends TestCase
 {
@@ -32,7 +31,7 @@ final class CacheTracingPassTest extends TestCase
             ->setPublic(true)
             ->addTag('cache.pool');
 
-        $container->register('app.cache.baz', CacheInterface::class)
+        $container->register('app.cache.baz')
             ->setPublic(true)
             ->setAbstract(true)
             ->addTag('cache.pool');
@@ -57,7 +56,7 @@ final class CacheTracingPassTest extends TestCase
     public function testProcessDoesNothingIfConditionsForEnablingTracingAreMissing(): void
     {
         $container = $this->createContainerBuilder(false);
-        $container->register('app.cache', CacheInterface::class);
+        $container->register('app.cache', AdapterInterface::class);
         $container->compile();
 
         $this->assertFalse($container->hasDefinition('app.cache.traceable.inner'));

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -9,10 +9,10 @@ use Jean85\PrettyVersions;
 use PHPUnit\Framework\TestCase;
 use Sentry\SentryBundle\DependencyInjection\Configuration;
 use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Component\Cache\CacheItem;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Contracts\Cache\CacheInterface;
 
 final class ConfigurationTest extends TestCase
 {
@@ -48,7 +48,7 @@ final class ConfigurationTest extends TestCase
                     'enabled' => class_exists(TwigBundle::class),
                 ],
                 'cache' => [
-                    'enabled' => interface_exists(CacheInterface::class),
+                    'enabled' => interface_exists(CacheItem::class),
                 ],
             ],
         ];


### PR DESCRIPTION
I just realized that relying on the presence of the [`CacheInterface`](https://github.com/symfony/cache-contracts/blob/c0446463729b89dd4fa62e9aeecc80287323615d/CacheInterface.php) interface from the [`symfony/cache-contracts`](https://github.com/symfony/cache-contracts) package is wrong because older versions of the Cache component (e.g. `3.4.x`) does not depend from it and therefore the tracing instrumentation is not activated automatically as expected.