### PR TITLE
fix: Make getTraceMeta() function public.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix compatibility issue with Twig >= 3.4.0 (#628)
+
 ## 4.2.9 (2022-05-03)
 
 - Fix deprecation notice thrown when instrumenting the `PDOStatement::bindParam()` method and passing `$length = null` on DBAL `2.x` (#613)

--- a/src/Twig/SentryExtension.php
+++ b/src/Twig/SentryExtension.php
@@ -29,7 +29,7 @@ final class SentryExtension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('sentry_trace_meta', \Closure::fromCallable([$this, 'getTraceMeta']), ['is_safe' => ['html']]),
+            new TwigFunction('sentry_trace_meta', [$this, 'getTraceMeta'], ['is_safe' => ['html']]),
         ];
     }
 

--- a/src/Twig/SentryExtension.php
+++ b/src/Twig/SentryExtension.php
@@ -36,7 +36,7 @@ final class SentryExtension extends AbstractExtension
     /**
      * Returns an HTML meta tag named `sentry-trace`.
      */
-    private function getTraceMeta(): string
+    public function getTraceMeta(): string
     {
         $span = $this->hub->getSpan();
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-symfony/issues/627