### PR TITLE
missing getNativeConnection() method from Connection interface

### DIFF
--- a/src/Tracing/Doctrine/DBAL/TracingServerInfoAwareDriverConnection.php
+++ b/src/Tracing/Doctrine/DBAL/TracingServerInfoAwareDriverConnection.php
@@ -161,4 +161,12 @@ final class TracingServerInfoAwareDriverConnection implements TracingDriverConne
     {
         return $this->decoratedConnection->getWrappedConnection();
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNativeConnection()
+    {
+        return $this->decoratedConnection->getNativeConnection();
+    }
 }


### PR DESCRIPTION
This method was added in doctrine/dbal 3.3
https://github.com/doctrine/dbal/commit/d9f969b366fcd4c7def89372b9c198edb2cc9fe5

and is required for example in Symfony Message component 

See Doctrine\DBAL\Connection : getNativeConnection()