### PR TITLE
Add the Monolog hook functionality

### DIFF
--- a/src/DependencyInjection/Compiler/RegisterMonologHandlerPass.php
+++ b/src/DependencyInjection/Compiler/RegisterMonologHandlerPass.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\DependencyInjection\Compiler;
+
+use Sentry\Monolog\Handler;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class RegisterMonologHandlerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition(Handler::class)) {
+            return;
+        }
+
+        $logger = $container->getDefinition('monolog.logger');
+        $logger->addMethodCall('pushHandler', [new Reference(Handler::class)]);
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -6,6 +6,7 @@ namespace Sentry\SentryBundle\DependencyInjection;
 
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Jean85\PrettyVersions;
+use Monolog\Logger;
 use Sentry\Options;
 use Sentry\SentryBundle\ErrorTypesParser;
 use Sentry\Transport\TransportFactoryInterface;
@@ -135,6 +136,7 @@ final class Configuration implements ConfigurationInterface
             ->end();
 
         $this->addMessengerSection($rootNode);
+        $this->addMonologSection($rootNode);
         $this->addDistributedTracingSection($rootNode);
 
         return $treeBuilder;
@@ -148,6 +150,26 @@ final class Configuration implements ConfigurationInterface
                     ->{interface_exists(MessageBusInterface::class) ? 'canBeDisabled' : 'canBeEnabled'}()
                     ->children()
                         ->booleanNode('capture_soft_fails')->defaultTrue()->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    private function addMonologSection(ArrayNodeDefinition $rootNode): void
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('monolog')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->arrayNode('error_handler')
+                            ->{class_exists(Logger::class) ? 'canBeDisabled' : 'canBeEnabled'}()
+                        ->end()
+                        ->scalarNode('level')
+                            ->defaultValue(Logger::DEBUG)
+                            ->cannotBeEmpty()
+                        ->end()
+                        ->booleanNode('bubble')->defaultTrue()->end()
                     ->end()
                 ->end()
             ->end();

--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -28,6 +28,7 @@ use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverMiddleware;
 use Sentry\SentryBundle\Tracing\Twig\TwigTracingExtension;
 use Sentry\Serializer\RepresentationSerializer;
 use Sentry\Serializer\Serializer;
+use Sentry\State\HubInterface;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Cache\CacheItem;
 use Symfony\Component\Config\FileLocator;
@@ -257,8 +258,11 @@ final class SentryExtension extends ConfigurableExtension
         }
 
         $definition = $container->getDefinition(Handler::class);
