### PR TITLE
Fix deprecation: PDOStatement::bindParam(): Passing null to $maxLength

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix PDOStatement deprecation notice on `bindParam()` (#586)
+
 ## 4.2.6 (2022-01-10)
 
 - Add support for `symfony/cache-contracts` package version `3.x` (#588)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fix PDOStatement deprecation notice on `bindParam()` (#586)
+- Fix deprecation notice thrown when instrumenting the `PDOStatement::bindParam()` method and passing `$length = null` (#586)
 
 ## 4.2.6 (2022-01-10)
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -246,6 +246,16 @@ parameters:
 			path: tests/Tracing/Doctrine/DBAL/TracingServerInfoAwareDriverConnectionTest.php
 
 		-
+			message: "#^Access to an undefined property PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&Sentry\\\\SentryBundle\\\\Tests\\\\Tracing\\\\Doctrine\\\\DBAL\\\\TracingStatementForV2Stub\\:\\:\\$bindParamCallArgsCount\\.$#"
+			count: 1
+			path: tests/Tracing/Doctrine/DBAL/TracingStatementForV2Test.php
+
+		-
+			message: "#^Parameter \\#2 \\$decoratedStatement of class Sentry\\\\SentryBundle\\\\Tracing\\\\Doctrine\\\\DBAL\\\\TracingStatementForV2 constructor expects Doctrine\\\\DBAL\\\\Driver\\\\Statement, PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&Sentry\\\\SentryBundle\\\\Tests\\\\Tracing\\\\Doctrine\\\\DBAL\\\\TracingStatementForV2Stub given\\.$#"
+			count: 1
+			path: tests/Tracing/Doctrine/DBAL/TracingStatementForV2Test.php
+
+		-
 			message: "#^Trying to mock an undefined method closeCursor\\(\\) on class Doctrine\\\\DBAL\\\\Driver\\\\Statement\\.$#"
 			count: 1
 			path: tests/Tracing/Doctrine/DBAL/TracingStatementForV2Test.php

--- a/src/Tracing/Doctrine/DBAL/TracingStatementForV2.php
+++ b/src/Tracing/Doctrine/DBAL/TracingStatementForV2.php
@@ -108,7 +108,7 @@ final class TracingStatementForV2 extends AbstractTracingStatement implements \I
      */
     public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null): bool
     {
-        return $this->decoratedStatement->bindParam($param, $variable, $type, $length);
+        return $this->decoratedStatement->bindParam($param, $variable, $type, ...\array_slice(\func_get_args(), 3));
     }
 
     /**

--- a/src/Tracing/Doctrine/DBAL/TracingStatementForV3.php
+++ b/src/Tracing/Doctrine/DBAL/TracingStatementForV3.php
@@ -27,7 +27,7 @@ final class TracingStatementForV3 extends AbstractTracingStatement implements St
      */
     public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null): bool
     {
-        return $this->decoratedStatement->bindParam($param, $variable, $type, $length);
+        return $this->decoratedStatement->bindParam($param, $variable, $type, ...array_slice(func_get_args(), 3));
     }
 
     /**

--- a/src/Tracing/Doctrine/DBAL/TracingStatementForV3.php
+++ b/src/Tracing/Doctrine/DBAL/TracingStatementForV3.php
@@ -27,7 +27,7 @@ final class TracingStatementForV3 extends AbstractTracingStatement implements St
      */
     public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null): bool
     {
-        return $this->decoratedStatement->bindParam($param, $variable, $type, ...array_slice(func_get_args(), 3));
+        return $this->decoratedStatement->bindParam($param, $variable, $type, ...\array_slice(\func_get_args(), 3));
     }
 
     /**

--- a/tests/Tracing/Doctrine/DBAL/TracingStatementForV3Test.php
+++ b/tests/Tracing/Doctrine/DBAL/TracingStatementForV3Test.php
@@ -61,22 +61,47 @@ final class TracingStatementForV3Test extends DoctrineTestCase
 
         $this->decoratedStatement->expects($this->once())
             ->method('bindParam')
-            ->with('foo', $variable, ParameterType::INTEGER)
+            ->with('foo', $variable, ParameterType::INTEGER, 10)
             ->willReturn(true);
 
-        $this->assertTrue($this->statement->bindParam('foo', $variable, ParameterType::INTEGER));
+        $this->assertTrue($this->statement->bindParam('foo', $variable, ParameterType::INTEGER, 10));
     }
 
-    public function testBindParamWithoutLength(): void
+    public function testBindParamForwardsLengthParamOnlyWhenExplicitlySet(): void
     {
         $variable = 'bar';
+        $decoratedStatement = new class() implements Statement {
+            /**
+             * @var int
+             */
+            public $bindParamCallArgsCount = 0;
 
