### PR TITLE
Default Statement::bindParam $length to 0, as using null causes a deprecation with PHP8+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix deprecation notice thrown when instrumenting the `PDOStatement::bindParam()` method and passing `$length = null` on DBAL `2.x` (#613)
+
 ## 4.2.8 (2022-03-31)
 
 - Fix compatibility issue with Doctrine Bundle `>= 2.6.0` (#608)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -441,12 +441,12 @@ parameters:
 			path: tests/Tracing/Doctrine/DBAL/TracingServerInfoAwareDriverConnectionTest.php
 
 		-
-			message: "#^Access to an undefined property PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&Sentry\\\\SentryBundle\\\\Tests\\\\Tracing\\\\Doctrine\\\\DBAL\\\\TracingStatementForV2Stub\\:\\:\\$bindParamCallArgsCount\\.$#"
+			message: "#^Parameter \\#2 \\$decoratedStatement of class Sentry\\\\SentryBundle\\\\Tracing\\\\Doctrine\\\\DBAL\\\\TracingStatementForV2 constructor expects Doctrine\\\\DBAL\\\\Driver\\\\Statement, PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&Sentry\\\\SentryBundle\\\\Tests\\\\Tracing\\\\Doctrine\\\\DBAL\\\\TracingStatementForV2Stub given\\.$#"
 			count: 1
 			path: tests/Tracing/Doctrine/DBAL/TracingStatementForV2Test.php
 
 		-
-			message: "#^Parameter \\#2 \\$decoratedStatement of class Sentry\\\\SentryBundle\\\\Tracing\\\\Doctrine\\\\DBAL\\\\TracingStatementForV2 constructor expects Doctrine\\\\DBAL\\\\Driver\\\\Statement, PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&Sentry\\\\SentryBundle\\\\Tests\\\\Tracing\\\\Doctrine\\\\DBAL\\\\TracingStatementForV2Stub given\\.$#"
+			message: "#^Parameter \\#4 \\$length of method Sentry\\\\SentryBundle\\\\Tracing\\\\Doctrine\\\\DBAL\\\\TracingStatementForV2\\:\\:bindParam\\(\\) expects int\\|null, mixed given\\.$#"
 			count: 1
 			path: tests/Tracing/Doctrine/DBAL/TracingStatementForV2Test.php
 

--- a/src/Tracing/Doctrine/DBAL/TracingStatementForV2.php
+++ b/src/Tracing/Doctrine/DBAL/TracingStatementForV2.php
@@ -108,7 +108,7 @@ final class TracingStatementForV2 extends AbstractTracingStatement implements \I
      */
     public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null): bool
     {
-        return $this->decoratedStatement->bindParam($param, $variable, $type, ...\array_slice(\func_get_args(), 3));
+        return $this->decoratedStatement->bindParam($param, $variable, $type, $length ?? 0, ...\array_slice(\func_get_args(), 4));
     }
 
     /**

--- a/tests/Tracing/Doctrine/DBAL/TracingStatementForV2Test.php
+++ b/tests/Tracing/Doctrine/DBAL/TracingStatementForV2Test.php
@@ -215,6 +215,10 @@ final class TracingStatementForV2Test extends DoctrineTestCase
 if (!interface_exists(Statement::class)) {
     abstract class TracingStatementForV2Stub
     {
+        /**
+         * @var int|null
+         */
+        public $bindParamLengthValue;
     }
 } else {
     /**
@@ -226,7 +230,10 @@ if (!interface_exists(Statement::class)) {
          * @var int
          */
         public $bindParamCallArgsCount = 0;
-        public $bindParamLengthValue = null;
+        /**
+         * @var int|null
+         */
+        public $bindParamLengthValue;
 
         public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null): bool
         {

--- a/tests/Tracing/Doctrine/DBAL/TracingStatementForV2Test.php
+++ b/tests/Tracing/Doctrine/DBAL/TracingStatementForV2Test.php
@@ -123,7 +123,7 @@ final class TracingStatementForV2Test extends DoctrineTestCase
      * @param mixed[] $callArgs
      * @param mixed[] $expectedCallArgs
      */
-    public function testBindParam(array $callArgs, int $expectedLengthArg, array $expectedCallArgs): void
+    public function testBindParam(array $callArgs, array $expectedCallArgs): void
     {
         $variable = 'bar';
         $decoratedStatement = $this->createPartialMock(TracingStatementForV2Stub::class, array_diff(get_class_methods(TracingStatementForV2Stub::class), ['bindParam']));
@@ -132,7 +132,6 @@ final class TracingStatementForV2Test extends DoctrineTestCase
 
         $this->assertTrue($this->statement->bindParam('foo', $variable, ParameterType::INTEGER, ...$callArgs));
         $this->assertSame($expectedCallArgs, $decoratedStatement->bindParamCallArgs);
-        $this->assertSame($expectedLengthArg, $decoratedStatement->bindParamLengthValue);
     }
 
     /**
@@ -142,19 +141,16 @@ final class TracingStatementForV2Test extends DoctrineTestCase
     {
         yield '$length parameter not passed at all' => [
             [],
-            0,
             ['foo', 'bar', 1, 0],
         ];
 
         yield '$length parameter passed as `null`' => [
             [null],
-            0,
             ['foo', 'bar', 1, 0],
         ];
 
         yield 'additional parameters passed' => [
             [null, 'baz'],
-            0,
             ['foo', 'bar', 1, 0, 'baz'],
         ];
     }
@@ -234,11 +230,6 @@ if (!interface_exists(Statement::class)) {
          * @var mixed[]
          */
         public $bindParamCallArgs = [];
-
-        /**
-         * @var int|null
-         */
-        public $bindParamLengthValue;
     }
 } else {
     /**
@@ -251,11 +242,6 @@ if (!interface_exists(Statement::class)) {
          */
         public $bindParamCallArgs = [];
 
-        /**
-         * @var int|null
-         */
-        public $bindParamLengthValue;
-
         public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null): bool
         {
             // Since PHPUnit forcefully calls the mocked methods with all
@@ -263,7 +249,6 @@ if (!interface_exists(Statement::class)) {
             // in an explicit manner, we can't use a mock to assert the number
             // of args used in the call to the function
             $this->bindParamCallArgs = \func_get_args();
-            $this->bindParamLengthValue = $length;
 
             return true;
         }

--- a/tests/Tracing/Doctrine/DBAL/TracingStatementForV2Test.php
+++ b/tests/Tracing/Doctrine/DBAL/TracingStatementForV2Test.php
@@ -137,7 +137,11 @@ final class TracingStatementForV2Test extends DoctrineTestCase
         $this->statement = new TracingStatementForV2($this->hub, $decoratedStatement, 'SELECT 1', ['db.system' => 'sqlite']);
 
         $this->assertTrue($this->statement->bindParam('foo', $variable, ParameterType::INTEGER));
-        $this->assertSame(3, $decoratedStatement->bindParamCallArgsCount);
+        $this->assertSame(4, $decoratedStatement->bindParamCallArgsCount);
+        $this->assertSame(0, $decoratedStatement->bindParamLengthValue);
+
+        $this->assertTrue($this->statement->bindParam('foo', $variable, ParameterType::STRING, 3));
+        $this->assertSame(3, $decoratedStatement->bindParamLengthValue);
     }
 
     public function testErrorCode(): void