-        $definition->setArgument(0, MonologLogger::toMonologLevel($config['level']));
-        $definition->setArgument(1, $config['bubble']);
+        $definition->setArguments([
+            new Reference(HubInterface::class),
+            MonologLogger::toMonologLevel($config['level']),
+            $config['bubble'],
+        ]);
     }
 
     /**

--- a/src/Resources/config/schema/sentry-1.0.xsd
+++ b/src/Resources/config/schema/sentry-1.0.xsd
@@ -12,6 +12,7 @@
             <xsd:element name="options" type="options" minOccurs="0" maxOccurs="1" />
             <xsd:element name="messenger" type="messenger" minOccurs="0" maxOccurs="1" />
             <xsd:element name="tracing" type="tracing" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="monolog" type="monolog" minOccurs="0" maxOccurs="1" />
         </xsd:choice>
 
         <xsd:attribute name="register-error-listener" type="xsd:boolean" />
@@ -115,4 +116,48 @@
             <xsd:element name="excluded-command" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
         </xsd:sequence>
     </xsd:complexType>
+
+    <xsd:complexType name="monolog">
+        <xsd:choice maxOccurs="unbounded">
+            <xsd:element name="error-handler" type="monolog-error-handler" minOccurs="0" maxOccurs="1" />
+        </xsd:choice>
+
+        <xsd:attribute name="level" type="monolog-level" />
+        <xsd:attribute name="bubble" type="xsd:boolean" />
+    </xsd:complexType>
+
+    <xsd:complexType name="monolog-error-handler">
+        <xsd:attribute name="enabled" type="xsd:boolean" />
+    </xsd:complexType>
+
+    <xsd:simpleType name="monolog-level">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="debug" />
+            <xsd:enumeration value="info" />
+            <xsd:enumeration value="notice" />
+            <xsd:enumeration value="warning" />
+            <xsd:enumeration value="error" />
+            <xsd:enumeration value="critical" />
+            <xsd:enumeration value="alert" />
+            <xsd:enumeration value="emergency" />
+
+            <xsd:enumeration value="DEBUG" />
+            <xsd:enumeration value="INFO" />
+            <xsd:enumeration value="NOTICE" />
+            <xsd:enumeration value="WARNING" />
+            <xsd:enumeration value="ERROR" />
+            <xsd:enumeration value="CRITICAL" />
+            <xsd:enumeration value="ALERT" />
+            <xsd:enumeration value="EMERGENCY" />
+
+            <xsd:enumeration value="100" />
+            <xsd:enumeration value="200" />
+            <xsd:enumeration value="250" />
+            <xsd:enumeration value="300" />
+            <xsd:enumeration value="400" />
+            <xsd:enumeration value="500" />
+            <xsd:enumeration value="550" />
+            <xsd:enumeration value="600" />
+        </xsd:restriction>
+    </xsd:simpleType>
 </xsd:schema>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -89,6 +89,10 @@
             <tag name="console.command" />
         </service>
 
+        <service id="Sentry\Monolog\Handler" class="Sentry\Monolog\Handler">
+            <argument type="service" id="Sentry\State\HubInterface" />
+        </service>
+
         <service id="Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverMiddleware" class="Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverMiddleware">
             <argument type="service" id="Sentry\State\HubInterface" />
         </service>

--- a/src/SentryBundle.php
+++ b/src/SentryBundle.php
@@ -6,6 +6,8 @@ namespace Sentry\SentryBundle;
 
 use Sentry\SentryBundle\DependencyInjection\Compiler\CacheTracingPass;
 use Sentry\SentryBundle\DependencyInjection\Compiler\DbalTracingPass;
+use Sentry\SentryBundle\DependencyInjection\Compiler\RegisterMonologHandlerPass;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -17,6 +19,7 @@ final class SentryBundle extends Bundle
     {
         parent::build($container);
 
+        $container->addCompilerPass(new RegisterMonologHandlerPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $container->addCompilerPass(new DbalTracingPass());
         $container->addCompilerPass(new CacheTracingPass());
     }

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -6,6 +6,7 @@ namespace Sentry\SentryBundle\Tests\DependencyInjection;
 
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Jean85\PrettyVersions;
+use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Sentry\SentryBundle\DependencyInjection\Configuration;
 use Symfony\Bundle\TwigBundle\TwigBundle;
@@ -39,6 +40,13 @@ final class ConfigurationTest extends TestCase
             'messenger' => [
                 'enabled' => interface_exists(MessageBusInterface::class),
                 'capture_soft_fails' => true,
+            ],
+            'monolog' => [
+                'error_handler' => [
+                    'enabled' => class_exists(Logger::class),
+                ],
+                'level' => Logger::DEBUG,
+                'bubble' => true,
             ],
             'tracing' => [
                 'enabled' => true,

--- a/tests/DependencyInjection/Fixtures/php/monolog_handler.php
+++ b/tests/DependencyInjection/Fixtures/php/monolog_handler.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Monolog\Logger;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/** @var ContainerBuilder $container */
+$container->loadFromExtension('sentry', [
+    'monolog' => [
+        'level' => Logger::ERROR,
+        'bubble' => false,
+    ],
+]);

--- a/tests/DependencyInjection/Fixtures/php/monolog_handler_disabled.php
+++ b/tests/DependencyInjection/Fixtures/php/monolog_handler_disabled.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/** @var ContainerBuilder $container */
+$container->loadFromExtension('sentry', [
+    'monolog' => [
+        'error_handler' => false,
+    ],
+]);

--- a/tests/DependencyInjection/Fixtures/xml/monolog_handler.xml
+++ b/tests/DependencyInjection/Fixtures/xml/monolog_handler.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:sentry="https://sentry.io/schema/dic/sentry-symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                               https://sentry.io/schema/dic/sentry-symfony https://sentry.io/schema/dic/sentry-symfony/sentry-1.0.xsd">
+
+    <sentry:config>
+        <sentry:monolog level="error" bubble="false" />
+    </sentry:config>
+</container>

