### PR TITLE
Require at least the version `3.5` of the core Sentry SDK

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -92,16 +92,20 @@ jobs:
   missing-optional-packages-tests:
     name: Tests without optional packages
     runs-on: ubuntu-latest
+    env:
+      SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - php: '7.2'
             dependencies: lowest
+            symfony-version: 3.4.*
           - php: '7.4'
             dependencies: highest
           - php: '8.0'
             dependencies: lowest
+            symfony-version: 4.4.*
           - php: '8.1'
             dependencies: highest
 
@@ -114,6 +118,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: pcov
+          tools: flex
 
       - name: Setup Problem Matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -113,7 +113,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          coverage: xdebug
+          coverage: pcov
 
       - name: Setup Problem Matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "php": "^7.2||^8.0",
         "jean85/pretty-package-versions": "^1.5 || ^2.0",
         "php-http/discovery": "^1.11",
-        "sentry/sdk": "^3.1",
+        "sentry/sdk": "^3.2",
         "symfony/cache-contracts": "^1.1||^2.4||^3.0",
         "symfony/config": "^3.4.44||^4.4.20||^5.0.11||^6.0",
         "symfony/console": "^3.4.44||^4.4.20||^5.0.11||^6.0",

--- a/tests/End2End/App/config.yml
+++ b/tests/End2End/App/config.yml
@@ -2,7 +2,6 @@ sentry:
   tracing:
     enabled: true
   options:
-    capture_silenced_errors: true
     error_types: E_ALL & ~E_USER_DEPRECATED
     traces_sample_rate: 0
 

--- a/tests/End2End/App/config.yml
+++ b/tests/End2End/App/config.yml
@@ -2,6 +2,7 @@ sentry:
   tracing:
     enabled: true
   options:
+    capture_silenced_errors: false
     error_types: E_ALL & ~E_USER_DEPRECATED
     traces_sample_rate: 0
 

--- a/tests/End2End/End2EndTest.php
+++ b/tests/End2End/End2EndTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sentry\SentryBundle\Tests\End2End;
 
 use Sentry\SentryBundle\Tests\End2End\App\Kernel;
+use Sentry\SentrySdk;
 use Sentry\State\HubInterface;
 use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -162,6 +163,11 @@ class End2EndTest extends WebTestCase
     public function testNotice(): void
     {
         $client = static::createClient();
+
+        /** @var HubInterface $hub */
+        $hub = $client->getContainer()->get('test.hub');
+        $hub->getClient()->getOptions()->setCaptureSilencedErrors(true);
+
         $client->request('GET', '/notice');
 
         $response = $client->getResponse();

--- a/tests/End2End/End2EndTest.php
+++ b/tests/End2End/End2EndTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Sentry\SentryBundle\Tests\End2End;
 
 use Sentry\SentryBundle\Tests\End2End\App\Kernel;
-use Sentry\SentrySdk;
 use Sentry\State\HubInterface;
 use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -166,7 +165,11 @@ class End2EndTest extends WebTestCase
 
         /** @var HubInterface $hub */
         $hub = $client->getContainer()->get('test.hub');
-        $hub->getClient()->getOptions()->setCaptureSilencedErrors(true);
+        $sentryClient = $hub->getClient();
+
+        $this->assertNotNull($sentryClient);
+
+        $sentryClient->getOptions()->setCaptureSilencedErrors(true);
 
         $client->request('GET', '/notice');
 


### PR DESCRIPTION
Prepare the terrain for supporting the new features introduced with the version `3.5` of the core SDK. One test needed to be adjusted because of a change in the SDK that now consider only the `capture_silenced_errors` option to decide whether a silenced error needs to be captured, and not also the current value reported by `error_reporting()`