-        $this->decoratedStatement = $this->createPartialMock(TestStatement::class, ['bindValue', 'execute']);
-        $this->statement = new TracingStatementForV3($this->hub, $this->decoratedStatement, 'SELECT 1', ['db.system' => 'sqlite']);
+            public function bindValue($param, $value, $type = ParameterType::STRING): bool
+            {
+                throw new \BadMethodCallException();
+            }
+
+            public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null): bool
+            {
+                // Since PHPUnit forcefully calls the mocked methods with all
+                // parameters, regardless of whether they were originally passed
+                // in an explicit manner, we can't use a mock to assert the number
+                // of args used in the call to the function
+                $this->bindParamCallArgsCount = \func_num_args();
+
+                return true;
+            }
+
+            public function execute($params = null): Result
+            {
+                throw new \BadMethodCallException();
+            }
+        };
+
+        $this->statement = new TracingStatementForV3($this->hub, $decoratedStatement, 'SELECT 1', ['db.system' => 'sqlite']);
 
         $this->assertTrue($this->statement->bindParam('foo', $variable, ParameterType::INTEGER));
-        $this->assertInstanceOf(TestStatement::class, $this->decoratedStatement);
-        $this->assertCount(3, $this->decoratedStatement->args);
+        $this->assertSame(3, $decoratedStatement->bindParamCallArgsCount);
     }
 
     public function testExecute(): void
@@ -119,20 +144,5 @@ final class TracingStatementForV3Test extends DoctrineTestCase
             ->willReturn($driverResult);
 
         $this->assertSame($driverResult, $this->statement->execute(['foo' => 'bar']));
-    }
-}
-
-abstract class TestStatement implements Statement {
-
-    /**
-     * @var mixed[]|null
-     */
-    public $args = null;
-
-    public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null)
-    {
-        $this->args = func_get_args();
-
-        return true;
     }
 }

--- a/tests/Tracing/Doctrine/DBAL/TracingStatementForV3Test.php
+++ b/tests/Tracing/Doctrine/DBAL/TracingStatementForV3Test.php
@@ -67,6 +67,17 @@ final class TracingStatementForV3Test extends DoctrineTestCase
         $this->assertTrue($this->statement->bindParam('foo', $variable, ParameterType::INTEGER));
     }
 
+    public function testBindParamWithoutLength(): void
+    {
+        $variable = 'bar';
+
+        $this->decoratedStatement = $this->createPartialMock(TestStatement::class, ['bindValue', 'execute']);
+        $this->statement = new TracingStatementForV3($this->hub, $this->decoratedStatement, 'SELECT 1', ['db.system' => 'sqlite']);
+
+        $this->assertTrue($this->statement->bindParam('foo', $variable, ParameterType::INTEGER));
+        $this->assertCount(3, $this->decoratedStatement->args);
+    }
+
     public function testExecute(): void
     {
         $driverResult = $this->createMock(Result::class);
@@ -107,5 +118,20 @@ final class TracingStatementForV3Test extends DoctrineTestCase
             ->willReturn($driverResult);
 
         $this->assertSame($driverResult, $this->statement->execute(['foo' => 'bar']));
+    }
+}
+
+abstract class TestStatement implements Statement {
+
+    /**
+     * @var array|null
+     */
+    public $args = null;
+
+    public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null)
+    {
+        $this->args = func_get_args();
+
+        return true;
     }
 }

--- a/tests/Tracing/Doctrine/DBAL/TracingStatementForV3Test.php
+++ b/tests/Tracing/Doctrine/DBAL/TracingStatementForV3Test.php
@@ -75,6 +75,7 @@ final class TracingStatementForV3Test extends DoctrineTestCase
         $this->statement = new TracingStatementForV3($this->hub, $this->decoratedStatement, 'SELECT 1', ['db.system' => 'sqlite']);
 
         $this->assertTrue($this->statement->bindParam('foo', $variable, ParameterType::INTEGER));
+        $this->assertInstanceOf(TestStatement::class, $this->decoratedStatement);
         $this->assertCount(3, $this->decoratedStatement->args);
     }
 

--- a/tests/Tracing/Doctrine/DBAL/TracingStatementForV3Test.php
+++ b/tests/Tracing/Doctrine/DBAL/TracingStatementForV3Test.php
@@ -125,7 +125,7 @@ final class TracingStatementForV3Test extends DoctrineTestCase
 abstract class TestStatement implements Statement {
 
     /**
-     * @var array|null
+     * @var mixed[]|null
      */
     public $args = null;
 


### PR DESCRIPTION
PHP version: `8.1.1`
doctrine/dbal: `3.2.0`
sentry/sentry-symfony: `4.2.5`

`Deprecated: PDOStatement::bindParam(): Passing null to parameter #4 ($maxLength) of type int is deprecated in ./vendor/doctrine/dbal/src/Driver/PDO/Statement.php on line 83`

While it may seem that the deprecation is caused by that Doctrine `Statement` class, it is in fact caused by passing `$length` as `null` to that method which is then passed on the the `PDOStatement` method call. The fix is done the same way as in Doctrine: https://github.com/doctrine/dbal/blob/3.2.x/src/Driver/PDO/Statement.php#L83