### PR TITLE
Support logging the impersonator user, if any

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 ## Unreleased
 
 - Add support for tracing of the Symfony HTTP client requests (#606)
+- Support logging the impersonator user, if any (#647)
 
 ## 4.3.0 (2022-05-30)
-- Fix compatibility issue with Symfony >= 6.1.0 (#635)
+
+- Fix compatibility issue with Symfony `>= 6.1.0` (#635)
 - Add `TracingDriverConnectionInterface::getNativeConnection()` method to get the original driver connection (#597)
 - Add `options.http_timeout` and `options.http_connect_timeout` configuration options (#593)
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -161,16 +161,6 @@ parameters:
 			path: src/EventListener/RequestListener.php
 
 		-
-			message: "#^Cannot call method getUser\\(\\) on Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\TokenInterface\\|null\\.$#"
-			count: 1
-			path: src/EventListener/RequestListener.php
-
-		-
-			message: "#^Parameter \\#1 \\$user of method Sentry\\\\SentryBundle\\\\EventListener\\\\RequestListener\\:\\:getUsername\\(\\) expects object\\|string, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null given\\.$#"
-			count: 1
-			path: src/EventListener/RequestListener.php
-
-		-
 			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpKernel\\\\Event\\\\KernelEvent\\:\\:isMasterRequest\\(\\)\\.$#"
 			count: 1
 			path: src/EventListener/SubRequestListener.php
@@ -312,6 +302,21 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$user of method Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\AbstractToken\\:\\:setUser\\(\\) expects Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface, string\\|Stringable\\|Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface given\\.$#"
+			count: 1
+			path: tests/EventListener/RequestListenerTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$roles of class Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\SwitchUserToken constructor expects array\\<string\\>, string given\\.$#"
+			count: 1
+			path: tests/EventListener/RequestListenerTest.php
+
+		-
+			message: "#^Parameter \\#4 \\$originalToken of class Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\SwitchUserToken constructor expects Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\TokenInterface, array\\<int, string\\> given\\.$#"
+			count: 1
+			path: tests/EventListener/RequestListenerTest.php
+
+		-
+			message: "#^Parameter \\#5 \\$originatedFromUri of class Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\SwitchUserToken constructor expects string\\|null, Sentry\\\\SentryBundle\\\\Tests\\\\EventListener\\\\AuthenticatedTokenStub given\\.$#"
 			count: 1
 			path: tests/EventListener/RequestListenerTest.php
 

--- a/tests/EventListener/Fixtures/UserWithIdentifierStub.php
+++ b/tests/EventListener/Fixtures/UserWithIdentifierStub.php
@@ -8,6 +8,16 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 final class UserWithIdentifierStub implements UserInterface
 {
+    /**
+     * @var string
+     */
+    private $username;
+
+    public function __construct(string $username = 'foo_user')
+    {
+        $this->username = $username;
+    }
+
     public function getUserIdentifier(): string
     {
         return $this->getUsername();
@@ -15,7 +25,7 @@ final class UserWithIdentifierStub implements UserInterface
 
     public function getUsername(): string
     {
-        return 'foo_user';
+        return $this->username;
     }
 
     public function getRoles(): array

--- a/tests/EventListener/RequestListenerTest.php
+++ b/tests/EventListener/RequestListenerTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -51,6 +52,9 @@ final class RequestListenerTest extends TestCase
 
     /**
      * @dataProvider handleKernelRequestEventDataProvider
+     * @dataProvider handleKernelRequestEventForSymfonyVersionLowerThan54DataProvider
+     * @dataProvider handleKernelRequestEventForSymfonyVersionGreaterThan54DataProvider
+     * @dataProvider handleKernelRequestEventForSymfonyVersionLowerThan60DataProvider
      */
     public function testHandleKernelRequestEvent(RequestEvent $requestEvent, ?ClientInterface $client, ?TokenInterface $token, ?UserDataBag $expectedUser): void
     {
@@ -138,46 +142,6 @@ final class RequestListenerTest extends TestCase
             UserDataBag::createFromUserIpAddress('127.0.0.1'),
         ];
 
-        if (version_compare(Kernel::VERSION, '6.0.0', '<')) {
-            yield 'token.authenticated = TRUE && token.user INSTANCEOF string' => [
-                new RequestEvent(
-                    $this->createMock(HttpKernelInterface::class),
-                    new Request([], [], [], [], [], ['REMOTE_ADDR' => '127.0.0.1']),
-                    HttpKernelInterface::MASTER_REQUEST
-                ),
-                $this->getMockedClientWithOptions(new Options(['send_default_pii' => true])),
-                new AuthenticatedTokenStub('foo_user'),
-                new UserDataBag(null, null, '127.0.0.1', 'foo_user'),
-            ];
-
-            yield 'token.authenticated = TRUE && token.user INSTANCEOF UserInterface && getUserIdentifier() method DOES NOT EXISTS' => [
-                new RequestEvent(
-                    $this->createMock(HttpKernelInterface::class),
-                    new Request([], [], [], [], [], ['REMOTE_ADDR' => '127.0.0.1']),
-                    HttpKernelInterface::MASTER_REQUEST
-                ),
-                $this->getMockedClientWithOptions(new Options(['send_default_pii' => true])),
-                new AuthenticatedTokenStub(new UserWithoutIdentifierStub()),
-                new UserDataBag(null, null, '127.0.0.1', 'foo_user'),
-            ];
-
-            yield 'token.authenticated = TRUE && token.user INSTANCEOF object && __toString() method EXISTS' => [
-                new RequestEvent(
-                    $this->createMock(HttpKernelInterface::class),
-                    new Request([], [], [], [], [], ['REMOTE_ADDR' => '127.0.0.1']),
-                    HttpKernelInterface::MASTER_REQUEST
-                ),
-                $this->getMockedClientWithOptions(new Options(['send_default_pii' => true])),
-                new AuthenticatedTokenStub(new class() implements \Stringable {
-                    public function __toString(): string
-                    {
-                        return 'foo_user';
-                    }
-                }),
-                new UserDataBag(null, null, '127.0.0.1', 'foo_user'),
-            ];
-        }
-
         yield 'token.authenticated = TRUE && token.user INSTANCEOF UserInterface && getUserIdentifier() method EXISTS' => [
             new RequestEvent(
                 $this->createMock(HttpKernelInterface::class),
@@ -198,6 +162,115 @@ final class RequestListenerTest extends TestCase
             $this->getMockedClientWithOptions(new Options(['send_default_pii' => true])),
             null,
             new UserDataBag(),
+        ];
+    }
+
+    /**
+     * @return \Generator<mixed>
+     */
+    public function handleKernelRequestEventForSymfonyVersionLowerThan54DataProvider(): \Generator
+    {
+        if (version_compare(Kernel::VERSION, '5.4.0', '>=')) {
+            return;
+        }
+
+        yield 'token.authenticated = TRUE && token INSTANCEOF SwitchUserToken' => [
+            new RequestEvent(
+                $this->createMock(HttpKernelInterface::class),
+                new Request([], [], [], [], [], ['REMOTE_ADDR' => '127.0.0.1']),
+                HttpKernelInterface::MASTER_REQUEST
+            ),
+            $this->getMockedClientWithOptions(new Options(['send_default_pii' => true])),
+            new SwitchUserToken(
+                new UserWithIdentifierStub(),
+                '',
+                'user_provider',
+                ['ROLE_USER'],
+                new AuthenticatedTokenStub(new UserWithIdentifierStub('foo_user_impersonator'))
+            ),
+            UserDataBag::createFromArray([
+                'ip_address' => '127.0.0.1',
+                'username' => 'foo_user',
+                'impersonator_username' => 'foo_user_impersonator',
+            ]),
+        ];
+    }
+
+    /**
+     * @return \Generator<mixed>
+     */
+    public function handleKernelRequestEventForSymfonyVersionGreaterThan54DataProvider(): \Generator
+    {
+        if (version_compare(Kernel::VERSION, '5.4.0', '<')) {
+            return;
+        }
+
+        yield 'token.authenticated = TRUE && token INSTANCEOF SwitchUserToken' => [
+            new RequestEvent(
+                $this->createMock(HttpKernelInterface::class),
+                new Request([], [], [], [], [], ['REMOTE_ADDR' => '127.0.0.1']),
+                HttpKernelInterface::MASTER_REQUEST
+            ),
+            $this->getMockedClientWithOptions(new Options(['send_default_pii' => true])),
+            new SwitchUserToken(
+                new UserWithIdentifierStub(),
+                'main',
+                ['ROLE_USER'],
+                new AuthenticatedTokenStub(new UserWithIdentifierStub('foo_user_impersonator'))
+            ),
+            UserDataBag::createFromArray([
+                'ip_address' => '127.0.0.1',
+                'username' => 'foo_user',
+                'impersonator_username' => 'foo_user_impersonator',
+            ]),
+        ];
+    }
+
+    /**
+     * @return \Generator<mixed>
+     */
+    public function handleKernelRequestEventForSymfonyVersionLowerThan60DataProvider(): \Generator
+    {
+        if (version_compare(Kernel::VERSION, '6.0.0', '>=')) {
+            return;
+        }
+
+        yield 'token.authenticated = TRUE && token.user INSTANCEOF string' => [
+            new RequestEvent(
+                $this->createMock(HttpKernelInterface::class),
+                new Request([], [], [], [], [], ['REMOTE_ADDR' => '127.0.0.1']),
+                HttpKernelInterface::MASTER_REQUEST
+            ),
+            $this->getMockedClientWithOptions(new Options(['send_default_pii' => true])),
+            new AuthenticatedTokenStub('foo_user'),
+            new UserDataBag(null, null, '127.0.0.1', 'foo_user'),
+        ];
+
+        yield 'token.authenticated = TRUE && token.user INSTANCEOF UserInterface && getUserIdentifier() method DOES NOT EXISTS' => [
+            new RequestEvent(
+                $this->createMock(HttpKernelInterface::class),
+                new Request([], [], [], [], [], ['REMOTE_ADDR' => '127.0.0.1']),
+                HttpKernelInterface::MASTER_REQUEST
+            ),
+            $this->getMockedClientWithOptions(new Options(['send_default_pii' => true])),
+            new AuthenticatedTokenStub(new UserWithoutIdentifierStub()),
+            new UserDataBag(null, null, '127.0.0.1', 'foo_user'),
+        ];
+
+        yield 'token.authenticated = TRUE && token.user INSTANCEOF object && __toString() method EXISTS' => [
+            new RequestEvent(
+                $this->createMock(HttpKernelInterface::class),
+                new Request([], [], [], [], [], ['REMOTE_ADDR' => '127.0.0.1']),
+                HttpKernelInterface::MASTER_REQUEST
+            ),
+            $this->getMockedClientWithOptions(new Options(['send_default_pii' => true])),
+            new AuthenticatedTokenStub(new class() implements \Stringable {
+                public function __toString(): string
+                {
+                    return 'foo_user';
+                }
+            }),
+            new UserDataBag(null, null, '127.0.0.1', 'foo_user'),
         ];
     }
 


### PR DESCRIPTION
Fixes #642 by logging the impersonator user as part of the metadata of the [User Interface](https://develop.sentry.dev/sdk/event-payloads/user/). @hunhejj given that you asked for this feature, would you mind trying this out and see if it works?