### PR TITLE
Prepare release 4.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+
+## 4.2.10 (2022-05-17)
+
 - Fix compatibility issue with Twig >= 3.4.0 (#628)
 
 ## 4.2.9 (2022-05-03)


### PR DESCRIPTION
I want to release the Twig fix so we can push forward to the 4.3 release, including #630 