### PR TITLE
Fix fatal errors logged twice on Symfony `3.4` on PHP `7.3` and `7.4`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix fatal errors logged twice on Symfony `3.4` (#570)
+
 ## 4.2.4 (2021-10-20)
 
 - Add return typehints to the methods of the `SentryExtension` class to prepare for Symfony 6 (#563)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,6 +11,11 @@ parameters:
 			path: src/DependencyInjection/Configuration.php
 
 		-
+			message: "#^Class Symfony\\\\Component\\\\Debug\\\\Exception\\\\FatalErrorException not found\\.$#"
+			count: 1
+			path: src/DependencyInjection/SentryExtension.php
+
+		-
 			message: "#^Else branch is unreachable because previous condition is always true\\.$#"
 			count: 1
 			path: src/EventListener/ErrorListener.php
@@ -54,6 +59,11 @@ parameters:
 			message: "#^Method Sentry\\\\SentryBundle\\\\Tracing\\\\Doctrine\\\\DBAL\\\\TracingServerInfoAwareDriverConnection\\:\\:query\\(\\) has parameter \\$args with no typehint specified\\.$#"
 			count: 1
 			path: src/Tracing/Doctrine/DBAL/TracingServerInfoAwareDriverConnection.php
+
+		-
+			message: "#^Class Symfony\\\\Component\\\\Debug\\\\Exception\\\\FatalErrorException not found\\.$#"
+			count: 1
+			path: tests/DependencyInjection/SentryExtensionTest.php
 
 		-
 			message: "#^Class Symfony\\\\Bundle\\\\FrameworkBundle\\\\Client not found\\.$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.10.0@916b098b008f6de4543892b1e0651c1c3b92cbfa">
+<files psalm-version="4.11.1@e33492398bd4e5e2ab60e331d445979bd83feecd">
+  <file src="src/DependencyInjection/SentryExtension.php">
+    <UndefinedClass occurrences="1">
+      <code>FatalErrorException</code>
+    </UndefinedClass>
+  </file>
   <file src="src/EventListener/ConsoleCommandListener.php">
     <InvalidExtendClass occurrences="1">
       <code>ConsoleListener</code>

--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -31,6 +31,7 @@ use Sentry\Transport\TransportFactoryInterface;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Cache\CacheItem;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Debug\Exception\FatalErrorException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader;
@@ -273,7 +274,14 @@ final class SentryExtension extends ConfigurableExtension
             // Prepend this integration to the beginning of the array so that
             // we can save some performance by skipping the rest of the integrations
             // if the error must be ignored
-            array_unshift($integrations, new Definition(IgnoreErrorsIntegration::class, [['ignore_exceptions' => [FatalError::class]]]));
+            array_unshift($integrations, new Definition(IgnoreErrorsIntegration::class, [
+                [
+                    'ignore_exceptions' => [
+                        FatalError::class,
+                        FatalErrorException::class,
+                    ],
+                ],
+            ]));
         }
 
         return $integrations;

--- a/tests/DependencyInjection/SentryExtensionTest.php
+++ b/tests/DependencyInjection/SentryExtensionTest.php
@@ -29,6 +29,7 @@ use Sentry\Serializer\Serializer;
 use Sentry\Transport\TransportFactoryInterface;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Debug\Exception\FatalErrorException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
@@ -185,7 +186,14 @@ abstract class SentryExtensionTest extends TestCase
         $optionsDefinition = $container->getDefinition('sentry.client.options');
         $expectedOptions = [
             'integrations' => [
-                new Definition(IgnoreErrorsIntegration::class, [['ignore_exceptions' => [FatalError::class]]]),
+                new Definition(IgnoreErrorsIntegration::class, [
+                    [
+                        'ignore_exceptions' => [
+                            FatalError::class,
+                            FatalErrorException::class,
+                        ],
+                    ],
+                ]),
                 new Reference('App\\Sentry\\Integration\\FooIntegration'),
             ],
             'default_integrations' => false,


### PR DESCRIPTION
While working on improving the CI pipeline to prepare it for Symfony `6.x`, I realized that two builds we don't have right now (Symfony `3.4` on PHP `7.3` and `7.4`) were reporting a failure in the E2E tests: it looks like on those versions of PHP the fatal errors are captured twice. Not sure why it doesn't happen on PHP `7.2` though...