### PR TITLE
Fix decoration of the Doctrine DBAL connection when it implemented the `ServerInfoAwareConnection` interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add return typehints to the methods of the `SentryExtension` class to prepare for Symfony 6 (#563)
 - Fix setting the IP address on the user context when it's not available (#565)
 - Fix wrong method existence check in `TracingDriverConnection::errorCode()` (#568)
+- Fix decoration of the Doctrine DBAL connection when it implemented the `ServerInfoAwareConnection` interface (#567)
 
 ## 4.2.3 (2021-09-21)
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -36,6 +36,26 @@ parameters:
 			path: src/Tracing/Doctrine/DBAL/TracingDriverConnection.php
 
 		-
+			message: "#^Method Sentry\\\\SentryBundle\\\\Tracing\\\\Doctrine\\\\DBAL\\\\TracingServerInfoAwareDriverConnection\\:\\:errorInfo\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tracing/Doctrine/DBAL/TracingServerInfoAwareDriverConnection.php
+
+		-
+			message: "#^Method Sentry\\\\SentryBundle\\\\Tracing\\\\Doctrine\\\\DBAL\\\\TracingServerInfoAwareDriverConnection\\:\\:exec\\(\\) has parameter \\$sql with no typehint specified\\.$#"
+			count: 1
+			path: src/Tracing/Doctrine/DBAL/TracingServerInfoAwareDriverConnection.php
+
+		-
+			message: "#^Method Sentry\\\\SentryBundle\\\\Tracing\\\\Doctrine\\\\DBAL\\\\TracingServerInfoAwareDriverConnection\\:\\:prepare\\(\\) has parameter \\$sql with no typehint specified\\.$#"
+			count: 1
+			path: src/Tracing/Doctrine/DBAL/TracingServerInfoAwareDriverConnection.php
+
+		-
+			message: "#^Method Sentry\\\\SentryBundle\\\\Tracing\\\\Doctrine\\\\DBAL\\\\TracingServerInfoAwareDriverConnection\\:\\:query\\(\\) has parameter \\$args with no typehint specified\\.$#"
+			count: 1
+			path: src/Tracing/Doctrine/DBAL/TracingServerInfoAwareDriverConnection.php
+
+		-
 			message: "#^Class Symfony\\\\Bundle\\\\FrameworkBundle\\\\Client not found\\.$#"
 			count: 1
 			path: tests/End2End/TracingEnd2EndTest.php
@@ -169,6 +189,26 @@ parameters:
 			message: "#^Trying to mock an undefined method errorInfo\\(\\) on class Doctrine\\\\DBAL\\\\Driver\\\\Connection\\.$#"
 			count: 1
 			path: tests/Tracing/Doctrine/DBAL/TracingDriverConnectionTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$hubOrConnectionFactory of class Sentry\\\\SentryBundle\\\\Tracing\\\\Doctrine\\\\DBAL\\\\TracingDriverMiddleware constructor expects Sentry\\\\SentryBundle\\\\Tracing\\\\Doctrine\\\\DBAL\\\\TracingDriverConnectionFactoryInterface\\|Sentry\\\\State\\\\HubInterface, null given\\.$#"
+			count: 1
+			path: tests/Tracing/Doctrine/DBAL/TracingDriverMiddlewareTest.php
+
+		-
+			message: "#^Trying to mock an undefined method errorCode\\(\\) on class Sentry\\\\SentryBundle\\\\Tracing\\\\Doctrine\\\\DBAL\\\\TracingDriverConnectionInterface\\.$#"
+			count: 1
+			path: tests/Tracing/Doctrine/DBAL/TracingServerInfoAwareDriverConnectionTest.php
+
+		-
+			message: "#^Trying to mock an undefined method errorInfo\\(\\) on class Sentry\\\\SentryBundle\\\\Tracing\\\\Doctrine\\\\DBAL\\\\TracingDriverConnectionInterface\\.$#"
+			count: 1
+			path: tests/Tracing/Doctrine/DBAL/TracingServerInfoAwareDriverConnectionTest.php
+
+		-
+			message: "#^Trying to mock an undefined method requiresQueryForServerVersion\\(\\) on class Sentry\\\\SentryBundle\\\\Tests\\\\Tracing\\\\Doctrine\\\\DBAL\\\\ServerInfoAwareConnectionStub\\.$#"
+			count: 1
+			path: tests/Tracing/Doctrine/DBAL/TracingServerInfoAwareDriverConnectionTest.php
 
 		-
 			message: "#^Trying to mock an undefined method closeCursor\\(\\) on class Doctrine\\\\DBAL\\\\Driver\\\\Statement\\.$#"

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -91,8 +91,14 @@
             <tag name="console.command" />
         </service>
 
-        <service id="Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverMiddleware" class="Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverMiddleware">
+        <service id="Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverConnectionFactoryInterface" alias="Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverConnectionFactory" />
+
+        <service id="Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverConnectionFactory" class="Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverConnectionFactory">
             <argument type="service" id="Sentry\State\HubInterface" />
+        </service>
+
+        <service id="Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverMiddleware" class="Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverMiddleware">
+            <argument type="service" id="Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverConnectionFactoryInterface" />
         </service>
 
         <service id="Sentry\SentryBundle\Tracing\Doctrine\DBAL\ConnectionConfigurator" class="Sentry\SentryBundle\Tracing\Doctrine\DBAL\ConnectionConfigurator">

--- a/src/Tracing/Doctrine/DBAL/TracingDriverConnection.php
+++ b/src/Tracing/Doctrine/DBAL/TracingDriverConnection.php
@@ -16,7 +16,7 @@ use Sentry\Tracing\SpanContext;
  * capabilities to Doctrine DBAL. This implementation IS and MUST be compatible
  * with all versions of Doctrine DBAL >= 2.10.
  */
-final class TracingDriverConnection implements DriverConnectionInterface
+final class TracingDriverConnection implements TracingDriverConnectionInterface
 {
     /**
      * @internal

--- a/src/Tracing/Doctrine/DBAL/TracingDriverConnectionFactory.php
+++ b/src/Tracing/Doctrine/DBAL/TracingDriverConnectionFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tracing\Doctrine\DBAL;
+
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Sentry\State\HubInterface;
+
+/**
+ * @internal
+ */
+final class TracingDriverConnectionFactory implements TracingDriverConnectionFactoryInterface
+{
+    /**
+     * @var HubInterface The current hub
+     */
+    private $hub;
+
+    /**
+     * Constructor.
+     *
+     * @param HubInterface $hub The current hub
+     */
+    public function __construct(HubInterface $hub)
+    {
+        $this->hub = $hub;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(Connection $connection, AbstractPlatform $databasePlatform, array $params): TracingDriverConnectionInterface
+    {
+        $tracingDriverConnection = new TracingDriverConnection(
+            $this->hub,
+            $connection,
+            $databasePlatform->getName(),
+            $params
+        );
+
+        if ($connection instanceof ServerInfoAwareConnection) {
+            $tracingDriverConnection = new TracingServerInfoAwareDriverConnection($tracingDriverConnection);
+        }
+
+        return $tracingDriverConnection;
+    }
+}

--- a/src/Tracing/Doctrine/DBAL/TracingDriverConnectionFactoryInterface.php
+++ b/src/Tracing/Doctrine/DBAL/TracingDriverConnectionFactoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tracing\Doctrine\DBAL;
+
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+interface TracingDriverConnectionFactoryInterface
+{
+    /**
+     * Creates an instance of a driver connection which is decorated to trace
+     * the performances of the queries.
+     *
+     * @param Connection           $connection       The connection to wrap
+     * @param AbstractPlatform     $databasePlatform The database platform
+     * @param array<string, mixed> $params           The params of the connection
+     */
+    public function create(Connection $connection, AbstractPlatform $databasePlatform, array $params): TracingDriverConnectionInterface;
+}

--- a/src/Tracing/Doctrine/DBAL/TracingDriverConnectionInterface.php
+++ b/src/Tracing/Doctrine/DBAL/TracingDriverConnectionInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tracing\Doctrine\DBAL;
+
+use Doctrine\DBAL\Driver\Connection;
+
+interface TracingDriverConnectionInterface extends Connection
+{
+    public function getWrappedConnection(): Connection;
+}

--- a/src/Tracing/Doctrine/DBAL/TracingServerInfoAwareDriverConnection.php
+++ b/src/Tracing/Doctrine/DBAL/TracingServerInfoAwareDriverConnection.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tracing\Doctrine\DBAL;
+
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
+use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\ParameterType;
+
+/**
+ * This is a simple implementation of the {@see ServerInfoAwareConnection} interface
+ * that forwards all method calls to the connection being decorated.
+ *
+ * @internal
+ */
+final class TracingServerInfoAwareDriverConnection implements TracingDriverConnectionInterface, ServerInfoAwareConnection
+{
+    /**
+     * @var TracingDriverConnectionInterface The decorated connection
+     */
+    private $decoratedConnection;
+
+    /**
+     * Constructor.
+     *
+     * @param TracingDriverConnectionInterface $decoratedConnection The decorated connection
+     */
+    public function __construct(TracingDriverConnectionInterface $decoratedConnection)
+    {
+        $this->decoratedConnection = $decoratedConnection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prepare($sql): Statement
+    {
+        return $this->decoratedConnection->prepare($sql);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function query(?string $sql = null, ...$args): Result
+    {
+        return $this->decoratedConnection->query($sql, ...$args);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function quote($value, $type = ParameterType::STRING)
+    {
+        return $this->decoratedConnection->quote($value, $type);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function exec($sql): int
+    {
+        return $this->decoratedConnection->exec($sql);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function lastInsertId($name = null): ?string
+    {
+        return $this->decoratedConnection->lastInsertId($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function beginTransaction(): bool
+    {
+        return $this->decoratedConnection->beginTransaction();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function commit(): bool
+    {
+        return $this->decoratedConnection->commit();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rollBack(): bool
+    {
+        return $this->decoratedConnection->rollBack();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getServerVersion(): string
+    {
+        $wrappedConnection = $this->getWrappedConnection();
+
+        if (!$wrappedConnection instanceof ServerInfoAwareConnection) {
+            throw new \BadMethodCallException(sprintf('The wrapped connection must be an instance of the "%s" interface.', ServerInfoAwareConnection::class));
+        }
+
+        return $wrappedConnection->getServerVersion();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function requiresQueryForServerVersion(): bool
+    {
+        $wrappedConnection = $this->getWrappedConnection();
+
+        if (!$wrappedConnection instanceof ServerInfoAwareConnection) {
+            throw new \BadMethodCallException(sprintf('The wrapped connection must be an instance of the "%s" interface.', ServerInfoAwareConnection::class));
+        }
+
+        if (!method_exists($wrappedConnection, 'requiresQueryForServerVersion')) {
+            throw new \BadMethodCallException(sprintf('The %s() method is not supported on Doctrine DBAL 3.0.', __METHOD__));
+        }
+
+        return $wrappedConnection->requiresQueryForServerVersion();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function errorCode(): ?string
+    {
+        if (method_exists($this->decoratedConnection, 'errorCode')) {
+            return $this->decoratedConnection->errorCode();
+        }
+
+        throw new \BadMethodCallException(sprintf('The %s() method is not supported on Doctrine DBAL 3.0.', __METHOD__));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function errorInfo(): array
+    {
+        if (method_exists($this->decoratedConnection, 'errorInfo')) {
+            return $this->decoratedConnection->errorInfo();
+        }
+
+        throw new \BadMethodCallException(sprintf('The %s() method is not supported on Doctrine DBAL 3.0.', __METHOD__));
+    }
+
+    public function getWrappedConnection(): Connection
+    {
+        return $this->decoratedConnection->getWrappedConnection();
+    }
+}

--- a/tests/Tracing/Doctrine/DBAL/ServerInfoAwareConnectionStub.php
+++ b/tests/Tracing/Doctrine/DBAL/ServerInfoAwareConnectionStub.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\Tracing\Doctrine\DBAL;
+
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
+
+interface ServerInfoAwareConnectionStub extends Connection, ServerInfoAwareConnection
+{
+}

--- a/tests/Tracing/Doctrine/DBAL/TracingDriverConnectionFactoryTest.php
+++ b/tests/Tracing/Doctrine/DBAL/TracingDriverConnectionFactoryTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\Tracing\Doctrine\DBAL;
+
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use PHPUnit\Framework\MockObject\MockObject;
+use Sentry\SentryBundle\Tests\DoctrineTestCase;
+use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverConnection;
+use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverConnectionFactory;
+use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingServerInfoAwareDriverConnection;
+use Sentry\State\HubInterface;
+
+final class TracingDriverConnectionFactoryTest extends DoctrineTestCase
+{
+    /**
+     * @var MockObject&HubInterface
+     */
+    private $hub;
+
+    /**
+     * @var MockObject&AbstractPlatform
+     */
+    private $databasePlatform;
+
+    /**
+     * @var TracingDriverConnectionFactory
+     */
+    private $tracingDriverConnectionFactory;
+
+    public static function setUpBeforeClass(): void
+    {
+        if (!self::isDoctrineDBALInstalled()) {
+            self::markTestSkipped('This test requires the "doctrine/dbal" Composer package.');
+        }
+    }
+
+    protected function setUp(): void
+    {
+        $this->hub = $this->createMock(HubInterface::class);
+        $this->databasePlatform = $this->createMock(AbstractPlatform::class);
+        $this->tracingDriverConnectionFactory = new TracingDriverConnectionFactory($this->hub);
+    }
+
+    public function testCreate(): void
+    {
+        $this->databasePlatform->expects($this->once())
+            ->method('getName')
+            ->willReturn('foo_platform');
+
+        $connection = $this->createMock(Connection::class);
+        $driverConnection = $this->tracingDriverConnectionFactory->create($connection, $this->databasePlatform, []);
+        $expectedDriverConnection = new TracingDriverConnection($this->hub, $connection, 'foo_platform', []);
+
+        $this->assertEquals($expectedDriverConnection, $driverConnection);
+    }
+
+    public function testCreateWithServerInfoAwareConnection(): void
+    {
+        if (!self::isDoctrineDBALVersion3Installed()) {
+            self::markTestSkipped('This test requires the version of the "doctrine/dbal" Composer package to be >= 3.0.');
+        }
+
+        $this->databasePlatform->expects($this->once())
+            ->method('getName')
+            ->willReturn('foo_platform');
+
+        $connection = $this->createMock(ServerInfoAwareConnectionStub::class);
+        $driverConnection = $this->tracingDriverConnectionFactory->create($connection, $this->databasePlatform, []);
+        $expectedDriverConnection = new TracingServerInfoAwareDriverConnection(new TracingDriverConnection($this->hub, $connection, 'foo_platform', []));
+
+        $this->assertEquals($expectedDriverConnection, $driverConnection);
+    }
+}

--- a/tests/Tracing/Doctrine/DBAL/TracingDriverMiddlewareTest.php
+++ b/tests/Tracing/Doctrine/DBAL/TracingDriverMiddlewareTest.php
@@ -5,23 +5,16 @@ declare(strict_types=1);
 namespace Sentry\SentryBundle\Tests\Tracing\Doctrine\DBAL;
 
 use Doctrine\DBAL\Driver as DriverInterface;
-use PHPUnit\Framework\MockObject\MockObject;
 use Sentry\SentryBundle\Tests\DoctrineTestCase;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriver;
+use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverConnectionFactoryInterface;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverMiddleware;
 use Sentry\State\HubInterface;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 final class TracingDriverMiddlewareTest extends DoctrineTestCase
 {
-    /**
-     * @var MockObject&HubInterface
-     */
-    private $hub;
-
-    /**
-     * @var TracingDriverMiddleware
-     */
-    private $middleware;
+    use ExpectDeprecationTrait;
 
     public static function setUpBeforeClass(): void
     {
@@ -30,16 +23,34 @@ final class TracingDriverMiddlewareTest extends DoctrineTestCase
         }
     }
 
-    protected function setUp(): void
+    public function testConstructorThrowsExceptionIfArgumentIsInvalid(): void
     {
-        $this->hub = $this->createMock(HubInterface::class);
-        $this->middleware = new TracingDriverMiddleware($this->hub);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The constructor requires either an instance of the "Sentry\\State\\HubInterface" interface or an instance of the "Sentry\\SentryBundle\\Tracing\\Doctrine\DBAL\\TracingDriverConnectionFactoryInterface" interface.');
+
+        new TracingDriverMiddleware(null);
     }
 
-    public function testWrap(): void
+    /**
+     * @group legacy
+     */
+    public function testWrapWithProvidedHubInstance(): void
+    {
+        $this->expectDeprecation('Not passing an instance of the "Sentry\\SentryBundle\\Tracing\\Doctrine\DBAL\\TracingDriverConnectionFactoryInterface" interface as argument of the constructor is deprecated since version 4.2 and will not work since version 5.0.');
+
+        $driver = $this->createMock(DriverInterface::class);
+        $hub = $this->createMock(HubInterface::class);
+        $middleware = new TracingDriverMiddleware($hub);
+
+        $this->assertInstanceOf(TracingDriver::class, $middleware->wrap($driver));
+    }
+
+    public function testWrapWithProvidedConnectionFactoryInstance(): void
     {
         $driver = $this->createMock(DriverInterface::class);
+        $connectionFactory = $this->createMock(TracingDriverConnectionFactoryInterface::class);
+        $middleware = new TracingDriverMiddleware($connectionFactory);
 
-        $this->assertInstanceOf(TracingDriver::class, $this->middleware->wrap($driver));
+        $this->assertInstanceOf(TracingDriver::class, $middleware->wrap($driver));
     }
 }

--- a/tests/Tracing/Doctrine/DBAL/TracingServerInfoAwareDriverConnectionTest.php
+++ b/tests/Tracing/Doctrine/DBAL/TracingServerInfoAwareDriverConnectionTest.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\Tracing\Doctrine\DBAL;
+
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\ParameterType;
+use PHPUnit\Framework\MockObject\MockObject;
+use Sentry\SentryBundle\Tests\DoctrineTestCase;
+use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverConnectionInterface;
+use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingServerInfoAwareDriverConnection;
+
+final class TracingServerInfoAwareDriverConnectionTest extends DoctrineTestCase
+{
+    /**
+     * @var MockObject&TracingDriverConnectionInterface
+     */
+    private $decoratedConnection;
+
+    /**
+     * @var TracingServerInfoAwareDriverConnection
+     */
+    private $connection;
+
+    public static function setUpBeforeClass(): void
+    {
+        if (!self::isDoctrineBundlePackageInstalled()) {
+            self::markTestSkipped();
+        }
+    }
+
+    protected function setUp(): void
+    {
+        $this->decoratedConnection = $this->createMock(TracingDriverConnectionInterface::class);
+        $this->connection = new TracingServerInfoAwareDriverConnection($this->decoratedConnection);
+    }
+
+    public function testPrepare(): void
+    {
+        $statement = $this->createMock(Statement::class);
+
+        $this->decoratedConnection->expects($this->once())
+            ->method('prepare')
+            ->with('SELECT 1 + 1')
+            ->willReturn($statement);
+
+        $this->assertSame($statement, $this->connection->prepare('SELECT 1 + 1'));
+    }
+
+    public function testQuery(): void
+    {
+        $result = $this->createMock(Result::class);
+
+        $this->decoratedConnection->expects($this->once())
+            ->method('query')
+            ->with('SELECT 1 + 1', 'foo', 'bar')
+            ->willReturn($result);
+
+        $this->assertSame($result, $this->connection->query('SELECT 1 + 1', 'foo', 'bar'));
+    }
+
+    public function testQuote(): void
+    {
+        $this->decoratedConnection->expects($this->once())
+            ->method('quote')
+            ->with('foo', ParameterType::STRING)
+            ->willReturn('foo');
+
+        $this->assertSame('foo', $this->connection->quote('foo'));
+    }
+
+    public function testExec(): void
+    {
+        $this->decoratedConnection->expects($this->once())
+            ->method('exec')
+            ->with('SELECT 1 + 1')
+            ->willReturn(10);
+
+        $this->assertSame(10, $this->connection->exec('SELECT 1 + 1'));
+    }
+
+    public function testLastInsertId(): void
+    {
+        $this->decoratedConnection->expects($this->once())
+            ->method('lastInsertId')
+            ->with('foo')
+            ->willReturn('10');
+
+        $this->assertSame('10', $this->connection->lastInsertId('foo'));
+    }
+
+    public function testBeginTransaction(): void
+    {
+        $this->decoratedConnection->expects($this->once())
+            ->method('beginTransaction')
+            ->willReturn(false);
+
+        $this->assertFalse($this->connection->beginTransaction());
+    }
+
+    public function testCommit(): void
+    {
+        $this->decoratedConnection->expects($this->once())
+            ->method('commit')
+            ->willReturn(false);
+
+        $this->assertFalse($this->connection->commit());
+    }
+
+    public function testRollBack(): void
+    {
+        $this->decoratedConnection->expects($this->once())
+            ->method('rollBack')
+            ->willReturn(false);
+
+        $this->assertFalse($this->connection->rollBack());
+    }
+
+    public function testGetServerVersion(): void
+    {
+        $wrappedConnection = $this->createMock(ServerInfoAwareConnectionStub::class);
+
+        $wrappedConnection->expects($this->once())
+            ->method('getServerVersion')
+            ->willReturn('0.0.1');
+
+        $this->decoratedConnection->expects($this->once())
+            ->method('getWrappedConnection')
+            ->willReturn($wrappedConnection);
+
+        $this->assertSame('0.0.1', $this->connection->getServerVersion());
+    }
+
+    public function testGetServerVersionThrowsExceptionIfWrappedConnectionIsNotServerInfoAware(): void
+    {
+        $this->decoratedConnection->expects($this->once())
+            ->method('getWrappedConnection')
+            ->willReturn($this->createMock(Connection::class));
+
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('The wrapped connection must be an instance of the "Doctrine\\DBAL\\Driver\\ServerInfoAwareConnection" interface.');
+
+        $this->connection->getServerVersion();
+    }
+
+    public function testRequiresQueryForServerVersion(): void
+    {
+        if (!self::isDoctrineDBALVersion2Installed()) {
+            self::markTestSkipped('This test requires the version of the "doctrine/dbal" Composer package to be ^2.13.');
+        }
+
+        $wrappedConnection = $this->createMock(ServerInfoAwareConnectionStub::class);
+        $wrappedConnection->expects($this->once())
+            ->method('requiresQueryForServerVersion')
+            ->willReturn(true);
+
+        $this->decoratedConnection->expects($this->once())
+            ->method('getWrappedConnection')
+            ->willReturn($wrappedConnection);
+
+        $this->assertTrue($this->connection->requiresQueryForServerVersion());
+    }
+
+    public function testRequiresQueryForServerVersionThrowsExceptionIfWrappedConnectionIsNotServerInfoAware(): void
+    {
+        if (!self::isDoctrineDBALVersion2Installed()) {
+            self::markTestSkipped('This test requires the version of the "doctrine/dbal" Composer package to be ^2.13.');
+        }
+
+        $this->decoratedConnection->expects($this->once())
+            ->method('getWrappedConnection')
+            ->willReturn($this->createMock(Connection::class));
+
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('The wrapped connection must be an instance of the "Doctrine\\DBAL\\Driver\\ServerInfoAwareConnection" interface.');
+
+        $this->connection->requiresQueryForServerVersion();
+    }
+
+    public function testRequiresQueryForServerVersionThrowsExceptionIfWrappedConnectionDoesNotImplementMethod(): void
+    {
+        if (!self::isDoctrineDBALVersion3Installed()) {
+            self::markTestSkipped('This test requires the version of the "doctrine/dbal" Composer package to be >= 3.0.');
+        }
+
+        $this->decoratedConnection->expects($this->once())
+            ->method('getWrappedConnection')
+            ->willReturn($this->createMock(ServerInfoAwareConnectionStub::class));
+
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('The Sentry\\SentryBundle\\Tracing\\Doctrine\\DBAL\\TracingServerInfoAwareDriverConnection::requiresQueryForServerVersion() method is not supported on Doctrine DBAL 3.0.');
+
+        $this->connection->requiresQueryForServerVersion();
+    }
+
+    public function testErrorCode(): void
+    {
+        if (!self::isDoctrineDBALVersion2Installed()) {
+            self::markTestSkipped('This test requires the version of the "doctrine/dbal" Composer package to be ^2.13.');
+        }
+
+        $this->decoratedConnection->expects($this->once())
+            ->method('errorCode')
+            ->willReturn('1002');
+
+        $this->assertSame('1002', $this->connection->errorCode());
+    }
+
+    public function testErrorCodeThrowsExceptionIfDecoratedConnectionDoesNotImplementMethod(): void
+    {
+        if (!self::isDoctrineDBALVersion3Installed()) {
+            self::markTestSkipped('This test requires the version of the "doctrine/dbal" Composer package to be >= 3.0.');
+        }
+
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('The Sentry\\SentryBundle\\Tracing\\Doctrine\\DBAL\\TracingServerInfoAwareDriverConnection::errorCode() method is not supported on Doctrine DBAL 3.0.');
+
+        $this->connection->errorCode();
+    }
+
+    public function testErrorInfo(): void
+    {
+        if (!self::isDoctrineDBALVersion2Installed()) {
+            self::markTestSkipped('This test requires the version of the "doctrine/dbal" Composer package to be ^2.13.');
+        }
+
+        $this->decoratedConnection->expects($this->once())
+            ->method('errorInfo')
+            ->willReturn(['foobar']);
+
+        $this->assertSame(['foobar'], $this->connection->errorInfo());
+    }
+
+    public function testErrorInfoThrowsExceptionIfDecoratedConnectionDoesNotImplementMethod(): void
+    {
+        if (!self::isDoctrineDBALVersion3Installed()) {
+            self::markTestSkipped('This test requires the version of the "doctrine/dbal" Composer package to be >= 3.0.');
+        }
+
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('The Sentry\\SentryBundle\\Tracing\\Doctrine\\DBAL\\TracingServerInfoAwareDriverConnection::errorInfo() method is not supported on Doctrine DBAL 3.0.');
+
+        $this->connection->errorInfo();
+    }
+
+    public function testGetWrappedConnection(): void
+    {
+        $wrappedConnection = $this->createMock(Connection::class);
+
+        $this->decoratedConnection->expects($this->once())
+            ->method('getWrappedConnection')
+            ->willReturn($wrappedConnection);
+
+        $this->assertSame($wrappedConnection, $this->connection->getWrappedConnection());
+    }
+}


### PR DESCRIPTION
This solves https://github.com/getsentry/sentry-symfony/issues/488#issuecomment-941401855: while instrumenting the Doctrine DBAL connection we weren't mirroring whether the original connection had implemented the `ServerInfoAwareConnection` interface, causing issues with `instanceof` checks