### PR TITLE
Fix compatibility issue with Doctrine `>= 2.6`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- ...
+- Fix compatibility issue with Doctrine Bundle `>= 2.6.0` (#608)
 
 ## 4.2.7 (2022-02-18)
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -136,7 +136,7 @@ parameters:
 			path: src/DependencyInjection/SentryExtension.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of method Symfony\\\\Component\\\\DependencyInjection\\\\Container\\:\\:setParameter\\(\\) expects array\\|bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			message: "#^Parameter \\#2 \\$value of method Symfony\\\\Component\\\\DependencyInjection\\\\Container\\:\\:setParameter\\(\\) expects array\\|bool\\|float\\|int\\|string\\|UnitEnum\\|null, mixed given\\.$#"
 			count: 2
 			path: src/DependencyInjection/SentryExtension.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.20.0@f82a70e7edfc6cf2705e9374c8a0b6a974a779ed">
+<files psalm-version="4.22.0@fc2c6ab4d5fa5d644d8617089f012f3bb84b8703">
   <file src="src/DependencyInjection/SentryExtension.php">
     <UndefinedClass occurrences="1">
       <code>FatalErrorException</code>
@@ -30,6 +30,9 @@
     <LessSpecificImplementedReturnType occurrences="1">
       <code>iterable</code>
     </LessSpecificImplementedReturnType>
+  </file>
+  <file src="src/Tracing/Doctrine/DBAL/Compatibility/MiddlewareInterface.php">
+    <UnrecognizedStatement occurrences="1"/>
   </file>
   <file src="src/Tracing/Doctrine/DBAL/TracingDriverForV2.php">
     <UndefinedClass occurrences="1">

--- a/src/Tracing/Doctrine/DBAL/Compatibility/MiddlewareInterface.php
+++ b/src/Tracing/Doctrine/DBAL/Compatibility/MiddlewareInterface.php
@@ -5,11 +5,21 @@ declare(strict_types=1);
 namespace Sentry\SentryBundle\Tracing\Doctrine\DBAL\Compatibility;
 
 use Doctrine\DBAL\Driver as DriverInterface;
+use Doctrine\DBAL\Driver\Middleware as DoctrineMiddlewareInterface;
 
-/**
- * @internal
- */
-interface MiddlewareInterface
-{
-    public function wrap(DriverInterface $driver): DriverInterface;
+if (interface_exists(DoctrineMiddlewareInterface::class)) {
+    /**
+     * @internal
+     */
+    interface MiddlewareInterface extends DoctrineMiddlewareInterface
+    {
+    }
+} else {
+    /**
+     * @internal
+     */
+    interface MiddlewareInterface
+    {
+        public function wrap(DriverInterface $driver): DriverInterface;
+    }
 }

--- a/src/Tracing/Doctrine/DBAL/TracingDriverMiddleware.php
+++ b/src/Tracing/Doctrine/DBAL/TracingDriverMiddleware.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Sentry\SentryBundle\Tracing\Doctrine\DBAL;
 
 use Doctrine\DBAL\Driver;
-use Doctrine\DBAL\Driver\Middleware;
+use Sentry\SentryBundle\Tracing\Doctrine\DBAL\Compatibility\MiddlewareInterface;
 use Sentry\State\HubInterface;
 
 /**
@@ -14,7 +14,7 @@ use Sentry\State\HubInterface;
  *
  * @internal since version 4.2
  */
-final class TracingDriverMiddleware implements Middleware
+final class TracingDriverMiddleware implements MiddlewareInterface
 {
     /**
      * @var TracingDriverConnectionFactoryInterface

--- a/src/aliases.php
+++ b/src/aliases.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Sentry\SentryBundle;
 
-use Doctrine\DBAL\Driver\Middleware as DoctrineMiddlewareInterface;
 use Doctrine\DBAL\Result;
 use Sentry\SentryBundle\EventListener\ErrorListenerExceptionEvent;
 use Sentry\SentryBundle\EventListener\RequestListenerControllerEvent;
@@ -18,7 +17,6 @@ use Sentry\SentryBundle\Tracing\Cache\TraceableCacheAdapterForV3;
 use Sentry\SentryBundle\Tracing\Cache\TraceableTagAwareCacheAdapter;
 use Sentry\SentryBundle\Tracing\Cache\TraceableTagAwareCacheAdapterForV2;
 use Sentry\SentryBundle\Tracing\Cache\TraceableTagAwareCacheAdapterForV3;
-use Sentry\SentryBundle\Tracing\Doctrine\DBAL\Compatibility\MiddlewareInterface;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverForV2;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverForV3;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingStatementForV2;
@@ -105,10 +103,6 @@ if (interface_exists(AdapterInterface::class)) {
             class_alias(TraceableTagAwareCacheAdapterForV2::class, TraceableTagAwareCacheAdapter::class);
         }
     }
-}
-
-if (!interface_exists(DoctrineMiddlewareInterface::class)) {
-    class_alias(MiddlewareInterface::class, DoctrineMiddlewareInterface::class);
 }
 
 if (!class_exists('Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingStatement')) {


### PR DESCRIPTION
Fixes #607: to workaround the problem of missing `Doctrine\DBAL\Driver\Middleware` interface in DBAL `2.x`, an alias was created pointing to our own interface. However, this solution causes issues to all third-party code that would incorrectly assume that the original interface really exists.