### PR TITLE
Support version 3 of the `symfony/cache-contracts` package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add support for `symfony/cache-contracts` package version `3.x` (#588)
+
 ## 4.2.5 (2021-12-13)
 
 - Add support for Symfony 6 (#566)

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "jean85/pretty-package-versions": "^1.5 || ^2.0",
         "php-http/discovery": "^1.11",
         "sentry/sdk": "^3.1",
-        "symfony/cache-contracts": "^1.1||^2.4",
+        "symfony/cache-contracts": "^1.1||^2.4||^3.0",
         "symfony/config": "^3.4.44||^4.4.20||^5.0.11||^6.0",
         "symfony/console": "^3.4.44||^4.4.20||^5.0.11||^6.0",
         "symfony/dependency-injection": "^3.4.44||^4.4.20||^5.0.11||^6.0",

--- a/src/Tracing/Cache/TraceableCacheAdapterForV2.php
+++ b/src/Tracing/Cache/TraceableCacheAdapterForV2.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tracing\Cache;
+
+use Sentry\State\HubInterface;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+use Symfony\Component\Cache\PruneableInterface;
+use Symfony\Component\Cache\ResettableInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+
+/**
+ * This implementation of a cache adapter supports the distributed tracing
+ * feature of Sentry.
+ *
+ * @internal
+ */
+final class TraceableCacheAdapterForV2 implements AdapterInterface, CacheInterface, PruneableInterface, ResettableInterface
+{
+    /**
+     * @phpstan-use TraceableCacheAdapterTrait<AdapterInterface>
+     */
+    use TraceableCacheAdapterTrait;
+
+    /**
+     * @param HubInterface     $hub              The current hub
+     * @param AdapterInterface $decoratedAdapter The decorated cache adapter
+     */
+    public function __construct(HubInterface $hub, AdapterInterface $decoratedAdapter)
+    {
+        $this->hub = $hub;
+        $this->decoratedAdapter = $decoratedAdapter;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param mixed[] $metadata
+     *
+     * @return mixed
+     */
+    public function get(string $key, callable $callback, float $beta = null, array &$metadata = null)
+    {
+        return $this->traceFunction('cache.get_item', function () use ($key, $callback, $beta, &$metadata) {
+            if (!$this->decoratedAdapter instanceof CacheInterface) {
+                throw new \BadMethodCallException(sprintf('The %s::get() method is not supported because the decorated adapter does not implement the "%s" interface.', self::class, CacheInterface::class));
+            }
+
+            return $this->decoratedAdapter->get($key, $callback, $beta, $metadata);
+        });
+    }
+}

--- a/src/Tracing/Cache/TraceableCacheAdapterForV3.php
+++ b/src/Tracing/Cache/TraceableCacheAdapterForV3.php
@@ -13,8 +13,10 @@ use Symfony\Contracts\Cache\CacheInterface;
 /**
  * This implementation of a cache adapter supports the distributed tracing
  * feature of Sentry.
+ *
+ * @internal
  */
-final class TraceableCacheAdapter implements AdapterInterface, CacheInterface, PruneableInterface, ResettableInterface
+final class TraceableCacheAdapterForV3 implements AdapterInterface, CacheInterface, PruneableInterface, ResettableInterface
 {
     /**
      * @phpstan-use TraceableCacheAdapterTrait<AdapterInterface>
@@ -29,5 +31,21 @@ final class TraceableCacheAdapter implements AdapterInterface, CacheInterface, P
     {
         $this->hub = $hub;
         $this->decoratedAdapter = $decoratedAdapter;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param mixed[] $metadata
+     */
+    public function get(string $key, callable $callback, float $beta = null, array &$metadata = null): mixed
+    {
+        return $this->traceFunction('cache.get_item', function () use ($key, $callback, $beta, &$metadata) {
+            if (!$this->decoratedAdapter instanceof CacheInterface) {
+                throw new \BadMethodCallException(sprintf('The %s::get() method is not supported because the decorated adapter does not implement the "%s" interface.', self::class, CacheInterface::class));
+            }
+
+            return $this->decoratedAdapter->get($key, $callback, $beta, $metadata);
+        });
     }
 }

--- a/src/Tracing/Cache/TraceableCacheAdapterTrait.php
+++ b/src/Tracing/Cache/TraceableCacheAdapterTrait.php
@@ -38,7 +38,7 @@ trait TraceableCacheAdapterTrait
      */
     public function getItem($key): CacheItem
     {
-        return $this->traceFunction('cache.get_item', function () use ($key) {
+        return $this->traceFunction('cache.get_item', function () use ($key): CacheItem {
             return $this->decoratedAdapter->getItem($key);
         });
     }
@@ -48,7 +48,7 @@ trait TraceableCacheAdapterTrait
      */
     public function getItems(array $keys = []): iterable
     {
-        return $this->traceFunction('cache.get_items', function () use ($keys) {
+        return $this->traceFunction('cache.get_items', function () use ($keys): iterable {
             return $this->decoratedAdapter->getItems($keys);
         });
     }
@@ -65,28 +65,10 @@ trait TraceableCacheAdapterTrait
 
     /**
      * {@inheritdoc}
-     *
-     * @param mixed[] $metadata
-     *
-     * @return mixed
-     */
-    public function get(string $key, callable $callback, float $beta = null, array &$metadata = null)
-    {
-        return $this->traceFunction('cache.get_item', function () use ($key, $callback, $beta, &$metadata) {
-            if (!$this->decoratedAdapter instanceof CacheInterface) {
-                throw new \BadMethodCallException(sprintf('The %s::get() method is not supported because the decorated adapter does not implement the "%s" interface.', self::class, CacheInterface::class));
-            }
-
-            return $this->decoratedAdapter->get($key, $callback, $beta, $metadata);
-        });
-    }
-
-    /**
-     * {@inheritdoc}
      */
     public function delete(string $key): bool
     {
-        return $this->traceFunction('cache.delete_item', function () use ($key) {
+        return $this->traceFunction('cache.delete_item', function () use ($key): bool {
             if (!$this->decoratedAdapter instanceof CacheInterface) {
                 throw new \BadMethodCallException(sprintf('The %s::delete() method is not supported because the decorated adapter does not implement the "%s" interface.', self::class, CacheInterface::class));
             }

--- a/src/Tracing/Cache/TraceableTagAwareCacheAdapterForV2.php
+++ b/src/Tracing/Cache/TraceableTagAwareCacheAdapterForV2.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tracing\Cache;
+
+use Sentry\State\HubInterface;
+use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
+use Symfony\Component\Cache\PruneableInterface;
+use Symfony\Component\Cache\ResettableInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+
+/**
+ * This implementation of a cache adapter aware of cache tags supports the
+ * distributed tracing feature of Sentry.
+ *
+ * @internal
+ */
+final class TraceableTagAwareCacheAdapterForV2 implements TagAwareAdapterInterface, TagAwareCacheInterface, PruneableInterface, ResettableInterface
+{
+    /**
+     * @phpstan-use TraceableCacheAdapterTrait<TagAwareAdapterInterface>
+     */
+    use TraceableCacheAdapterTrait;
+
+    /**
+     * @param HubInterface             $hub              The current hub
+     * @param TagAwareAdapterInterface $decoratedAdapter The decorated cache adapter
+     */
+    public function __construct(HubInterface $hub, TagAwareAdapterInterface $decoratedAdapter)
+    {
+        $this->hub = $hub;
+        $this->decoratedAdapter = $decoratedAdapter;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param mixed[] $metadata
+     *
+     * @return mixed
+     */
+    public function get(string $key, callable $callback, float $beta = null, array &$metadata = null)
+    {
+        return $this->traceFunction('cache.get_item', function () use ($key, $callback, $beta, &$metadata) {
+            if (!$this->decoratedAdapter instanceof CacheInterface) {
+                throw new \BadMethodCallException(sprintf('The %s::get() method is not supported because the decorated adapter does not implement the "%s" interface.', self::class, CacheInterface::class));
+            }
+
+            return $this->decoratedAdapter->get($key, $callback, $beta, $metadata);
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function invalidateTags(array $tags): bool
+    {
+        return $this->traceFunction('cache.invalidate_tags', function () use ($tags): bool {
+            return $this->decoratedAdapter->invalidateTags($tags);
+        });
+    }
+}

--- a/src/Tracing/Cache/TraceableTagAwareCacheAdapterForV3.php
+++ b/src/Tracing/Cache/TraceableTagAwareCacheAdapterForV3.php
@@ -8,13 +8,16 @@ use Sentry\State\HubInterface;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Component\Cache\ResettableInterface;
+use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\TagAwareCacheInterface;
 
 /**
  * This implementation of a cache adapter aware of cache tags supports the
  * distributed tracing feature of Sentry.
+ *
+ * @internal
  */
-final class TraceableTagAwareCacheAdapter implements TagAwareAdapterInterface, TagAwareCacheInterface, PruneableInterface, ResettableInterface
+final class TraceableTagAwareCacheAdapterForV3 implements TagAwareAdapterInterface, TagAwareCacheInterface, PruneableInterface, ResettableInterface
 {
     /**
      * @phpstan-use TraceableCacheAdapterTrait<TagAwareAdapterInterface>
@@ -29,6 +32,22 @@ final class TraceableTagAwareCacheAdapter implements TagAwareAdapterInterface, T
     {
         $this->hub = $hub;
         $this->decoratedAdapter = $decoratedAdapter;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param mixed[] $metadata
+     */
+    public function get(string $key, callable $callback, float $beta = null, array &$metadata = null): mixed
+    {
+        return $this->traceFunction('cache.get_item', function () use ($key, $callback, $beta, &$metadata) {
+            if (!$this->decoratedAdapter instanceof CacheInterface) {
+                throw new \BadMethodCallException(sprintf('The %s::get() method is not supported because the decorated adapter does not implement the "%s" interface.', self::class, CacheInterface::class));
+            }
+
+            return $this->decoratedAdapter->get($key, $callback, $beta, $metadata);
+        });
     }
 
     /**

--- a/src/aliases.php
+++ b/src/aliases.php
@@ -12,11 +12,19 @@ use Sentry\SentryBundle\EventListener\RequestListenerRequestEvent;
 use Sentry\SentryBundle\EventListener\RequestListenerResponseEvent;
 use Sentry\SentryBundle\EventListener\RequestListenerTerminateEvent;
 use Sentry\SentryBundle\EventListener\SubRequestListenerRequestEvent;
+use Sentry\SentryBundle\Tracing\Cache\TraceableCacheAdapter;
+use Sentry\SentryBundle\Tracing\Cache\TraceableCacheAdapterForV2;
+use Sentry\SentryBundle\Tracing\Cache\TraceableCacheAdapterForV3;
+use Sentry\SentryBundle\Tracing\Cache\TraceableTagAwareCacheAdapter;
+use Sentry\SentryBundle\Tracing\Cache\TraceableTagAwareCacheAdapterForV2;
+use Sentry\SentryBundle\Tracing\Cache\TraceableTagAwareCacheAdapterForV3;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\Compatibility\MiddlewareInterface;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverForV2;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverForV3;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingStatementForV2;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingStatementForV3;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+use Symfony\Component\Cache\DoctrineProvider;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
@@ -76,6 +84,26 @@ if (version_compare(Kernel::VERSION, '4.3.0', '>=')) {
 
     if (!class_exists(SubRequestListenerRequestEvent::class, false)) {
         class_alias(GetResponseEvent::class, SubRequestListenerRequestEvent::class);
+    }
+}
+
+if (interface_exists(AdapterInterface::class)) {
+    if (!class_exists(DoctrineProvider::class, false) && version_compare(\PHP_VERSION, '8.0.0', '>=')) {
+        if (!class_exists(TraceableCacheAdapter::class, false)) {
+            class_alias(TraceableCacheAdapterForV3::class, TraceableCacheAdapter::class);
+        }
+
+        if (!class_exists(TraceableTagAwareCacheAdapter::class, false)) {
+            class_alias(TraceableTagAwareCacheAdapterForV3::class, TraceableTagAwareCacheAdapter::class);
+        }
+    } else {
+        if (!class_exists(TraceableCacheAdapter::class, false)) {
+            class_alias(TraceableCacheAdapterForV2::class, TraceableCacheAdapter::class);
+        }
+
+        if (!class_exists(TraceableTagAwareCacheAdapter::class, false)) {
+            class_alias(TraceableTagAwareCacheAdapterForV2::class, TraceableTagAwareCacheAdapter::class);
+        }
     }
 }
 

--- a/tests/DependencyInjection/Compiler/CacheTracingPassTest.php
+++ b/tests/DependencyInjection/Compiler/CacheTracingPassTest.php
@@ -6,8 +6,8 @@ namespace Sentry\SentryBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use Sentry\SentryBundle\DependencyInjection\Compiler\CacheTracingPass;
-use Sentry\SentryBundle\Tracing\Cache\TraceableCacheAdapter;
-use Sentry\SentryBundle\Tracing\Cache\TraceableTagAwareCacheAdapter;
+use Sentry\SentryBundle\Tracing\Cache\TraceableCacheAdapterForV2;
+use Sentry\SentryBundle\Tracing\Cache\TraceableTagAwareCacheAdapterForV2;
 use Sentry\State\HubInterface;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
@@ -50,7 +50,7 @@ final class CacheTracingPassTest extends TestCase
                     ->setPublic(true)
                     ->addTag('cache.pool'),
             ],
-            TraceableCacheAdapter::class,
+            TraceableCacheAdapterForV2::class,
             \get_class($cacheAdapter),
         ];
 
@@ -60,7 +60,7 @@ final class CacheTracingPassTest extends TestCase
                     ->setPublic(true)
                     ->addTag('cache.pool'),
             ],
-            TraceableTagAwareCacheAdapter::class,
+            TraceableTagAwareCacheAdapterForV2::class,
             \get_class($tagAwareCacheAdapter),
         ];
 
@@ -71,7 +71,7 @@ final class CacheTracingPassTest extends TestCase
                     ->setPublic(true)
                     ->addTag('cache.pool'),
             ],
-            TraceableCacheAdapter::class,
+            TraceableCacheAdapterForV2::class,
             \get_class($cacheAdapter),
         ];
 
@@ -83,7 +83,7 @@ final class CacheTracingPassTest extends TestCase
                     ->setPublic(true)
                     ->addTag('cache.pool'),
             ],
-            TraceableTagAwareCacheAdapter::class,
+            TraceableTagAwareCacheAdapterForV2::class,
             \get_class($tagAwareCacheAdapter),
         ];
 
@@ -96,7 +96,7 @@ final class CacheTracingPassTest extends TestCase
                     ->setPublic(true)
                     ->addTag('cache.pool'),
             ],
-            TraceableTagAwareCacheAdapter::class,
+            TraceableTagAwareCacheAdapterForV2::class,
             \get_class($tagAwareCacheAdapter),
         ];
 
@@ -107,7 +107,7 @@ final class CacheTracingPassTest extends TestCase
                     ->setPublic(true)
                     ->addTag('cache.pool'),
             ],
-            TraceableTagAwareCacheAdapter::class,
+            TraceableTagAwareCacheAdapterForV2::class,
             \get_class($tagAwareCacheAdapter),
         ];
     }
@@ -143,12 +143,12 @@ final class CacheTracingPassTest extends TestCase
         $container->setParameter('sentry.tracing.cache.enabled', $isTracingActive);
 
         $container->register(HubInterface::class, HubInterface::class);
-        $container->register('sentry.tracing.traceable_cache_adapter', TraceableCacheAdapter::class)
+        $container->register('sentry.tracing.traceable_cache_adapter', TraceableCacheAdapterForV2::class)
             ->setAbstract(true)
             ->setArgument(0, new Reference(HubInterface::class))
             ->setArgument(1, null);
 
-        $container->register('sentry.tracing.traceable_tag_aware_cache_adapter', TraceableTagAwareCacheAdapter::class)
+        $container->register('sentry.tracing.traceable_tag_aware_cache_adapter', TraceableTagAwareCacheAdapterForV2::class)
             ->setAbstract(true)
             ->setArgument(0, new Reference(HubInterface::class))
             ->setArgument(1, null);

--- a/tests/DependencyInjection/Compiler/CacheTracingPassTest.php
+++ b/tests/DependencyInjection/Compiler/CacheTracingPassTest.php
@@ -6,8 +6,8 @@ namespace Sentry\SentryBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use Sentry\SentryBundle\DependencyInjection\Compiler\CacheTracingPass;
-use Sentry\SentryBundle\Tracing\Cache\TraceableCacheAdapterForV2;
-use Sentry\SentryBundle\Tracing\Cache\TraceableTagAwareCacheAdapterForV2;
+use Sentry\SentryBundle\Tracing\Cache\TraceableCacheAdapter;
+use Sentry\SentryBundle\Tracing\Cache\TraceableTagAwareCacheAdapter;
 use Sentry\State\HubInterface;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
@@ -50,7 +50,7 @@ final class CacheTracingPassTest extends TestCase
                     ->setPublic(true)
                     ->addTag('cache.pool'),
             ],
-            TraceableCacheAdapterForV2::class,
+            TraceableCacheAdapter::class,
             \get_class($cacheAdapter),
         ];
 
@@ -60,7 +60,7 @@ final class CacheTracingPassTest extends TestCase
                     ->setPublic(true)
                     ->addTag('cache.pool'),
             ],
-            TraceableTagAwareCacheAdapterForV2::class,
+            TraceableTagAwareCacheAdapter::class,
             \get_class($tagAwareCacheAdapter),
         ];
 
@@ -71,7 +71,7 @@ final class CacheTracingPassTest extends TestCase
                     ->setPublic(true)
                     ->addTag('cache.pool'),
             ],
-            TraceableCacheAdapterForV2::class,
+            TraceableCacheAdapter::class,
             \get_class($cacheAdapter),
         ];
 
@@ -83,7 +83,7 @@ final class CacheTracingPassTest extends TestCase
                     ->setPublic(true)
                     ->addTag('cache.pool'),
             ],
-            TraceableTagAwareCacheAdapterForV2::class,
+            TraceableTagAwareCacheAdapter::class,
             \get_class($tagAwareCacheAdapter),
         ];
 
@@ -96,7 +96,7 @@ final class CacheTracingPassTest extends TestCase
                     ->setPublic(true)
                     ->addTag('cache.pool'),
             ],
-            TraceableTagAwareCacheAdapterForV2::class,
+            TraceableTagAwareCacheAdapter::class,
             \get_class($tagAwareCacheAdapter),
         ];
 
@@ -107,7 +107,7 @@ final class CacheTracingPassTest extends TestCase
                     ->setPublic(true)
                     ->addTag('cache.pool'),
             ],
-            TraceableTagAwareCacheAdapterForV2::class,
+            TraceableTagAwareCacheAdapter::class,
             \get_class($tagAwareCacheAdapter),
         ];
     }
@@ -143,12 +143,12 @@ final class CacheTracingPassTest extends TestCase
         $container->setParameter('sentry.tracing.cache.enabled', $isTracingActive);
 
         $container->register(HubInterface::class, HubInterface::class);
-        $container->register('sentry.tracing.traceable_cache_adapter', TraceableCacheAdapterForV2::class)
+        $container->register('sentry.tracing.traceable_cache_adapter', TraceableCacheAdapter::class)
             ->setAbstract(true)
             ->setArgument(0, new Reference(HubInterface::class))
             ->setArgument(1, null);
 
-        $container->register('sentry.tracing.traceable_tag_aware_cache_adapter', TraceableTagAwareCacheAdapterForV2::class)
+        $container->register('sentry.tracing.traceable_tag_aware_cache_adapter', TraceableTagAwareCacheAdapter::class)
             ->setAbstract(true)
             ->setArgument(0, new Reference(HubInterface::class))
             ->setArgument(1, null);


### PR DESCRIPTION
This PR adds support for `symfony/cache-contracts` package version `3.x`. Since one of the interfaces is using the `mixed` keyword which has been introduced in PHP 8, we have to fork the implementation of our classes to support both the new and the old versions