### PR TITLE
Add failing test for register_error_listener

### DIFF
--- a/tests/DependencyInjection/Fixtures/php/error_listener_disabled_from_env.php
+++ b/tests/DependencyInjection/Fixtures/php/error_listener_disabled_from_env.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/** @var ContainerBuilder $container */
+$container->setParameter('env(REGISTER_ERROR_LISTENER)', 'false');
+$container->loadFromExtension('sentry', [
+    'register_error_listener' => '%env(bool:REGISTER_ERROR_LISTENER)%',
+]);

--- a/tests/DependencyInjection/Fixtures/xml/error_listener_disabled_from_env.xml
+++ b/tests/DependencyInjection/Fixtures/xml/error_listener_disabled_from_env.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:sentry="https://sentry.io/schema/dic/sentry-symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                               https://sentry.io/schema/dic/sentry-symfony https://sentry.io/schema/dic/sentry-symfony/sentry-1.0.xsd">
+    <parameters>
+        <parameter key="env(REGISTER_ERROR_LISTENER)">false</parameter>
+    </parameters>
+    <sentry:config register-error-listener="%env(bool:REGISTER_ERROR_LISTENER)%" />
+</container>

--- a/tests/DependencyInjection/Fixtures/yml/error_listener_disabled_from_env.yml
+++ b/tests/DependencyInjection/Fixtures/yml/error_listener_disabled_from_env.yml
@@ -1,0 +1,4 @@
+parameters:
+    env(REGISTER_ERROR_LISTENER): "false"
+sentry:
+    register_error_listener: "%env(bool:REGISTER_ERROR_LISTENER)%"

--- a/tests/DependencyInjection/SentryExtensionTest.php
+++ b/tests/DependencyInjection/SentryExtensionTest.php
@@ -56,6 +56,13 @@ abstract class SentryExtensionTest extends TestCase
         ], $definition->getTag('kernel.event_listener')[0]);
     }
 
+    public function testErrorListenerDisabledFromEnv(): void
+    {
+        $container = $this->createContainerFromFixture('error_listener_disabled_from_env');
+
+        $this->assertFalse($container->hasDefinition(ErrorListener::class));
+    }
+
     public function testErrorListenerIsRemovedWhenDisabled(): void
     {
         $container = $this->createContainerFromFixture('error_listener_disabled');


### PR DESCRIPTION
Pulling this value from the ENV doesn't seem to work as this test
demonstrates.

Instead of a boolean I'm seeing `env_e71e97ef5efbff51_bool_REGISTER_ERROR_LISTENER_ee2aa964b5d330a7af36cf7065e7419f` at https://github.com/getsentry/sentry-symfony/blob/31edf15fd22fcfb2ba0989cef7d70f34a41f6abf/src/DependencyInjection/SentryExtension.php#L259 I assume something needs to be adjusted to get Symfony to send the real value, but I'm not familiar with the DI system and can't see where that may be so I've just included this failing test in the hope that it helps resolve the issue.