@@ -222,6 +226,7 @@ if (!interface_exists(Statement::class)) {
          * @var int
          */
         public $bindParamCallArgsCount = 0;
+        public $bindParamLengthValue = null;
 
         public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null): bool
         {
@@ -230,6 +235,7 @@ if (!interface_exists(Statement::class)) {
             // in an explicit manner, we can't use a mock to assert the number
             // of args used in the call to the function
             $this->bindParamCallArgsCount = \func_num_args();
+            $this->bindParamLengthValue = $length;
 
             return true;
         }

--- a/tests/Tracing/Doctrine/DBAL/TracingStatementForV2Test.php
+++ b/tests/Tracing/Doctrine/DBAL/TracingStatementForV2Test.php
@@ -119,6 +119,9 @@ final class TracingStatementForV2Test extends DoctrineTestCase
 
     /**
      * @dataProvider bindParamDataProvider
+     *
+     * @param mixed[] $callArgs
+     * @param mixed[] $expectedCallArgs
      */
     public function testBindParam(array $callArgs, int $expectedLengthArg, array $expectedCallArgs): void
     {
@@ -227,6 +230,11 @@ final class TracingStatementForV2Test extends DoctrineTestCase
 if (!interface_exists(Statement::class)) {
     abstract class TracingStatementForV2Stub
     {
+        /**
+         * @var mixed[]
+         */
+        public $bindParamCallArgs = [];
+
         /**
          * @var int|null
          */


### PR DESCRIPTION
When using PHP8+ with Doctrine DBALv2 and calling `PDOStatement::bindParam()` with just 2 params causes a deprecation for passing null to an int param. The default in PDO is `0`, so this change defaults to 0 when calling the decorated statement.

Fixes #611