### PR TITLE
Add missing return type hints to the methods of the `SentryExtension` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add typehint to `SentryExtension` dependency injection (Symfony 5.4).
+
 ## 4.2.3 (2021-09-21)
 
 - Fix: Test if `TracingStatement` exists before attempting to create the class alias, otherwise it breaks when opcache is enabled. (#552)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Add return typehints to `SentryExtension` dependency injection to prepare for Symfony 6. (#563)
+- Add return typehints to the methods of the `SentryExtension` class to prepare for Symfony 6 (#563)
 
 ## 4.2.3 (2021-09-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Add typehint to `SentryExtension` dependency injection (Symfony 5.4).
+- Add return typehints to `SentryExtension` dependency injection to prepare for Symfony 6. (#563)
 
 ## 4.2.3 (2021-09-21)
 

--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -43,7 +43,7 @@ final class SentryExtension extends ConfigurableExtension
     /**
      * {@inheritdoc}
      */
-    public function getXsdValidationBasePath()
+    public function getXsdValidationBasePath(): string
     {
         return __DIR__ . '/../Resources/config/schema';
     }
@@ -51,7 +51,7 @@ final class SentryExtension extends ConfigurableExtension
     /**
      * {@inheritdoc}
      */
-    public function getNamespace()
+    public function getNamespace(): string
     {
         return 'https://sentry.io/schema/dic/sentry-symfony';
     }


### PR DESCRIPTION
I'm testing symfony 5.4-dev and I'm getting few warning related with sentry-symfony

<img width="961" alt="Screenshot 2021-10-04 at 13 48 37" src="https://user-images.githubusercontent.com/6358755/135846615-3b292575-a7ca-41bb-9e7d-70f3eb13ac10.png">
