### PR TITLE
define TracingStatement alias conditionally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: Test if `TracingStatement` exists before attempting to create the class alias, otherwise it breaks when opcache is enabled. (#552)
+
 ## 4.2.2 (2021-08-30)
 
 - Fix missing instrumentation of the `Statement::execute()` method of Doctrine DBAL (#548)

--- a/src/aliases.php
+++ b/src/aliases.php
@@ -87,8 +87,10 @@ if (!interface_exists(LegacyExceptionConverterDriverInterface::class)) {
     class_alias(ExceptionConverterDriverInterface::class, LegacyExceptionConverterDriverInterface::class);
 }
 
-if (class_exists(Result::class)) {
-    class_alias(TracingStatementForV3::class, 'Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingStatement');
-} elseif (interface_exists(Result::class)) {
-    class_alias(TracingStatementForV2::class, 'Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingStatement');
+if (!class_exists('Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingStatement')) {
+    if (class_exists(Result::class)) {
+        class_alias(TracingStatementForV3::class, 'Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingStatement');
+    } elseif (interface_exists(Result::class)) {
+        class_alias(TracingStatementForV2::class, 'Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingStatement');
+    }
 }


### PR DESCRIPTION
Since the alias is defined unconditionally, when using opcache PHP emits a Warning that can break applications.

