### PR TITLE
fix(types): added nullability to getDatabase method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix return type for `TracingDriver::getDatabase()` method (#541)
+
 ## 4.2.0 (2021-08-12)
 
 - Log the bus name, receiver name and message class name as event tags when using Symfony Messenger (#492)

--- a/src/Tracing/Doctrine/DBAL/TracingDriver.php
+++ b/src/Tracing/Doctrine/DBAL/TracingDriver.php
@@ -101,7 +101,7 @@ final class TracingDriver implements DriverInterface, VersionAwarePlatformDriver
     /**
      * {@inheritdoc}
      */
-    public function getDatabase(Connection $conn): string
+    public function getDatabase(Connection $conn): ?string
     {
         if (method_exists($this->decoratedDriver, 'getDatabase')) {
             return $this->decoratedDriver->getDatabase($conn);


### PR DESCRIPTION
If getDatabase doesn't allow null return values, it will fail when the Driver returns null for this method.

It happens in https://github.com/webmozart/doctrine-dbal/blob/master/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php#L114 when using `DATABASE_URL="sqlite:///:memory:"`

this is weird because in-memory dbs are usually used in a test environments were sentry is deactivated, but this class is still being loaded and throws errors in all the tests. 

I get the following error in all the tests:
`TypeError : Return value of Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriver::getDatabase() must be of the type string, null returned`

with this change it works for me.