### PR TITLE
Add accessor for wrapped DBAL Connection to TracingDriverConnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Make the transport factory configurable in the bundle's config (#504)
 - Add the `sentry_trace_meta()` Twig function to print the `sentry-trace` HTML meta tag (#510)
 - Make the list of commands for which distributed tracing is active configurable (#515)
+- Introduce `TracingDriverConnection::getWrappedConnection()` (#536)
 
 ## 4.1.4 (2021-06-18)
 

--- a/src/Tracing/Doctrine/DBAL/TracingDriverConnection.php
+++ b/src/Tracing/Doctrine/DBAL/TracingDriverConnection.php
@@ -188,6 +188,11 @@ final class TracingDriverConnection implements DriverConnectionInterface
         throw new \BadMethodCallException(sprintf('The %s() method is not supported on Doctrine DBAL 3.0.', __METHOD__));
     }
 
+    public function getWrappedConnection(): DriverConnectionInterface
+    {
+        return $this->decoratedConnection;
+    }
+
     /**
      * @phpstan-template T
      *

--- a/tests/Tracing/Doctrine/DBAL/TracingDriverConnectionTest.php
+++ b/tests/Tracing/Doctrine/DBAL/TracingDriverConnectionTest.php
@@ -336,6 +336,13 @@ final class TracingDriverConnectionTest extends DoctrineTestCase
         $this->assertFalse($this->connection->rollBack());
     }
 
+    public function testGetWrappedConnection(): void
+    {
+        $connection = new TracingDriverConnection($this->hub, $this->decoratedConnection, 'foo_platform', []);
+
+        $this->assertSame($this->decoratedConnection, $connection->getWrappedConnection());
+    }
+
     /**
      * @return \Generator<mixed>
      */


### PR DESCRIPTION
Allows accessing e.g. underlying PDO instance so reflection does not have to be used for that.

Mimics DBAL's `Connection::getWrappedConnection()`` https://github.com/doctrine/dbal/blob/25496429ef4bba2352b0ced7daffe1b3dec83d13/src/Connection.php#L1518-L1525

Resolves https://github.com/getsentry/sentry-symfony/issues/522