### PR TITLE
Lower the version requirement for the `symfony/cache-contracts` package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "jean85/pretty-package-versions": "^1.5 || ^2.0",
         "php-http/discovery": "^1.11",
         "sentry/sdk": "^3.1",
-        "symfony/cache-contracts": "^2.4",
+        "symfony/cache-contracts": "^1.1||^2.4",
         "symfony/config": "^3.4.44||^4.4.20||^5.0.11",
         "symfony/console": "^3.4.44||^4.4.20||^5.0.11",
         "symfony/dependency-injection": "^3.4.44||^4.4.20||^5.0.11",


### PR DESCRIPTION
While investigating #545, I noticed that we are requiring `symfony/cache-contracts:^2.4` while `symfony/symfony:^4.4` requires `symfony/cache-contracts:^1.1` (actually it replaces that package with `symfony/contracts:^1.1`). This makes it impossible to install `sentry/sentry-symfony:^4.2` on a plain Symfony `4.4` installation (no Flex). ~However, I cannot understand why it works with `sentry/sentry-symfony:4.1.3` though, since that version is the one where the `composer.json` requirement actually got changed~