### PR TITLE
Fix wrong method existence check in `TracingDriverConnection::errorCode()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add return typehints to the methods of the `SentryExtension` class to prepare for Symfony 6 (#563)
 - Fix setting the IP address on the user context when it's not available (#565)
+- Fix wrong method existence check in `TracingDriverConnection::errorCode()` (#568)
 
 ## 4.2.3 (2021-09-21)
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,17 +16,7 @@ parameters:
 			path: src/EventListener/ErrorListener.php
 
 		-
-			message: "#^Call to an undefined method Doctrine\\\\DBAL\\\\Driver\\\\Connection\\:\\:errorCode\\(\\)\\.$#"
-			count: 1
-			path: src/Tracing/Doctrine/DBAL/TracingDriverConnection.php
-
-		-
-			message: "#^Method Sentry\\\\SentryBundle\\\\Tracing\\\\Doctrine\\\\DBAL\\\\TracingDriverConnection\\:\\:errorCode\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: src/Tracing/Doctrine/DBAL/TracingDriverConnection.php
-
-		-
-			message: "#^Method Sentry\\\\SentryBundle\\\\Tracing\\\\Doctrine\\\\DBAL\\\\TracingDriverConnection\\:\\:errorInfo\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Sentry\\\\SentryBundle\\\\Tracing\\\\Doctrine\\\\DBAL\\\\TracingDriverConnection\\:\\:errorInfo\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Tracing/Doctrine/DBAL/TracingDriverConnection.php
 
@@ -169,6 +159,16 @@ parameters:
 			message: "#^Parameter \\#1 \\$decoratedAdapter of method Sentry\\\\SentryBundle\\\\Tests\\\\Tracing\\\\Cache\\\\AbstractTraceableCacheAdapterTest\\<TCacheAdapter of Symfony\\\\Component\\\\Cache\\\\Adapter\\\\AdapterInterface,TDecoratedCacheAdapter of Symfony\\\\Component\\\\Cache\\\\Adapter\\\\AdapterInterface\\>\\:\\:createCacheAdapter\\(\\) expects TDecoratedCacheAdapter of Symfony\\\\Component\\\\Cache\\\\Adapter\\\\AdapterInterface, PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&Sentry\\\\SentryBundle\\\\Tests\\\\Tracing\\\\Cache\\\\ResettableCacheAdapterInterface given\\.$#"
 			count: 1
 			path: tests/Tracing/Cache/AbstractTraceableCacheAdapterTest.php
+
+		-
+			message: "#^Trying to mock an undefined method errorCode\\(\\) on class Doctrine\\\\DBAL\\\\Driver\\\\Connection\\.$#"
+			count: 1
+			path: tests/Tracing/Doctrine/DBAL/TracingDriverConnectionTest.php
+
+		-
+			message: "#^Trying to mock an undefined method errorInfo\\(\\) on class Doctrine\\\\DBAL\\\\Driver\\\\Connection\\.$#"
+			count: 1
+			path: tests/Tracing/Doctrine/DBAL/TracingDriverConnectionTest.php
 
 		-
 			message: "#^Trying to mock an undefined method closeCursor\\(\\) on class Doctrine\\\\DBAL\\\\Driver\\\\Statement\\.$#"

--- a/src/Tracing/Doctrine/DBAL/TracingDriverConnection.php
+++ b/src/Tracing/Doctrine/DBAL/TracingDriverConnection.php
@@ -133,7 +133,7 @@ final class TracingDriverConnection implements DriverConnectionInterface
     /**
      * {@inheritdoc}
      */
-    public function beginTransaction()
+    public function beginTransaction(): bool
     {
         return $this->traceFunction(self::SPAN_OP_CONN_BEGIN_TRANSACTION, 'BEGIN TRANSACTION', function (): bool {
             return $this->decoratedConnection->beginTransaction();
@@ -143,7 +143,7 @@ final class TracingDriverConnection implements DriverConnectionInterface
     /**
      * {@inheritdoc}
      */
-    public function commit()
+    public function commit(): bool
     {
         return $this->traceFunction(self::SPAN_OP_TRANSACTION_COMMIT, 'COMMIT', function (): bool {
             return $this->decoratedConnection->commit();
@@ -153,7 +153,7 @@ final class TracingDriverConnection implements DriverConnectionInterface
     /**
      * {@inheritdoc}
      */
-    public function rollBack()
+    public function rollBack(): bool
     {
         return $this->traceFunction(self::SPAN_OP_TRANSACTION_ROLLBACK, 'ROLLBACK', function (): bool {
             return $this->decoratedConnection->rollBack();
@@ -163,9 +163,9 @@ final class TracingDriverConnection implements DriverConnectionInterface
     /**
      * {@inheritdoc}
      */
-    public function errorCode()
+    public function errorCode(): ?string
     {
-        if (method_exists($this->decoratedConnection, 'errorInfo')) {
+        if (method_exists($this->decoratedConnection, 'errorCode')) {
             return $this->decoratedConnection->errorCode();
         }
 
@@ -175,7 +175,7 @@ final class TracingDriverConnection implements DriverConnectionInterface
     /**
      * {@inheritdoc}
      */
-    public function errorInfo()
+    public function errorInfo(): array
     {
         if (method_exists($this->decoratedConnection, 'errorInfo')) {
             return $this->decoratedConnection->errorInfo();

--- a/tests/Tracing/Doctrine/DBAL/TracingDriverConnectionTest.php
+++ b/tests/Tracing/Doctrine/DBAL/TracingDriverConnectionTest.php
@@ -339,6 +339,56 @@ final class TracingDriverConnectionTest extends DoctrineTestCase
         $this->assertFalse($this->connection->rollBack());
     }
 
+    public function testErrorCode(): void
+    {
+        if (!self::isDoctrineDBALVersion2Installed()) {
+            self::markTestSkipped('This test requires the version of the "doctrine/dbal" Composer package to be ^2.13.');
+        }
+
+        $this->decoratedConnection->expects($this->once())
+            ->method('errorCode')
+            ->willReturn('1002');
+
+        $this->assertSame('1002', $this->connection->errorCode());
+    }
+
+    public function testErrorCodeThrowsExceptionIfDecoratedConnectionDoesNotImplementMethod(): void
+    {
+        if (!self::isDoctrineDBALVersion3Installed()) {
+            self::markTestSkipped('This test requires the version of the "doctrine/dbal" Composer package to be >= 3.0.');
+        }
+
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('The Sentry\\SentryBundle\\Tracing\\Doctrine\\DBAL\\TracingDriverConnection::errorCode() method is not supported on Doctrine DBAL 3.0.');
+
+        $this->connection->errorCode();
+    }
+
+    public function testErrorInfo(): void
+    {
+        if (!self::isDoctrineDBALVersion2Installed()) {
+            self::markTestSkipped('This test requires the version of the "doctrine/dbal" Composer package to be ^2.13.');
+        }
+
+        $this->decoratedConnection->expects($this->once())
+            ->method('errorInfo')
+            ->willReturn(['foobar']);
+
+        $this->assertSame(['foobar'], $this->connection->errorInfo());
+    }
+
+    public function testErrorInfoThrowsExceptionIfDecoratedConnectionDoesNotImplementMethod(): void
+    {
+        if (!self::isDoctrineDBALVersion3Installed()) {
+            self::markTestSkipped('This test requires the version of the "doctrine/dbal" Composer package to be >= 3.0.');
+        }
+
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('The Sentry\\SentryBundle\\Tracing\\Doctrine\\DBAL\\TracingDriverConnection::errorInfo() method is not supported on Doctrine DBAL 3.0.');
+
+        $this->connection->errorInfo();
+    }
+
     public function testGetWrappedConnection(): void
     {
         $connection = new TracingDriverConnection($this->hub, $this->decoratedConnection, 'foo_platform', []);


### PR DESCRIPTION
While working on another PR I spotted that the `method_exists` check in `TracingDriverConnection::errorCode()` was referring to the wrong method name. I've added a bunch of unit tests to ensure this now works as expected and we prevent a future regression