### PR TITLE
Add the `sentry_trace_meta()` Twig function to print the `sentry-trace` HTML meta tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Make the transport factory configurable in the bundle's config (#504)
+- Add the `sentry_trace_meta()` Twig function to print the `sentry-trace` HTML meta tag (#510)
 
 ## 4.1.0 (2021-04-19)
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -116,5 +116,11 @@
             <argument type="service" id="Symfony\Component\HttpFoundation\RequestStack" />
             <argument type="service" id="Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface" on-invalid="null" />
         </service>
+
+        <service id="Sentry\SentryBundle\Twig\SentryExtension" class="Sentry\SentryBundle\Twig\SentryExtension">
+            <argument type="service" id="Sentry\State\HubInterface" />
+
+            <tag name="twig.extension" />
+        </service>
     </services>
 </container>

--- a/src/Twig/SentryExtension.php
+++ b/src/Twig/SentryExtension.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Twig;
+
+use Sentry\State\HubInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class SentryExtension extends AbstractExtension
+{
+    /**
+     * @var HubInterface The current hub
+     */
+    private $hub;
+
+    /**
+     * @param HubInterface $hub The current hub
+     */
+    public function __construct(HubInterface $hub)
+    {
+        $this->hub = $hub;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('sentry_trace_meta', \Closure::fromCallable([$this, 'getTraceMeta']), ['is_safe' => ['html']]),
+        ];
+    }
+
+    /**
+     * Returns an HTML meta tag named `sentry-trace`.
+     */
+    private function getTraceMeta(): string
+    {
+        $span = $this->hub->getSpan();
+
+        return sprintf('<meta name="sentry-trace" content="%s" />', null !== $span ? $span->toTraceparent() : '');
+    }
+}

--- a/tests/Twig/SentryExtensionTest.php
+++ b/tests/Twig/SentryExtensionTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\Twig;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sentry\SentryBundle\Twig\SentryExtension;
+use Sentry\State\HubInterface;
+use Sentry\Tracing\Span;
+use Sentry\Tracing\SpanId;
+use Sentry\Tracing\TraceId;
+use Sentry\Tracing\Transaction;
+use Sentry\Tracing\TransactionContext;
+use Symfony\Bundle\TwigBundle\TwigBundle;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+final class SentryExtensionTest extends TestCase
+{
+    /**
+     * @var MockObject&HubInterface
+     */
+    private $hub;
+
+    public static function setUpBeforeClass(): void
+    {
+        if (!self::isTwigBundlePackageInstalled()) {
+            self::markTestSkipped('This test requires the "symfony/twig-bundle" Composer package to be installed.');
+        }
+    }
+
+    protected function setUp(): void
+    {
+        $this->hub = $this->createMock(HubInterface::class);
+    }
+
+    /**
+     * @dataProvider traceMetaFunctionDataProvider
+     */
+    public function testTraceMetaFunction(?Span $span, string $expectedTemplate): void
+    {
+        $this->hub->expects($this->once())
+            ->method('getSpan')
+            ->willReturn($span);
+
+        $environment = new Environment(new ArrayLoader(['foo.twig' => '{{ sentry_trace_meta() }}']));
+        $environment->addExtension(new SentryExtension($this->hub));
+
+        $this->assertSame($expectedTemplate, $environment->render('foo.twig'));
+    }
+
+    /**
+     * @return \Generator<mixed>
+     */
+    public function traceMetaFunctionDataProvider(): \Generator
+    {
+        yield [
+            null,
+            '<meta name="sentry-trace" content="" />',
+        ];
+
+        $transaction = new Transaction(new TransactionContext());
+        $transaction->setTraceId(new TraceId('a3c01c41d7b94b90aee23edac90f4319'));
+        $transaction->setSpanId(new SpanId('e69c2aef0ec34f2a'));
+
+        yield [
+            $transaction,
+            '<meta name="sentry-trace" content="a3c01c41d7b94b90aee23edac90f4319-e69c2aef0ec34f2a" />',
+        ];
+    }
+
+    private static function isTwigBundlePackageInstalled(): bool
+    {
+        return class_exists(TwigBundle::class);
+    }
+}


### PR DESCRIPTION
As per title, fixes #458 by adding the `sentry_trace_meta()` Twig function. Unlike the Laravel's SDK, I decided to always print the HTML meta tag regardless of whether a transaction/span is active because I like to be consistent in the expected output and because there should be no issue in having a blank string as its content