### PR TITLE
Make the transport factory configurable in the bundle's config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Make the transport factory configurable in the bundle's config (#504)
+
 ## 4.1.0 (2021-04-19)
 
 - Avoid failures when the `RequestFetcher` fails to translate the `Request` (#472)

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -8,6 +8,7 @@ use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Jean85\PrettyVersions;
 use Sentry\Options;
 use Sentry\SentryBundle\ErrorTypesParser;
+use Sentry\Transport\TransportFactoryInterface;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -35,6 +36,10 @@ final class Configuration implements ConfigurationInterface
                     ->info('If this value is not provided, the SDK will try to read it from the SENTRY_DSN environment variable. If that variable also does not exist, the SDK will just not send any events.')
                 ->end()
                 ->booleanNode('register_error_listener')->defaultTrue()->end()
+                ->scalarNode('transport_factory')
+                    ->info('The service ID of the transport factory used by the default SDK client.')
+                    ->defaultValue(TransportFactoryInterface::class)
+                ->end()
                 ->arrayNode('options')
                     ->addDefaultsIfNotSet()
                     ->fixXmlConfig('integration')

--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -26,7 +26,6 @@ use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverMiddleware;
 use Sentry\SentryBundle\Tracing\Twig\TwigTracingExtension;
 use Sentry\Serializer\RepresentationSerializer;
 use Sentry\Serializer\Serializer;
-use Sentry\Transport\TransportFactoryInterface;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -128,7 +127,7 @@ final class SentryExtension extends ConfigurableExtension
             ->setArgument(0, new Reference('sentry.client.options'))
             ->addMethodCall('setSdkIdentifier', [SentryBundle::SDK_IDENTIFIER])
             ->addMethodCall('setSdkVersion', [PrettyVersions::getVersion('sentry/sentry-symfony')->getPrettyVersion()])
-            ->addMethodCall('setTransportFactory', [new Reference(TransportFactoryInterface::class)])
+            ->addMethodCall('setTransportFactory', [new Reference($config['transport_factory'])])
             ->addMethodCall('setSerializer', [$serializer])
             ->addMethodCall('setRepresentationSerializer', [$representationSerializerDefinition]);
 

--- a/src/Resources/config/schema/sentry-1.0.xsd
+++ b/src/Resources/config/schema/sentry-1.0.xsd
@@ -15,6 +15,7 @@
         </xsd:choice>
 
         <xsd:attribute name="register-error-listener" type="xsd:boolean" />
+        <xsd:attribute name="transport-factory" type="xsd:string" />
         <xsd:attribute name="dsn" type="xsd:string" />
     </xsd:complexType>
 

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -20,6 +20,7 @@ final class ConfigurationTest extends TestCase
     {
         $expectedBundleDefaultConfig = [
             'register_error_listener' => true,
+            'transport_factory' => 'Sentry\\Transport\\TransportFactoryInterface',
             'options' => [
                 'integrations' => [],
                 'prefixes' => array_merge(['%kernel.project_dir%'], array_filter(explode(\PATH_SEPARATOR, get_include_path() ?: ''))),

--- a/tests/DependencyInjection/Fixtures/php/full.php
+++ b/tests/DependencyInjection/Fixtures/php/full.php
@@ -7,6 +7,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 /** @var ContainerBuilder $container */
 $container->loadFromExtension('sentry', [
     'dsn' => 'https://examplePublicKey@o0.ingest.sentry.io/0',
+    'transport_factory' => 'App\\Sentry\\Transport\\TransportFactory',
     'options' => [
         'integrations' => ['App\\Sentry\\Integration\\FooIntegration'],
         'default_integrations' => false,
@@ -28,7 +29,7 @@ $container->loadFromExtension('sentry', [
         ],
         'error_types' => \E_ALL,
         'max_breadcrumbs' => 1,
-        'before_breadcrumb' => 'App\Sentry\BeforeBreadcrumbCallback',
+        'before_breadcrumb' => 'App\\Sentry\\BeforeBreadcrumbCallback',
         'in_app_exclude' => ['%kernel.cache_dir%'],
         'in_app_include' => ['%kernel.project_dir%'],
         'send_default_pii' => true,

--- a/tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/tests/DependencyInjection/Fixtures/xml/full.xml
@@ -6,7 +6,10 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                                https://sentry.io/schema/dic/sentry-symfony https://sentry.io/schema/dic/sentry-symfony/sentry-1.0.xsd">
 
-    <sentry:config dsn="https://examplePublicKey@o0.ingest.sentry.io/0">
+    <sentry:config
+        dsn="https://examplePublicKey@o0.ingest.sentry.io/0"
+        transport-factory="App\Sentry\Transport\TransportFactory"
+    >
         <sentry:options default-integrations="false"
                         send-attempts="1"
                         sample-rate="1"

--- a/tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/tests/DependencyInjection/Fixtures/yml/full.yml
@@ -1,5 +1,6 @@
 sentry:
     dsn: https://examplePublicKey@o0.ingest.sentry.io/0
+    transport_factory: App\Sentry\Transport\TransportFactory
     options:
         integrations:
             - App\Sentry\Integration\FooIntegration

--- a/tests/DependencyInjection/SentryExtensionTest.php
+++ b/tests/DependencyInjection/SentryExtensionTest.php
@@ -25,7 +25,6 @@ use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverMiddleware;
 use Sentry\SentryBundle\Tracing\Twig\TwigTracingExtension;
 use Sentry\Serializer\RepresentationSerializer;
 use Sentry\Serializer\Serializer;
-use Sentry\Transport\TransportFactoryInterface;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -231,7 +230,7 @@ abstract class SentryExtensionTest extends TestCase
 
         $this->assertDefinitionMethodCallAt($methodCalls[0], 'setSdkIdentifier', [SentryBundle::SDK_IDENTIFIER]);
         $this->assertDefinitionMethodCallAt($methodCalls[1], 'setSdkVersion', [PrettyVersions::getVersion('sentry/sentry-symfony')->getPrettyVersion()]);
-        $this->assertDefinitionMethodCallAt($methodCalls[2], 'setTransportFactory', [new Reference(TransportFactoryInterface::class)]);
+        $this->assertDefinitionMethodCallAt($methodCalls[2], 'setTransportFactory', [new Reference('App\\Sentry\\Transport\\TransportFactory')]);
 
         $this->assertSame('setSerializer', $methodCalls[3][0]);
         $this->assertInstanceOf(Definition::class, $methodCalls[3][1][0]);


### PR DESCRIPTION
While answering issue #497 I realized that making the transport factory configurable in the bundle's config so that there is no need to use a compiler pass to modify the service definition of the SDK client would make things much more easy for the users. Change itself is pretty small, it just adds a new config node that can be set to the name of the service to use in place of the default one 😄 