### PR TITLE
Fix static analysis due to Symfony 5.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Check for the presence of the `getUsername()` method when extracting the name of the logged-in user since `UserInterface::getUsername` got removed in Symfony 5.3 (#518)
+- Fix extraction of the username of the logged-in user in Symfony 5.3 (#518)
 
 ## 4.1.3 (2021-05-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Unreleased
 
+- Check for the presence of the `getUsername()` method when extracting the name of the logged-in user since `UserInterface::getUsername` got removed in Symfony 5.3 (#518)
+
 ## 4.1.3 (2021-05-31)
 
--  Fix missing require of the `symfony/cache-contracts` package (#506)
+- Fix missing require of the `symfony/cache-contracts` package (#506)
 
 ## 4.1.2 (2021-05-17)
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,6 +10,7 @@ parameters:
         - tests/End2End/App
     dynamicConstantNames:
         - Symfony\Component\HttpKernel\Kernel::VERSION
+        - Symfony\Component\HttpKernel\Kernel::VERSION_ID
         - Doctrine\DBAL\Version::VERSION
     stubFiles:
         - tests/Stubs/Profile.phpstub

--- a/src/EventListener/RequestListener.php
+++ b/src/EventListener/RequestListener.php
@@ -104,7 +104,13 @@ final class RequestListener
     private function getUsername($user): ?string
     {
         if ($user instanceof UserInterface) {
-            return method_exists($user, 'getUserIdentifier') ? $user->getUserIdentifier() : $user->getUsername();
+            if (method_exists($user, 'getUserIdentifier')) {
+                return $user->getUserIdentifier();
+            }
+
+            if (method_exists($user, 'getUsername')) {
+                return $user->getUsername();
+            }
         }
 
         if (\is_string($user)) {


### PR DESCRIPTION
This is tecnically a bug, even if it's really hard to come by in a real application.

It surfaced thanks to static analysis after the release of Symfony 5.3, in particular the removal of `UserInterface::getUsername`: https://github.com/symfony/symfony/pull/40403