### PR TITLE
Fix deprecations triggered by Symfony 5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix the conditions to automatically enable the cache instrumentation when possible (#487)
+- Fix deprecations triggered by Symfony 5.3 (#489)
 
 ## 4.1.0 (2021-04-19)
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -181,17 +181,17 @@ parameters:
 			path: tests/EventListener/RequestListenerTest.php
 
 		-
-			message: "#^Call to method isMasterRequest\\(\\) on an unknown class Symfony\\\\Component\\\\HttpKernel\\\\Event\\\\GetResponseEvent\\.$#"
-			count: 1
-			path: tests/EventListener/SubRequestListenerTest.php
-
-		-
 			message: "#^Instantiated class Symfony\\\\Component\\\\HttpKernel\\\\Event\\\\GetResponseEvent not found\\.$#"
 			count: 2
 			path: tests/EventListener/SubRequestListenerTest.php
 
 		-
 			message: "#^Parameter \\#1 \\$event of method Sentry\\\\SentryBundle\\\\EventListener\\\\SubRequestListener\\:\\:handleKernelRequestEvent\\(\\) expects Symfony\\\\Component\\\\HttpKernel\\\\Event\\\\RequestEvent, Symfony\\\\Component\\\\HttpKernel\\\\Event\\\\GetResponseEvent\\|Symfony\\\\Component\\\\HttpKernel\\\\Event\\\\RequestEvent given\\.$#"
+			count: 1
+			path: tests/EventListener/SubRequestListenerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$event of method Sentry\\\\SentryBundle\\\\Tests\\\\EventListener\\\\SubRequestListenerTest\\:\\:isMainRequest\\(\\) expects Symfony\\\\Component\\\\HttpKernel\\\\Event\\\\KernelEvent, Symfony\\\\Component\\\\HttpKernel\\\\Event\\\\GetResponseEvent\\|Symfony\\\\Component\\\\HttpKernel\\\\Event\\\\RequestEvent given\\.$#"
 			count: 1
 			path: tests/EventListener/SubRequestListenerTest.php
 

--- a/src/EventListener/AbstractTracingRequestListener.php
+++ b/src/EventListener/AbstractTracingRequestListener.php
@@ -11,6 +11,8 @@ use Symfony\Component\Routing\Route;
 
 abstract class AbstractTracingRequestListener
 {
+    use KernelEventForwardCompatibilityTrait;
+
     /**
      * @var HubInterface The current hub
      */

--- a/src/EventListener/KernelEventForwardCompatibilityTrait.php
+++ b/src/EventListener/KernelEventForwardCompatibilityTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\EventListener;
+
+use Symfony\Component\HttpKernel\Event\KernelEvent;
+
+/**
+ * Provides forward compatibility with newer Symfony versions.
+ *
+ * @internal
+ */
+trait KernelEventForwardCompatibilityTrait
+{
+    protected function isMainRequest(KernelEvent $event): bool
+    {
+        return method_exists($event, 'isMainRequest')
+            ? $event->isMainRequest()
+            : $event->isMasterRequest()
+        ;
+    }
+}

--- a/src/EventListener/RequestListener.php
+++ b/src/EventListener/RequestListener.php
@@ -17,6 +17,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
  */
 final class RequestListener
 {
+    use KernelEventForwardCompatibilityTrait;
+
     /**
      * @var HubInterface The current hub
      */
@@ -47,7 +49,7 @@ final class RequestListener
      */
     public function handleKernelRequestEvent(RequestListenerRequestEvent $event): void
     {
-        if (!$event->isMasterRequest()) {
+        if (!$this->isMainRequest($event)) {
             return;
         }
 
@@ -81,7 +83,7 @@ final class RequestListener
      */
     public function handleKernelControllerEvent(RequestListenerControllerEvent $event): void
     {
-        if (!$event->isMasterRequest()) {
+        if (!$this->isMainRequest($event)) {
             return;
         }
 
@@ -102,7 +104,7 @@ final class RequestListener
     private function getUsername($user): ?string
     {
         if ($user instanceof UserInterface) {
-            return $user->getUsername();
+            return method_exists($user, 'getUserIdentifier') ? $user->getUserIdentifier() : $user->getUsername();
         }
 
         if (\is_string($user)) {

--- a/src/EventListener/SubRequestListener.php
+++ b/src/EventListener/SubRequestListener.php
@@ -13,6 +13,8 @@ use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
  */
 final class SubRequestListener
 {
+    use KernelEventForwardCompatibilityTrait;
+
     /**
      * @var HubInterface The current hub
      */
@@ -36,7 +38,7 @@ final class SubRequestListener
      */
     public function handleKernelRequestEvent(SubRequestListenerRequestEvent $event): void
     {
-        if ($event->isMasterRequest()) {
+        if ($this->isMainRequest($event)) {
             return;
         }
 
@@ -51,7 +53,7 @@ final class SubRequestListener
      */
     public function handleKernelFinishRequestEvent(FinishRequestEvent $event): void
     {
-        if ($event->isMasterRequest()) {
+        if ($this->isMainRequest($event)) {
             return;
         }
 

--- a/src/EventListener/TracingRequestListener.php
+++ b/src/EventListener/TracingRequestListener.php
@@ -24,7 +24,7 @@ final class TracingRequestListener extends AbstractTracingRequestListener
      */
     public function handleKernelRequestEvent(RequestListenerRequestEvent $event): void
     {
-        if (!$event->isMasterRequest()) {
+        if (!$this->isMainRequest($event)) {
             return;
         }
 

--- a/src/EventListener/TracingSubRequestListener.php
+++ b/src/EventListener/TracingSubRequestListener.php
@@ -22,7 +22,7 @@ final class TracingSubRequestListener extends AbstractTracingRequestListener
      */
     public function handleKernelRequestEvent(SubRequestListenerRequestEvent $event): void
     {
-        if ($event->isMasterRequest()) {
+        if ($this->isMainRequest($event)) {
             return;
         }
 
@@ -53,7 +53,7 @@ final class TracingSubRequestListener extends AbstractTracingRequestListener
      */
     public function handleKernelFinishRequestEvent(FinishRequestEvent $event): void
     {
-        if ($event->isMasterRequest()) {
+        if ($this->isMainRequest($event)) {
             return;
         }
 

--- a/tests/EventListener/RequestListenerTest.php
+++ b/tests/EventListener/RequestListenerTest.php
@@ -221,7 +221,12 @@ final class RequestListenerTest extends TestCase
                             return null;
                         }
 
-                        public function getUsername()
+                        public function getUsername(): string
+                        {
+                            return $this->getUserIdentifier();
+                        }
+
+                        public function getUserIdentifier(): string
                         {
                             return 'foo_user';
                         }
@@ -411,7 +416,12 @@ final class RequestListenerTest extends TestCase
                             return null;
                         }
 
-                        public function getUsername()
+                        public function getUsername(): string
+                        {
+                            return $this->getUserIdentifier();
+                        }
+
+                        public function getUserIdentifier(): string
                         {
                             return 'foo_user';
                         }

--- a/tests/EventListener/SubRequestListenerTest.php
+++ b/tests/EventListener/SubRequestListenerTest.php
@@ -6,6 +6,7 @@ namespace Sentry\SentryBundle\Tests\EventListener;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Sentry\SentryBundle\EventListener\KernelEventForwardCompatibilityTrait;
 use Sentry\SentryBundle\EventListener\SubRequestListener;
 use Sentry\State\HubInterface;
 use Sentry\State\Scope;
@@ -18,6 +19,8 @@ use Symfony\Component\HttpKernel\Kernel;
 
 class SubRequestListenerTest extends TestCase
 {
+    use KernelEventForwardCompatibilityTrait;
+
     /**
      * @var MockObject&HubInterface
      */
@@ -42,7 +45,7 @@ class SubRequestListenerTest extends TestCase
      */
     public function testHandleKernelRequestEvent($event): void
     {
-        $this->hub->expects($event->isMasterRequest() ? $this->never() : $this->once())
+        $this->hub->expects($this->isMainRequest($event) ? $this->never() : $this->once())
             ->method('pushScope')
             ->willReturn(new Scope());
 
@@ -92,7 +95,7 @@ class SubRequestListenerTest extends TestCase
      */
     public function testHandleKernelFinishRequestEvent($event): void
     {
-        $this->hub->expects($event->isMasterRequest() ? $this->never() : $this->once())
+        $this->hub->expects($this->isMainRequest($event) ? $this->never() : $this->once())
             ->method('popScope');
 
         $this->listener->handleKernelFinishRequestEvent($event);


### PR DESCRIPTION
This PR fixes deprecation warnings from the upcoming Symfony 5.3 release:

* The "master request" has been renamed to "main request".
* Implementations of `UserInterface` must provide a `getUserIdentifier()` method now.