### PR TITLE
Fix decoration of cache adapters inheriting parent service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix decoration of cache adapters inheriting parent service (#525)
 - Fix extraction of the username of the logged-in user in Symfony 5.3 (#518)
 
 ## 4.1.3 (2021-05-31)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -226,9 +226,19 @@ parameters:
 			path: tests/Tracing/Cache/AbstractTraceableCacheAdapterTest.php
 
 		-
-			message: "#^Parameter \\#2 \\$decoratedAdapter of class Sentry\\\\SentryBundle\\\\Tracing\\\\Cache\\\\TraceableTagAwareCacheAdapter constructor expects Symfony\\\\Component\\\\Cache\\\\Adapter\\\\TagAwareAdapterInterface, Symfony\\\\Component\\\\Cache\\\\Adapter\\\\AdapterInterface given\\.$#"
+			message: "#^Parameter \\#1 \\$decoratedAdapter of method Sentry\\\\SentryBundle\\\\Tests\\\\Tracing\\\\Cache\\\\AbstractTraceableCacheAdapterTest\\<TCacheAdapter of Symfony\\\\Component\\\\Cache\\\\Adapter\\\\AdapterInterface,TDecoratedCacheAdapter of Symfony\\\\Component\\\\Cache\\\\Adapter\\\\AdapterInterface\\>\\:\\:createCacheAdapter\\(\\) expects TDecoratedCacheAdapter of Symfony\\\\Component\\\\Cache\\\\Adapter\\\\AdapterInterface, PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&Sentry\\\\SentryBundle\\\\Tests\\\\Tracing\\\\Cache\\\\CacheInterface given\\.$#"
+			count: 2
+			path: tests/Tracing/Cache/AbstractTraceableCacheAdapterTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$decoratedAdapter of method Sentry\\\\SentryBundle\\\\Tests\\\\Tracing\\\\Cache\\\\AbstractTraceableCacheAdapterTest\\<TCacheAdapter of Symfony\\\\Component\\\\Cache\\\\Adapter\\\\AdapterInterface,TDecoratedCacheAdapter of Symfony\\\\Component\\\\Cache\\\\Adapter\\\\AdapterInterface\\>\\:\\:createCacheAdapter\\(\\) expects TDecoratedCacheAdapter of Symfony\\\\Component\\\\Cache\\\\Adapter\\\\AdapterInterface, PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&Sentry\\\\SentryBundle\\\\Tests\\\\Tracing\\\\Cache\\\\PruneableCacheAdapterInterface given\\.$#"
 			count: 1
-			path: tests/Tracing/Cache/TraceableTagAwareCacheAdapterTest.php
+			path: tests/Tracing/Cache/AbstractTraceableCacheAdapterTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$decoratedAdapter of method Sentry\\\\SentryBundle\\\\Tests\\\\Tracing\\\\Cache\\\\AbstractTraceableCacheAdapterTest\\<TCacheAdapter of Symfony\\\\Component\\\\Cache\\\\Adapter\\\\AdapterInterface,TDecoratedCacheAdapter of Symfony\\\\Component\\\\Cache\\\\Adapter\\\\AdapterInterface\\>\\:\\:createCacheAdapter\\(\\) expects TDecoratedCacheAdapter of Symfony\\\\Component\\\\Cache\\\\Adapter\\\\AdapterInterface, PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&Sentry\\\\SentryBundle\\\\Tests\\\\Tracing\\\\Cache\\\\ResettableCacheAdapterInterface given\\.$#"
+			count: 1
+			path: tests/Tracing/Cache/AbstractTraceableCacheAdapterTest.php
 
 		-
 			message: "#^Parameter \\#1 \\$driverException of class Doctrine\\\\DBAL\\\\Exception\\\\DriverException constructor expects Doctrine\\\\DBAL\\\\Driver\\\\Exception, string given\\.$#"

--- a/src/DependencyInjection/Compiler/CacheTracingPass.php
+++ b/src/DependencyInjection/Compiler/CacheTracingPass.php
@@ -52,9 +52,9 @@ final class CacheTracingPass implements CompilerPassInterface
     {
         $class = $definition->getClass();
 
-        while ($definition instanceof ChildDefinition) {
+        while (null === $class && $definition instanceof ChildDefinition) {
             $definition = $container->findDefinition($definition->getParent());
-            $class = $class ?: $definition->getClass();
+            $class = $definition->getClass();
         }
 
         return $class;

--- a/tests/DependencyInjection/Compiler/CacheTracingPassTest.php
+++ b/tests/DependencyInjection/Compiler/CacheTracingPassTest.php
@@ -66,7 +66,7 @@ final class CacheTracingPassTest extends TestCase
 
         yield 'Cache pool adapter service inheriting parent service' => [
             [
-                'app.cache.parent' => (new Definition(\get_class($cacheAdapter))),
+                'app.cache.parent' => new Definition(\get_class($cacheAdapter)),
                 'app.cache' => (new ChildDefinition('app.cache.parent'))
                     ->setPublic(true)
                     ->addTag('cache.pool'),
@@ -75,9 +75,34 @@ final class CacheTracingPassTest extends TestCase
             \get_class($cacheAdapter),
         ];
 
+        yield 'Tag-aware cache pool adapter service inheriting parent service and overriding class' => [
+            [
+                'app.cache.parent' => new Definition(\get_class($cacheAdapter)),
+                'app.cache' => (new ChildDefinition('app.cache.parent'))
+                    ->setClass(\get_class($tagAwareCacheAdapter))
+                    ->setPublic(true)
+                    ->addTag('cache.pool'),
+            ],
+            TraceableTagAwareCacheAdapter::class,
+            \get_class($tagAwareCacheAdapter),
+        ];
+
+        yield 'Tag-aware cache pool adapter service inheriting multiple parent services' => [
+            [
+                'app.cache.parent_1' => new Definition(\get_class($cacheAdapter)),
+                'app.cache.parent_2' => (new ChildDefinition('app.cache.parent_1'))
+                    ->setClass(\get_class($tagAwareCacheAdapter)),
+                'app.cache' => (new ChildDefinition('app.cache.parent_2'))
+                    ->setPublic(true)
+                    ->addTag('cache.pool'),
+            ],
+            TraceableTagAwareCacheAdapter::class,
+            \get_class($tagAwareCacheAdapter),
+        ];
+
         yield 'Tag-aware cache pool adapter service inheriting parent service' => [
             [
-                'app.cache.parent' => (new Definition(\get_class($tagAwareCacheAdapter))),
+                'app.cache.parent' => new Definition(\get_class($tagAwareCacheAdapter)),
                 'app.cache' => (new ChildDefinition('app.cache.parent'))
                     ->setPublic(true)
                     ->addTag('cache.pool'),

--- a/tests/Tracing/Cache/AbstractTraceableCacheAdapterTest.php
+++ b/tests/Tracing/Cache/AbstractTraceableCacheAdapterTest.php
@@ -18,6 +18,7 @@ use Symfony\Contracts\Cache\CacheInterface as BaseCacheInterface;
 
 /**
  * @phpstan-template TCacheAdapter of AdapterInterface
+ * @phpstan-template TDecoratedCacheAdapter of AdapterInterface
  */
 abstract class AbstractTraceableCacheAdapterTest extends TestCase
 {
@@ -410,12 +411,14 @@ abstract class AbstractTraceableCacheAdapterTest extends TestCase
     }
 
     /**
+     * @phpstan-param TDecoratedCacheAdapter $decoratedAdapter
+     *
      * @phpstan-return TCacheAdapter
      */
-    abstract protected function createCacheAdapter(AdapterInterface $decoratedAdapter): AdapterInterface;
+    abstract protected function createCacheAdapter(AdapterInterface $decoratedAdapter);
 
     /**
-     * @return class-string<AdapterInterface>
+     * @return class-string<TDecoratedCacheAdapter>
      */
     abstract protected static function getAdapterClassFqcn(): string;
 }

--- a/tests/Tracing/Cache/TraceableCacheAdapterTest.php
+++ b/tests/Tracing/Cache/TraceableCacheAdapterTest.php
@@ -8,14 +8,14 @@ use Sentry\SentryBundle\Tracing\Cache\TraceableCacheAdapter;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 
 /**
- * @phpstan-extends AbstractTraceableCacheAdapterTest<TraceableCacheAdapter>
+ * @phpstan-extends AbstractTraceableCacheAdapterTest<TraceableCacheAdapter, AdapterInterface>
  */
 final class TraceableCacheAdapterTest extends AbstractTraceableCacheAdapterTest
 {
     /**
      * {@inheritdoc}
      */
-    protected function createCacheAdapter(AdapterInterface $decoratedAdapter): AdapterInterface
+    protected function createCacheAdapter(AdapterInterface $decoratedAdapter): TraceableCacheAdapter
     {
         return new TraceableCacheAdapter($this->hub, $decoratedAdapter);
     }

--- a/tests/Tracing/Cache/TraceableTagAwareCacheAdapterTest.php
+++ b/tests/Tracing/Cache/TraceableTagAwareCacheAdapterTest.php
@@ -5,18 +5,46 @@ declare(strict_types=1);
 namespace Sentry\SentryBundle\Tests\Tracing\Cache;
 
 use Sentry\SentryBundle\Tracing\Cache\TraceableTagAwareCacheAdapter;
+use Sentry\Tracing\Transaction;
+use Sentry\Tracing\TransactionContext;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 
 /**
- * @phpstan-extends AbstractTraceableCacheAdapterTest<TraceableTagAwareCacheAdapter>
+ * @phpstan-extends AbstractTraceableCacheAdapterTest<TraceableTagAwareCacheAdapter, TagAwareAdapterInterface>
  */
 final class TraceableTagAwareCacheAdapterTest extends AbstractTraceableCacheAdapterTest
 {
+    public function testInvalidateTags(): void
+    {
+        $transaction = new Transaction(new TransactionContext(), $this->hub);
+        $transaction->initSpanRecorder();
+
+        $this->hub->expects($this->once())
+            ->method('getSpan')
+            ->willReturn($transaction);
+
+        $decoratedAdapter = $this->createMock(self::getAdapterClassFqcn());
+        $decoratedAdapter->expects($this->once())
+            ->method('invalidateTags')
+            ->with(['foo'])
+            ->willReturn(true);
+
+        $adapter = $this->createCacheAdapter($decoratedAdapter);
+
+        $this->assertTrue($adapter->invalidateTags(['foo']));
+
+        $spans = $transaction->getSpanRecorder()->getSpans();
+
+        $this->assertCount(2, $spans);
+        $this->assertSame('cache.invalidate_tags', $spans[1]->getOp());
+        $this->assertNotNull($spans[1]->getEndTimestamp());
+    }
+
     /**
      * {@inheritdoc}
      */
-    protected function createCacheAdapter(AdapterInterface $decoratedAdapter): AdapterInterface
+    protected function createCacheAdapter(AdapterInterface $decoratedAdapter): TraceableTagAwareCacheAdapter
     {
         return new TraceableTagAwareCacheAdapter($this->hub, $decoratedAdapter);
     }


### PR DESCRIPTION
Fixes #524: when running a compiler pass during the `TYPE_BEFORE_OPTIMIZATION` phase, services inheriting a parent one have not been resolved yet and consequently their class is still set to `null`. This was causing the check to decorate the cache adapter according to whether they were implementations of the `TagAwareAdapterInterface` interface or not to fail, resulting in the decorator to always inherit the base `AdapterInterface` interface even when the adaptor should have been an instance of `TagAwareAdapterInterface`