### PR TITLE
Avoid throwing from the `TraceableCacheAdapterTrait::prune()` and `TraceableCacheAdapterTrait::reset()` methods when the decorated adapter doesn't implement the respective interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix return type for `TracingDriver::getDatabase()` method (#541)
+- Avoid throwing exception from the `TraceableCacheAdapterTrait::prune()` and `TraceableCacheAdapterTrait::reset()` methods when the decorated adapter does not implement the respective interfaces (#543)
 
 ## 4.2.0 (2021-08-12)
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -222,7 +222,7 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method TCacheAdapter of Symfony\\\\Component\\\\Cache\\\\Adapter\\\\AdapterInterface\\:\\:reset\\(\\)\\.$#"
-			count: 2
+			count: 1
 			path: tests/Tracing/Cache/AbstractTraceableCacheAdapterTest.php
 
 		-

--- a/src/Tracing/Cache/TraceableCacheAdapterTrait.php
+++ b/src/Tracing/Cache/TraceableCacheAdapterTrait.php
@@ -159,7 +159,7 @@ trait TraceableCacheAdapterTrait
     {
         return $this->traceFunction('cache.prune', function (): bool {
             if (!$this->decoratedAdapter instanceof PruneableInterface) {
-                throw new \BadMethodCallException(sprintf('The %s::prune() method is not supported because the decorated adapter does not implement the "%s" interface.', self::class, PruneableInterface::class));
+                return false;
             }
 
             return $this->decoratedAdapter->prune();
@@ -171,11 +171,9 @@ trait TraceableCacheAdapterTrait
      */
     public function reset(): void
     {
-        if (!$this->decoratedAdapter instanceof ResettableInterface) {
-            throw new \BadMethodCallException(sprintf('The %s::reset() method is not supported because the decorated adapter does not implement the "%s" interface.', self::class, ResettableInterface::class));
+        if ($this->decoratedAdapter instanceof ResettableInterface) {
+            $this->decoratedAdapter->reset();
         }
-
-        $this->decoratedAdapter->reset();
     }
 
     /**

--- a/tests/Tracing/Cache/AbstractTraceableCacheAdapterTest.php
+++ b/tests/Tracing/Cache/AbstractTraceableCacheAdapterTest.php
@@ -375,14 +375,24 @@ abstract class AbstractTraceableCacheAdapterTest extends TestCase
         $this->assertNotNull($spans[1]->getEndTimestamp());
     }
 
-    public function testPruneThrowsExceptionIfDecoratedAdapterIsNotPruneable(): void
+    public function testPruneReturnsFalseIfDecoratedAdapterIsNotPruneable(): void
     {
+        $transaction = new Transaction(new TransactionContext(), $this->hub);
+        $transaction->initSpanRecorder();
+
+        $this->hub->expects($this->once())
+            ->method('getSpan')
+            ->willReturn($transaction);
+
         $adapter = $this->createCacheAdapter($this->createMock(static::getAdapterClassFqcn()));
 
-        $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage(sprintf('The %s::prune() method is not supported because the decorated adapter does not implement the "Symfony\\Component\\Cache\\PruneableInterface" interface.', \get_class($adapter)));
+        $this->assertFalse($adapter->prune());
 
-        $adapter->prune();
+        $spans = $transaction->getSpanRecorder()->getSpans();
+
+        $this->assertCount(2, $spans);
+        $this->assertSame('cache.prune', $spans[1]->getOp());
+        $this->assertNotNull($spans[1]->getEndTimestamp());
     }
 
     public function testReset(): void
@@ -392,16 +402,6 @@ abstract class AbstractTraceableCacheAdapterTest extends TestCase
             ->method('reset');
 
         $adapter = $this->createCacheAdapter($decoratedAdapter);
-        $adapter->reset();
-    }
-
-    public function testResetThrowsExceptionIfDecoratedAdapterIsNotResettable(): void
-    {
-        $adapter = $this->createCacheAdapter($this->createMock(static::getAdapterClassFqcn()));
-
-        $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage(sprintf('The %s::reset() method is not supported because the decorated adapter does not implement the "Symfony\\Component\\Cache\\ResettableInterface" interface.', \get_class($adapter)));
-
         $adapter->reset();
     }
 


### PR DESCRIPTION
Fixes #542 by avoiding to throw from the `TraceableCacheAdapterTrait::prune()` and `TraceableCacheAdapterTrait::reset()` methods if the decorated adapter doesn't implement the respective interfaces