--- a/tests/DependencyInjection/Fixtures/xml/monolog_handler_disabled.xml
+++ b/tests/DependencyInjection/Fixtures/xml/monolog_handler_disabled.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:sentry="https://sentry.io/schema/dic/sentry-symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                               https://sentry.io/schema/dic/sentry-symfony https://sentry.io/schema/dic/sentry-symfony/sentry-1.0.xsd">
+
+    <sentry:config>
+        <sentry:monolog>
+            <sentry:error-handler enabled="false" />
+        </sentry:monolog>
+    </sentry:config>
+</container>

--- a/tests/DependencyInjection/Fixtures/yml/monolog_handler.yml
+++ b/tests/DependencyInjection/Fixtures/yml/monolog_handler.yml
@@ -1,0 +1,4 @@
+sentry:
+    monolog:
+        level: !php/const Monolog\Logger::ERROR
+        bubble: false

--- a/tests/DependencyInjection/Fixtures/yml/monolog_handler_disabled.yml
+++ b/tests/DependencyInjection/Fixtures/yml/monolog_handler_disabled.yml
@@ -1,0 +1,3 @@
+sentry:
+    monolog:
+        error_handler: false

--- a/tests/DependencyInjection/SentryExtensionTest.php
+++ b/tests/DependencyInjection/SentryExtensionTest.php
@@ -6,10 +6,12 @@ namespace Sentry\SentryBundle\Tests\DependencyInjection;
 
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Jean85\PrettyVersions;
+use Monolog\Logger as MonologLogger;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Sentry\ClientInterface;
 use Sentry\Integration\IgnoreErrorsIntegration;
+use Sentry\Monolog\Handler;
 use Sentry\Options;
 use Sentry\SentryBundle\DependencyInjection\SentryExtension;
 use Sentry\SentryBundle\EventListener\ConsoleListener;
@@ -176,6 +178,22 @@ abstract class SentryExtensionTest extends TestCase
                 ],
             ],
         ], $definition->getTags());
+    }
+
+    public function testMonologHandler(): void
+    {
+        $container = $this->createContainerFromFixture('monolog_handler');
+        $definition = $container->getDefinition(Handler::class);
+
+        $this->assertSame(MonologLogger::ERROR, $definition->getArgument(0));
+        $this->assertFalse($definition->getArgument(1));
+    }
+
+    public function testMonologHandlerIsRemovedWhenDisabled(): void
+    {
+        $container = $this->createContainerFromFixture('monolog_handler_disabled');
+
+        $this->assertFalse($container->hasDefinition(Handler::class));
     }
 
     public function testClentIsCreatedFromOptions(): void

--- a/tests/End2End/App/KernelHookedToMonolog.php
+++ b/tests/End2End/App/KernelHookedToMonolog.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\End2End\App;
+
+use Symfony\Component\Config\Loader\LoaderInterface;
+
+class KernelHookedToMonolog extends Kernel
+{
+    public function registerContainerConfiguration(LoaderInterface $loader): void
+    {
+        parent::registerContainerConfiguration($loader);
+
+        $loader->load(__DIR__ . '/sentry_hooked_to_monolog.yml');
+    }
+}

--- a/tests/End2End/App/sentry_hooked_to_monolog.yml
+++ b/tests/End2End/App/sentry_hooked_to_monolog.yml
@@ -1,0 +1,9 @@
+sentry:
+  register_error_listener: false
+  monolog:
+    error_handler:
+      enabled: true
+  options:
+    # TODO: add a simple option to switch off the error/fatal integrations
+    default_integrations: false
+    integrations: []

--- a/tests/End2End/End2EndHookedToMonologTest.php
+++ b/tests/End2End/End2EndHookedToMonologTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\End2End;
+
+use Sentry\SentryBundle\Tests\End2End\App\KernelHookedToMonolog;
+
+/**
+ * @runTestsInSeparateProcesses
+ */
+class End2EndHookedToMonologTest extends End2EndTest
+{
+    protected static function getKernelClass(): string
+    {
+        return KernelHookedToMonolog::class;
+    }
+}


### PR DESCRIPTION
This is another attempt at #337 

I'm currently following the strategy outlined in https://github.com/getsentry/sentry-symfony/issues/337#issuecomment-800920045

It seems to work with this config:
```yaml
sentry:
  register_error_listener: false
  monolog:
    error_handler:
      enabled: true
  options:
    # TODO: add a simple option to switch off the error/fatal integrations
    default_integrations: false
    integrations: []
```
But E2E tests are failing and I'm having a hard time to run them with the debugger.