### PR TITLE
Pass logger from options to TransportFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix: Test if `TracingStatement` exists before attempting to create the class alias, otherwise it breaks when opcache is enabled. (#552)
+- Fix: Pass logger from `logger` config option to `TransportFactory` (#555)
 
 ## 4.2.2 (2021-08-30)
 

--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -27,6 +27,7 @@ use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverMiddleware;
 use Sentry\SentryBundle\Tracing\Twig\TwigTracingExtension;
 use Sentry\Serializer\RepresentationSerializer;
 use Sentry\Serializer\Serializer;
+use Sentry\Transport\TransportFactoryInterface;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Cache\CacheItem;
 use Symfony\Component\Config\FileLocator;
@@ -124,6 +125,13 @@ final class SentryExtension extends ConfigurableExtension
             ->setPublic(false)
             ->setArgument(0, new Reference('sentry.client.options'));
 
+        $loggerReference = null === $config['logger']
+            ? new Reference(NullLogger::class, ContainerBuilder::IGNORE_ON_INVALID_REFERENCE)
+            : new Reference($config['logger']);
+
+        $factoryBuilderDefinition = $container->getDefinition(TransportFactoryInterface::class);
+        $factoryBuilderDefinition->setArgument('$logger', $loggerReference);
+
         $clientBuilderDefinition = (new Definition(ClientBuilder::class))
             ->setArgument(0, new Reference('sentry.client.options'))
             ->addMethodCall('setSdkIdentifier', [SentryBundle::SDK_IDENTIFIER])
@@ -131,7 +139,7 @@ final class SentryExtension extends ConfigurableExtension
             ->addMethodCall('setTransportFactory', [new Reference($config['transport_factory'])])
             ->addMethodCall('setSerializer', [$serializer])
             ->addMethodCall('setRepresentationSerializer', [$representationSerializerDefinition])
-            ->addMethodCall('setLogger', [null !== $config['logger'] ? new Reference($config['logger']) : new Reference(NullLogger::class, ContainerBuilder::IGNORE_ON_INVALID_REFERENCE)]);
+            ->addMethodCall('setLogger', [$loggerReference]);
 
         $container
             ->setDefinition('sentry.client', new Definition(Client::class))

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -14,6 +14,8 @@
             <argument type="service" id="Psr\Http\Message\RequestFactoryInterface" on-invalid="ignore" />
             <argument type="service" id="Psr\Http\Message\ResponseFactoryInterface" on-invalid="ignore" />
             <argument type="service" id="Psr\Http\Message\StreamFactoryInterface" on-invalid="ignore" />
+            <argument>null</argument>
+            <argument /> <!-- $logger -->
         </service>
 
         <service id="Sentry\State\HubInterface">

--- a/tests/DependencyInjection/SentryExtensionTest.php
+++ b/tests/DependencyInjection/SentryExtensionTest.php
@@ -26,6 +26,7 @@ use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverMiddleware;
 use Sentry\SentryBundle\Tracing\Twig\TwigTracingExtension;
 use Sentry\Serializer\RepresentationSerializer;
 use Sentry\Serializer\Serializer;
+use Sentry\Transport\TransportFactoryInterface;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -243,6 +244,16 @@ abstract class SentryExtensionTest extends TestCase
         $this->assertInstanceOf(Definition::class, $methodCalls[4][1][0]);
         $this->assertSame(RepresentationSerializer::class, $methodCalls[4][1][0]->getClass());
         $this->assertEquals($methodCalls[4][1][0]->getArgument(0), new Reference('sentry.client.options'));
+    }
+
+    public function testLoggerIsPassedToTransportFactory(): void
+    {
+        $container = $this->createContainerFromFixture('full');
+
+        $transportFactoryDefinition = $container->findDefinition(TransportFactoryInterface::class);
+        $logger = $transportFactoryDefinition->getArgument('$logger');
+
+        $this->assertSame('app.logger', $logger->__toString());
     }
 
     public function testErrorTypesOptionIsParsedFromStringToIntegerValue(): void


### PR DESCRIPTION
I have noticed that a transport error was being logged in https://github.com/getsentry/sentry-php/blob/bfab90c7ef921221b52b75b5108201e87f0f4661/src/Transport/HttpTransport.php#L112-L115

but there always was default NullLogger registered. So I've found that even though I set logger via `options` it was not being passed to the Transport.

This fixes it.