### PR TITLE
Allow to pass custom serializer and representation_serializer in configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Add option to provide custom `Serializer` and `RepresentationSerializer` via configuration (#491)
 
 - Make the transport factory configurable in the bundle's config (#504)
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Keep in mind that leaving the `dsn` value empty (or undeclared) in other environ
 ```yaml
 sentry:
     dsn: "https://public:secret@sentry.example.com/1"
-    messenger: 
+    messenger:
         enabled: true # flushes Sentry messages at the end of each message handling
         capture_soft_fails: true # captures exceptions marked for retry too
     options:
@@ -99,7 +99,7 @@ the [PHP specific](https://docs.sentry.io/platforms/php/#php-specific-options) o
 
 #### Optional: use custom HTTP factory/transport
 
-Since SDK 2.0 uses HTTPlug to remain transport-agnostic, you need to have installed two packages that provides 
+Since SDK 2.0 uses HTTPlug to remain transport-agnostic, you need to have installed two packages that provides
 [`php-http/async-client-implementation`](https://packagist.org/providers/php-http/async-client-implementation)
 and [`http-message-implementation`](https://packagist.org/providers/psr/http-message-implementation).
 
@@ -114,7 +114,7 @@ If instead you want to use a different HTTP client or message factory, you can o
 ```
 This will prevent the installation of ``sentry/sdk`` package and will allow you to install through Composer the HTTP client or message factory of your choice.
 
-For example for using Guzzle's components: 
+For example for using Guzzle's components:
 
 ```bash
 composer require php-http/guzzle6-adapter guzzlehttp/psr7
@@ -131,14 +131,14 @@ composer require pugx/sentry-sdk
  * 4.x is actively maintained and developed on the master branch, and uses Sentry SDK 3.0;
  * 3.x is supported only for fixes and uses Sentry SDK 2.0;
  * 2.x is no longer maintained; from this version onwards it requires Symfony 3+ and PHP 7.1+;
- * 1.x is no longer maintained; you can use it for Symfony < 2.8 and PHP 5.6/7.0; 
+ * 1.x is no longer maintained; you can use it for Symfony < 2.8 and PHP 5.6/7.0;
  * 0.8.x is no longer maintained.
 
 ### Upgrading to 4.0
 
 The 4.0 version of the bundle uses the newest version (3.x) of the underlying Sentry SDK. If you need to migrate from previous versions, please check the `UPGRADE-4.0.md` document.
 
-#### Custom serializers
+#### Custom class serializers
 
 The option class_serializers can be used to send customized objects serialization.
 ```yml
@@ -161,6 +161,15 @@ final class ValueObjectSerializer
         ];
     }
 }
