### PR TITLE
Add `symfony/flex` to the list of Composer plugins allowed to run

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "sort-packages": true,
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
-            "phpstan/extension-installer": true
+            "phpstan/extension-installer": true,
+            "symfony/flex": true
         }
     },
     "require": {


### PR DESCRIPTION
As per title, when we added the `allow-plugins` option to `composer.json` we forgot the `symfony/flex` plugin, which is required to install the same version for all Symfony components in the CI. This PR fixes the issue