### PR TITLE
Add bus, receiver and message name to extra's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
 ## Unreleased
-- Attach bus, receiver and message class name as extra's
 
+- Log the bus name, receiver name and message class name as event tags when using Symfony Messenger (#492)
 - Make the transport factory configurable in the bundle's config (#504)
 - Add the `sentry_trace_meta()` Twig function to print the `sentry-trace` HTML meta tag (#510)
 - Make the list of commands for which distributed tracing is active configurable (#515)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Attach bus, receiver and message class name as extra's
 
 - Make the transport factory configurable in the bundle's config (#504)
 - Add the `sentry_trace_meta()` Twig function to print the `sentry-trace` HTML meta tag (#510)

--- a/tests/EventListener/MessengerListenerTest.php
+++ b/tests/EventListener/MessengerListenerTest.php
@@ -47,11 +47,20 @@ final class MessengerListenerTest extends TestCase
             $this->markTestSkipped('Messenger not supported in this environment.');
         }
 
+        $scope = new Scope();
         $this->hub->expects($this->exactly(\count($exceptions)))
-            ->method('captureEvent')
-            ->withConsecutive(...array_map(static function (\Throwable $exception): array {
-                return [$exception];
-            }, $exceptions));
+            ->method('withScope')
+            ->willReturnCallback(function (callable $callback) use ($scope): void {
+                $callback($scope);
+
+                // $scope has no tags getters, should make assertions against this
+                // 'messenger.receiver_name => 'receiver',
+                // 'messenger.message_class' => 'stdClass',
+                // 'messenger.message_bus' => 'commandBus',
+            });
+
+        $this->hub->expects($this->exactly(\count($exceptions)))
+            ->method('captureEvent');
 
         $this->hub->expects($this->once())
             ->method('getClient')


### PR DESCRIPTION
Hello,

With this PR we can send extra information about the worker like busName, receiver, and the actual message object name.
In the future (when I have more time) we can add configuration for custom stamps to be sent along.