+```
+
+#### Custom serializer
+
+The option `serializer` and `representation_serializer` can be used to provide your own serializer service.
+```yml
+sentry:
+    serializer: App\CustomSerializer # must implement Sentry\Serializer\SerializerInterface
+    representation_serializer: App\CustomRepresentationSerializer # must implement Sentry\Serializer\RepresentationSerializerInterface
 ```
 
 [Last stable image]: https://poser.pugx.org/sentry/sentry-symfony/version.svg

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -40,6 +40,8 @@ final class Configuration implements ConfigurationInterface
                     ->info('The service ID of the transport factory used by the default SDK client.')
                     ->defaultValue(TransportFactoryInterface::class)
                 ->end()
+                ->scalarNode('representation_serializer')->defaultNull()->end()
+                ->scalarNode('serializer')->defaultNull()->end()
                 ->arrayNode('options')
                     ->addDefaultsIfNotSet()
                     ->fixXmlConfig('integration')

--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -115,20 +115,28 @@ final class SentryExtension extends ConfigurableExtension
             ->setPublic(false)
             ->setArgument(0, $options);
 
-        $serializer = (new Definition(Serializer::class))
-            ->setPublic(false)
-            ->setArgument(0, new Reference('sentry.client.options'));
+        if (null !== $config['serializer']) {
+            $serializerDefinition = new Reference($config['serializer']);
+        } else {
+            $serializerDefinition = (new Definition(Serializer::class))
+                ->setPublic(false)
+                ->setArgument(0, new Reference('sentry.client.options'));
+        }
 
-        $representationSerializerDefinition = (new Definition(RepresentationSerializer::class))
-            ->setPublic(false)
-            ->setArgument(0, new Reference('sentry.client.options'));
+        if (null !== $config['representation_serializer']) {
+            $representationSerializerDefinition = new Reference($config['representation_serializer']);
+        } else {
+            $representationSerializerDefinition = (new Definition(RepresentationSerializer::class))
+                ->setPublic(false)
+                ->setArgument(0, new Reference('sentry.client.options'));
+        }
 
         $clientBuilderDefinition = (new Definition(ClientBuilder::class))
             ->setArgument(0, new Reference('sentry.client.options'))
             ->addMethodCall('setSdkIdentifier', [SentryBundle::SDK_IDENTIFIER])
             ->addMethodCall('setSdkVersion', [PrettyVersions::getVersion('sentry/sentry-symfony')->getPrettyVersion()])
             ->addMethodCall('setTransportFactory', [new Reference($config['transport_factory'])])
-            ->addMethodCall('setSerializer', [$serializer])
+            ->addMethodCall('setSerializer', [$serializerDefinition])
             ->addMethodCall('setRepresentationSerializer', [$representationSerializerDefinition]);
 
         $container

--- a/src/Resources/config/schema/sentry-1.0.xsd
+++ b/src/Resources/config/schema/sentry-1.0.xsd
@@ -12,6 +12,8 @@
             <xsd:element name="options" type="options" minOccurs="0" maxOccurs="1" />
             <xsd:element name="messenger" type="messenger" minOccurs="0" maxOccurs="1" />
             <xsd:element name="tracing" type="tracing" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="serializer" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="representation_serializer" type="xsd:string" minOccurs="0" maxOccurs="1"/>
         </xsd:choice>
 
         <xsd:attribute name="register-error-listener" type="xsd:boolean" />

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -21,6 +21,8 @@ final class ConfigurationTest extends TestCase
         $expectedBundleDefaultConfig = [
             'register_error_listener' => true,
             'transport_factory' => 'Sentry\\Transport\\TransportFactoryInterface',
+            'representation_serializer' => null,
+            'serializer' => null,
             'options' => [
                 'integrations' => [],
                 'prefixes' => array_merge(['%kernel.project_dir%'], array_filter(explode(\PATH_SEPARATOR, get_include_path() ?: ''))),

--- a/tests/DependencyInjection/Fixtures/php/custom_representation_serializer.php
+++ b/tests/DependencyInjection/Fixtures/php/custom_representation_serializer.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/** @var ContainerBuilder $container */
+$container->loadFromExtension('sentry', [
+    'representation_serializer' => 'custom_representation_serializer',
+]);

--- a/tests/DependencyInjection/Fixtures/php/custom_serializer.php
+++ b/tests/DependencyInjection/Fixtures/php/custom_serializer.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/** @var ContainerBuilder $container */
+$container->loadFromExtension('sentry', [
+    'serializer' => 'custom_serializer',
+]);

--- a/tests/DependencyInjection/Fixtures/xml/custom_representation_serializer.xml
+++ b/tests/DependencyInjection/Fixtures/xml/custom_representation_serializer.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:sentry="https://sentry.io/schema/dic/sentry-symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                               https://sentry.io/schema/dic/sentry-symfony https://sentry.io/schema/dic/sentry-symfony/sentry-1.0.xsd">
+
+    <sentry:config>
+        <sentry:representation_serializer>custom_representation_serializer</sentry:representation_serializer>
+    </sentry:config>
+</container>

--- a/tests/DependencyInjection/Fixtures/xml/custom_serializer.xml
+++ b/tests/DependencyInjection/Fixtures/xml/custom_serializer.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:sentry="https://sentry.io/schema/dic/sentry-symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                               https://sentry.io/schema/dic/sentry-symfony https://sentry.io/schema/dic/sentry-symfony/sentry-1.0.xsd">
+
+    <sentry:config>
+        <sentry:serializer>custom_serializer</sentry:serializer>
+    </sentry:config>
+</container>

--- a/tests/DependencyInjection/Fixtures/yml/custom_representation_serializer.yml
+++ b/tests/DependencyInjection/Fixtures/yml/custom_representation_serializer.yml
@@ -1,0 +1,2 @@
+sentry:
+    representation_serializer: custom_representation_serializer

--- a/tests/DependencyInjection/Fixtures/yml/custom_serializer.yml
+++ b/tests/DependencyInjection/Fixtures/yml/custom_serializer.yml
@@ -1,0 +1,2 @@
+sentry:
+    serializer: custom_serializer

--- a/tests/DependencyInjection/SentryExtensionTest.php
+++ b/tests/DependencyInjection/SentryExtensionTest.php
@@ -361,6 +361,24 @@ abstract class SentryExtensionTest extends TestCase
         $this->assertFalse($container->hasDefinition(TwigTracingExtension::class));
     }
 
+    public function testRepresentationSerializerOption(): void
+    {
+        $container = $this->createContainerFromFixture('custom_representation_serializer');
+        $factory = $container->findDefinition('sentry.client')->getFactory();
+
+        $methodCalls = $factory[0]->getMethodCalls();
+        $this->assertDefinitionMethodCallAt($methodCalls[4], 'setRepresentationSerializer', [new Reference('custom_representation_serializer')]);
+    }
+
+    public function testSerializerOption(): void
+    {
+        $container = $this->createContainerFromFixture('custom_serializer');
+        $factory = $container->findDefinition('sentry.client')->getFactory();
+
+        $methodCalls = $factory[0]->getMethodCalls();
+        $this->assertDefinitionMethodCallAt($methodCalls[3], 'setSerializer', [new Reference('custom_serializer')]);
+    }
+
     private function createContainerFromFixture(string $fixtureFile): ContainerBuilder
     {
         $container = new ContainerBuilder(new EnvPlaceholderParameterBag([


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-symfony/issues/482

> Well I can improve the docs but I would say that such compiler pass is rather a hack than proper solution.
> The problem with the compiler pass is that it's a modification of the internals and not the public API so it's a subject to change in future releases without any warning.
>I know of SerializableInterface and class_serializers but there are use cases when you need to modify "global" behaviour.
> I'd prefer to add the representation serializer (and perhaps even the serializer) as optional configuration options.
>I can prepare a PR if such modification is a welcome change.