### PR TITLE
Add support for accessing dbal native connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `TracingDriverConnectionInterface::getNativeConnection()` method to get the original driver connection (#597)
+
 ## 4.2.6 (2022-01-10)
 
 - Add support for `symfony/cache-contracts` package version `3.x` (#588)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -241,7 +241,7 @@ parameters:
 			path: tests/Tracing/Doctrine/DBAL/TracingServerInfoAwareDriverConnectionTest.php
 
 		-
-			message: "#^Trying to mock an undefined method requiresQueryForServerVersion\\(\\) on class Sentry\\\\SentryBundle\\\\Tests\\\\Tracing\\\\Doctrine\\\\DBAL\\\\ServerInfoAwareConnectionStub\\.$#"
+			message: "#^Trying to mock an undefined method requiresQueryForServerVersion\\(\\) on class Sentry\\\\SentryBundle\\\\Tests\\\\Tracing\\\\Doctrine\\\\DBAL\\\\Fixture\\\\ServerInfoAwareConnectionStub\\.$#"
 			count: 1
 			path: tests/Tracing/Doctrine/DBAL/TracingServerInfoAwareDriverConnectionTest.php
 

--- a/src/Tracing/Doctrine/DBAL/TracingDriverConnection.php
+++ b/src/Tracing/Doctrine/DBAL/TracingDriverConnection.php
@@ -166,6 +166,20 @@ final class TracingDriverConnection implements TracingDriverConnectionInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return resource|object
+     */
+    public function getNativeConnection()
+    {
+        if (!method_exists($this->decoratedConnection, 'getNativeConnection')) {
+            throw new \BadMethodCallException(sprintf('The connection "%s" does not support accessing the native connection.', \get_class($this->decoratedConnection)));
+        }
+
+        return $this->decoratedConnection->getNativeConnection();
+    }
+
+    /**
+     * {@inheritdoc}
      */
     public function errorCode(): ?string
     {

--- a/src/Tracing/Doctrine/DBAL/TracingDriverConnectionInterface.php
+++ b/src/Tracing/Doctrine/DBAL/TracingDriverConnectionInterface.php
@@ -6,6 +6,9 @@ namespace Sentry\SentryBundle\Tracing\Doctrine\DBAL;
 
 use Doctrine\DBAL\Driver\Connection;
 
+/**
+ * @method resource|object getNativeConnection()
+ */
 interface TracingDriverConnectionInterface extends Connection
 {
     public function getWrappedConnection(): Connection;

--- a/src/Tracing/Doctrine/DBAL/TracingServerInfoAwareDriverConnection.php
+++ b/src/Tracing/Doctrine/DBAL/TracingServerInfoAwareDriverConnection.php
@@ -117,6 +117,20 @@ final class TracingServerInfoAwareDriverConnection implements TracingDriverConne
 
     /**
      * {@inheritdoc}
+     *
+     * @return resource|object
+     */
+    public function getNativeConnection()
+    {
+        if (!method_exists($this->decoratedConnection, 'getNativeConnection')) {
+            throw new \BadMethodCallException(sprintf('The connection "%s" does not support accessing the native connection.', \get_class($this->decoratedConnection)));
+        }
+
+        return $this->decoratedConnection->getNativeConnection();
+    }
+
+    /**
+     * {@inheritdoc}
      */
     public function requiresQueryForServerVersion(): bool
     {

--- a/tests/Tracing/Doctrine/DBAL/Fixture/NativeDriverConnectionInterface.php
+++ b/tests/Tracing/Doctrine/DBAL/Fixture/NativeDriverConnectionInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\Tracing\Doctrine\DBAL\Fixture;
+
+use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverConnectionInterface;
+
+interface NativeDriverConnectionInterface extends TracingDriverConnectionInterface
+{
+    /**
+     * @return object|resource
+     */
+    public function getNativeConnection();
+}

--- a/tests/Tracing/Doctrine/DBAL/Fixture/NativeDriverConnectionInterfaceStub.php
+++ b/tests/Tracing/Doctrine/DBAL/Fixture/NativeDriverConnectionInterfaceStub.php
@@ -6,7 +6,7 @@ namespace Sentry\SentryBundle\Tests\Tracing\Doctrine\DBAL\Fixture;
 
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverConnectionInterface;
 
-interface NativeDriverConnectionInterface extends TracingDriverConnectionInterface
+interface NativeDriverConnectionInterfaceStub extends TracingDriverConnectionInterface
 {
     /**
      * @return object|resource

--- a/tests/Tracing/Doctrine/DBAL/Fixture/ServerInfoAwareConnectionStub.php
+++ b/tests/Tracing/Doctrine/DBAL/Fixture/ServerInfoAwareConnectionStub.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sentry\SentryBundle\Tests\Tracing\Doctrine\DBAL;
+namespace Sentry\SentryBundle\Tests\Tracing\Doctrine\DBAL\Fixture;
 
 use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;

--- a/tests/Tracing/Doctrine/DBAL/TracingDriverConnectionFactoryTest.php
+++ b/tests/Tracing/Doctrine/DBAL/TracingDriverConnectionFactoryTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use PHPUnit\Framework\MockObject\MockObject;
 use Sentry\SentryBundle\Tests\DoctrineTestCase;
+use Sentry\SentryBundle\Tests\Tracing\Doctrine\DBAL\Fixture\ServerInfoAwareConnectionStub;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverConnection;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverConnectionFactory;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingServerInfoAwareDriverConnection;

--- a/tests/Tracing/Doctrine/DBAL/TracingDriverConnectionTest.php
+++ b/tests/Tracing/Doctrine/DBAL/TracingDriverConnectionTest.php
@@ -10,7 +10,9 @@ use Doctrine\DBAL\Driver\Statement as DriverStatementInterface;
 use Doctrine\DBAL\ParameterType;
 use PHPUnit\Framework\MockObject\MockObject;
 use Sentry\SentryBundle\Tests\DoctrineTestCase;
+use Sentry\SentryBundle\Tests\Tracing\Doctrine\DBAL\Fixture\NativeDriverConnectionInterface;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverConnection;
+use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverConnectionInterface;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingStatement;
 use Sentry\State\HubInterface;
 use Sentry\Tracing\Transaction;
@@ -394,6 +396,33 @@ final class TracingDriverConnectionTest extends DoctrineTestCase
         $connection = new TracingDriverConnection($this->hub, $this->decoratedConnection, 'foo_platform', []);
 
         $this->assertSame($this->decoratedConnection, $connection->getWrappedConnection());
+    }
+
+    public function testGetNativeConnection(): void
+    {
+        $nativeConnection = new class() {
+        };
+
+        $decoratedConnection = $this->createMock(NativeDriverConnectionInterface::class);
+        $decoratedConnection->expects($this->once())
+            ->method('getNativeConnection')
+            ->willReturn($nativeConnection);
+
+        $connection = new TracingDriverConnection($this->hub, $decoratedConnection, 'foo_platform', []);
+
+        $this->assertSame($nativeConnection, $connection->getNativeConnection());
+    }
+
+    public function testGetNativeConnectionThrowsExceptionIfDecoratedConnectionDoesNotImplementMethod(): void
+    {
+        $decoratedConnection = $this->createMock(TracingDriverConnectionInterface::class);
+
+        $connection = new TracingDriverConnection($this->hub, $decoratedConnection, 'foo_platform', []);
+
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessageMatches('~The connection .+? does not support accessing the native connection~');
+
+        $connection->getNativeConnection();
     }
 
     /**

--- a/tests/Tracing/Doctrine/DBAL/TracingDriverConnectionTest.php
+++ b/tests/Tracing/Doctrine/DBAL/TracingDriverConnectionTest.php
@@ -10,7 +10,7 @@ use Doctrine\DBAL\Driver\Statement as DriverStatementInterface;
 use Doctrine\DBAL\ParameterType;
 use PHPUnit\Framework\MockObject\MockObject;
 use Sentry\SentryBundle\Tests\DoctrineTestCase;
-use Sentry\SentryBundle\Tests\Tracing\Doctrine\DBAL\Fixture\NativeDriverConnectionInterface;
+use Sentry\SentryBundle\Tests\Tracing\Doctrine\DBAL\Fixture\NativeDriverConnectionInterfaceStub;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverConnection;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverConnectionInterface;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingStatement;
@@ -403,7 +403,7 @@ final class TracingDriverConnectionTest extends DoctrineTestCase
         $nativeConnection = new class() {
         };
 
-        $decoratedConnection = $this->createMock(NativeDriverConnectionInterface::class);
+        $decoratedConnection = $this->createMock(NativeDriverConnectionInterfaceStub::class);
         $decoratedConnection->expects($this->once())
             ->method('getNativeConnection')
             ->willReturn($nativeConnection);
@@ -416,11 +416,10 @@ final class TracingDriverConnectionTest extends DoctrineTestCase
     public function testGetNativeConnectionThrowsExceptionIfDecoratedConnectionDoesNotImplementMethod(): void
     {
         $decoratedConnection = $this->createMock(TracingDriverConnectionInterface::class);
-
         $connection = new TracingDriverConnection($this->hub, $decoratedConnection, 'foo_platform', []);
 
         $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessageMatches('~The connection .+? does not support accessing the native connection~');
+        $this->expectExceptionMessageMatches('/The connection ".*?" does not support accessing the native connection\./');
 
         $connection->getNativeConnection();
     }

--- a/tests/Tracing/Doctrine/DBAL/TracingServerInfoAwareDriverConnectionTest.php
+++ b/tests/Tracing/Doctrine/DBAL/TracingServerInfoAwareDriverConnectionTest.php
@@ -10,7 +10,8 @@ use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\ParameterType;
 use PHPUnit\Framework\MockObject\MockObject;
 use Sentry\SentryBundle\Tests\DoctrineTestCase;
-use Sentry\SentryBundle\Tests\Tracing\Doctrine\DBAL\Fixture\NativeDriverConnectionInterface;
+use Sentry\SentryBundle\Tests\Tracing\Doctrine\DBAL\Fixture\NativeDriverConnectionInterfaceStub;
+use Sentry\SentryBundle\Tests\Tracing\Doctrine\DBAL\Fixture\ServerInfoAwareConnectionStub;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverConnectionInterface;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingServerInfoAwareDriverConnection;
 
@@ -263,7 +264,7 @@ final class TracingServerInfoAwareDriverConnectionTest extends DoctrineTestCase
         $nativeConnection = new class() {
         };
 
-        $decoratedConnection = $this->createMock(NativeDriverConnectionInterface::class);
+        $decoratedConnection = $this->createMock(NativeDriverConnectionInterfaceStub::class);
         $decoratedConnection->expects($this->once())
             ->method('getNativeConnection')
             ->willReturn($nativeConnection);
@@ -276,11 +277,10 @@ final class TracingServerInfoAwareDriverConnectionTest extends DoctrineTestCase
     public function testGetNativeConnectionThrowsExceptionIfDecoratedConnectionDoesNotImplementMethod(): void
     {
         $decoratedConnection = $this->createMock(TracingDriverConnectionInterface::class);
-
         $connection = new TracingServerInfoAwareDriverConnection($decoratedConnection);
 
         $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessageMatches('~The connection .+? does not support accessing the native connection~');
+        $this->expectExceptionMessageMatches('/The connection ".*?" does not support accessing the native connection\./');
 
         $connection->getNativeConnection();
     }


### PR DESCRIPTION
Dbal V3 contains:

```php
/**
 * Connection interface.
 * Driver connections must implement this interface.
 *
 * @method resource|object getNativeConnection()
 */
interface Connection
```