### PR TITLE
Support http_connect_timeout and http_timeout options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add `TracingDriverConnectionInterface::getNativeConnection()` method to get the original driver connection (#597)
+- Add `options.http_timeout` and `options.http_connect_timeout` configuration options (#593)
 
 ## 4.2.10 (2022-05-17)
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -130,6 +130,8 @@ final class Configuration implements ConfigurationInterface
                             ->normalizeKeys(false)
                             ->scalarPrototype()->end()
                         ->end()
+                        ->integerNode('http_connect_timeout')->min(0)->end()
+                        ->integerNode('http_timeout')->min(0)->end()
                     ->end()
                 ->end()
             ->end();

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -116,6 +116,14 @@ final class Configuration implements ConfigurationInterface
                         ->booleanNode('send_default_pii')->end()
                         ->integerNode('max_value_length')->min(0)->end()
                         ->scalarNode('http_proxy')->end()
+                        ->integerNode('http_connect_timeout')
+                            ->min(0)
+                            ->info('The maximum number of seconds to wait while trying to connect to a server. It works only when using the default transport.')
+                        ->end()
+                        ->integerNode('http_timeout')
+                            ->min(0)
+                            ->info('The maximum execution time for the request+response as a whole. It works only when using the default transport.')
+                        ->end()
                         ->booleanNode('capture_silenced_errors')->end()
                         ->enumNode('max_request_body_size')
                             ->values([
@@ -130,8 +138,6 @@ final class Configuration implements ConfigurationInterface
                             ->normalizeKeys(false)
                             ->scalarPrototype()->end()
                         ->end()
-                        ->integerNode('http_connect_timeout')->min(0)->end()
-                        ->integerNode('http_timeout')->min(0)->end()
                     ->end()
                 ->end()
             ->end();

--- a/src/Resources/config/schema/sentry-1.0.xsd
+++ b/src/Resources/config/schema/sentry-1.0.xsd
@@ -49,10 +49,10 @@
         <xsd:attribute name="send-default-pii" type="xsd:boolean" />
         <xsd:attribute name="max-value-length" type="xsd:integer" />
         <xsd:attribute name="http-proxy" type="xsd:string" />
-        <xsd:attribute name="capture-silenced-errors" type="xsd:boolean" />
-        <xsd:attribute name="max-request-body-size" type="max-request-body-size" />
         <xsd:attribute name="http-timeout" type="xsd:integer" />
         <xsd:attribute name="http-connect-timeout" type="xsd:integer" />
+        <xsd:attribute name="capture-silenced-errors" type="xsd:boolean" />
+        <xsd:attribute name="max-request-body-size" type="max-request-body-size" />
     </xsd:complexType>
 
     <xsd:complexType name="tag">

--- a/src/Resources/config/schema/sentry-1.0.xsd
+++ b/src/Resources/config/schema/sentry-1.0.xsd
@@ -51,6 +51,8 @@
         <xsd:attribute name="http-proxy" type="xsd:string" />
         <xsd:attribute name="capture-silenced-errors" type="xsd:boolean" />
         <xsd:attribute name="max-request-body-size" type="max-request-body-size" />
+        <xsd:attribute name="http-timeout" type="xsd:integer" />
+        <xsd:attribute name="http-connect-timeout" type="xsd:integer" />
     </xsd:complexType>
 
     <xsd:complexType name="tag">

--- a/tests/DependencyInjection/Fixtures/php/full.php
+++ b/tests/DependencyInjection/Fixtures/php/full.php
@@ -36,11 +36,11 @@ $container->loadFromExtension('sentry', [
         'send_default_pii' => true,
         'max_value_length' => 255,
         'http_proxy' => 'proxy.example.com:8080',
+        'http_timeout' => 10,
+        'http_connect_timeout' => 15,
         'capture_silenced_errors' => true,
         'max_request_body_size' => 'none',
         'class_serializers' => ['App\\FooClass' => 'App\\Sentry\\Serializer\\FooClassSerializer'],
-        'http_timeout' => 10,
-        'http_connect_timeout' => 15,
     ],
     'messenger' => [
         'enabled' => true,

--- a/tests/DependencyInjection/Fixtures/php/full.php
+++ b/tests/DependencyInjection/Fixtures/php/full.php
@@ -39,6 +39,8 @@ $container->loadFromExtension('sentry', [
         'capture_silenced_errors' => true,
         'max_request_body_size' => 'none',
         'class_serializers' => ['App\\FooClass' => 'App\\Sentry\\Serializer\\FooClassSerializer'],
+        'http_timeout' => 10,
+        'http_connect_timeout' => 15,
     ],
     'messenger' => [
         'enabled' => true,

--- a/tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/tests/DependencyInjection/Fixtures/xml/full.xml
@@ -30,10 +30,10 @@
                         send-default-pii="true"
                         max-value-length="255"
                         http-proxy="proxy.example.com:8080"
-                        capture-silenced-errors="true"
-                        max-request-body-size="none"
                         http-timeout="10"
                         http-connect-timeout="15"
+                        capture-silenced-errors="true"
+                        max-request-body-size="none"
         >
             <sentry:integration>App\Sentry\Integration\FooIntegration</sentry:integration>
             <sentry:prefix>%kernel.project_dir%</sentry:prefix>

--- a/tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/tests/DependencyInjection/Fixtures/xml/full.xml
@@ -32,6 +32,8 @@
                         http-proxy="proxy.example.com:8080"
                         capture-silenced-errors="true"
                         max-request-body-size="none"
+                        http-timeout="10"
+                        http-connect-timeout="15"
         >
             <sentry:integration>App\Sentry\Integration\FooIntegration</sentry:integration>
             <sentry:prefix>%kernel.project_dir%</sentry:prefix>

--- a/tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/tests/DependencyInjection/Fixtures/yml/full.yml
@@ -32,12 +32,12 @@ sentry:
         send_default_pii: true
         max_value_length: 255
         http_proxy: proxy.example.com:8080
+        http_timeout: 10
+        http_connect_timeout: 15
         capture_silenced_errors: true
         max_request_body_size: 'none'
         class_serializers:
             App\FooClass: App\Sentry\Serializer\FooClassSerializer
-        http_timeout: 10
-        http_connect_timeout: 15
     messenger:
         enabled: true
         capture_soft_fails: false

--- a/tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/tests/DependencyInjection/Fixtures/yml/full.yml
@@ -36,6 +36,8 @@ sentry:
         max_request_body_size: 'none'
         class_serializers:
             App\FooClass: App\Sentry\Serializer\FooClassSerializer
+        http_timeout: 10
+        http_connect_timeout: 15
     messenger:
         enabled: true
         capture_soft_fails: false

--- a/tests/DependencyInjection/SentryExtensionTest.php
+++ b/tests/DependencyInjection/SentryExtensionTest.php
@@ -226,7 +226,7 @@ abstract class SentryExtensionTest extends TestCase
             ],
             'dsn' => 'https://examplePublicKey@o0.ingest.sentry.io/0',
             'http_timeout' => 10,
-            'http_connect_timeout' => 15
+            'http_connect_timeout' => 15,
         ];
 
         $this->assertSame(Options::class, $optionsDefinition->getClass());

--- a/tests/DependencyInjection/SentryExtensionTest.php
+++ b/tests/DependencyInjection/SentryExtensionTest.php
@@ -219,14 +219,14 @@ abstract class SentryExtensionTest extends TestCase
             'send_default_pii' => true,
             'max_value_length' => 255,
             'http_proxy' => 'proxy.example.com:8080',
+            'http_timeout' => 10,
+            'http_connect_timeout' => 15,
             'capture_silenced_errors' => true,
             'max_request_body_size' => 'none',
             'class_serializers' => [
                 'App\\FooClass' => new Reference('App\\Sentry\\Serializer\\FooClassSerializer'),
             ],
             'dsn' => 'https://examplePublicKey@o0.ingest.sentry.io/0',
-            'http_timeout' => 10,
-            'http_connect_timeout' => 15,
         ];
 
         $this->assertSame(Options::class, $optionsDefinition->getClass());

--- a/tests/DependencyInjection/SentryExtensionTest.php
+++ b/tests/DependencyInjection/SentryExtensionTest.php
@@ -225,6 +225,8 @@ abstract class SentryExtensionTest extends TestCase
                 'App\\FooClass' => new Reference('App\\Sentry\\Serializer\\FooClassSerializer'),
             ],
             'dsn' => 'https://examplePublicKey@o0.ingest.sentry.io/0',
+            'http_timeout' => 10,
+            'http_connect_timeout' => 15
         ];
 
         $this->assertSame(Options::class, $optionsDefinition->getClass());


### PR DESCRIPTION
I raised this issue: https://github.com/getsentry/sentry-symfony/issues/592

This PR adds the ability to set options for http (timeout) options, when paired with https://github.com/getsentry/sentry-php/pull/1282 (which modifies the `sentry-php` SDK) will allow the setting of these options via Symfony yml configuration.

Example use:

`sentry.yml`:
```yml
sentry:
    options:
        http_timeout: 1
        http_connect_timeout: 1
```

If I've missed the mark, feel free to reject - I'd just love to be able to do this in my app, if it's possible already please let me know, thanks!