### PR TITLE
SentryTestCommand > Fix deprecated `$defaultName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix compatibility issue with Symfony >= 6.1.0 (#635)
 
 ## 4.2.10 (2022-05-17)
 

--- a/src/Command/SentryTestCommand.php
+++ b/src/Command/SentryTestCommand.php
@@ -11,8 +11,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SentryTestCommand extends Command
 {
-    protected static $defaultName = 'sentry:test';
-
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $currentHub = SentrySdk::getCurrentHub();

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -88,7 +88,7 @@
         </service>
 
         <service id="Sentry\SentryBundle\Command\SentryTestCommand" class="Sentry\SentryBundle\Command\SentryTestCommand">
-            <tag name="console.command" />
+            <tag name="console.command" command="sentry:test" />
         </service>
 
         <service id="Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverConnectionFactoryInterface" alias="Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverConnectionFactory" />

--- a/tests/Command/SentryTestCommandTest.php
+++ b/tests/Command/SentryTestCommandTest.php
@@ -115,8 +115,11 @@ class SentryTestCommandTest extends BaseTestCase
 
     private function executeCommand(): CommandTester
     {
+        $command = new SentryTestCommand();
+        $command->setName('sentry:test');
+
         $application = new Application();
-        $application->add(new SentryTestCommand());
+        $application->add($command);
 
         $command = $application->find('sentry:test');
         $commandTester = new CommandTester($command);


### PR DESCRIPTION
This fixes a deprecation on Symfony 6.1:
```
Since symfony/console 6.1: Relying on the static property "$defaultName" for setting a command name is deprecated. Add the "Symfony\Component\Console\Attribute\AsCommand" attribute to the "Sentry\SentryBundle\Command\SentryTestCommand" class instead.
```
