### PR TITLE
Prepare release `4.2.8`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 4.2.8 (2022-03-31)
+
 - Fix compatibility issue with Doctrine Bundle `>= 2.6.0` (#608)
 
 ## 4.2.7 (2022-02-18)


### PR DESCRIPTION
Nothing that's worth mentioning, I'm only updating the CHANGELOG. Opening a PR is now required due to the recent activation of the branch protection rule for `master` 😞