### PR TITLE
Add support for getNativeConnection

### DIFF
--- a/src/Tracing/Doctrine/DBAL/TracingDriverConnection.php
+++ b/src/Tracing/Doctrine/DBAL/TracingDriverConnection.php
@@ -87,6 +87,16 @@ final class TracingDriverConnection implements TracingDriverConnectionInterface
     }
 
     /**
+     * Returns a PDO native connection
+     *
+     * @return resource|object
+     */
+    public function getNativeConnection()
+    {
+        return $this->decoratedConnection->getNativeConnection();
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function prepare($sql): Statement

--- a/src/Tracing/Doctrine/DBAL/TracingServerInfoAwareDriverConnection.php
+++ b/src/Tracing/Doctrine/DBAL/TracingServerInfoAwareDriverConnection.php
@@ -34,6 +34,16 @@ final class TracingServerInfoAwareDriverConnection implements TracingDriverConne
     }
 
     /**
+     * Returns a PDO native connection
+     *
+     * @return resource|object
+     */
+    public function getNativeConnection()
+    {
+        return $this->decoratedConnection->getNativeConnection();
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function prepare($sql): Statement


### PR DESCRIPTION
Add support for method `getNativeConnection`

This method, present in Doctrine/dbal/src/Driver/PDO/Connection.php:128 is used by Doctrine when using a PostgreSQL database.

Without it, the bundle crashes with this error:
```
The driver connection Sentry\SentryBundle\Tracing\Doctrine\DBAL\
TracingServerInfoAwareDriverConnection does not support accessing the native connection.
```

So, I added a simple wrapper to allow Doctrine to access the method.


By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
