### PR TITLE
test: Add dsn to e2e test config

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,6 +10,8 @@ parameters:
         - src/aliases.php
     excludePaths:
         - src/aliases.php
+        - src/Tracing/Cache/TraceableCacheAdapterForV2.php
+        - src/Tracing/Cache/TraceableTagAwareCacheAdapterForV2.php
         - src/Tracing/Doctrine/DBAL/TracingStatementForV2.php
         - src/Tracing/Doctrine/DBAL/TracingDriverForV2.php
         - tests/End2End/App

--- a/tests/End2End/App/config.yml
+++ b/tests/End2End/App/config.yml
@@ -1,4 +1,5 @@
 sentry:
+  dsn: http://public@example.com/sentry/1
   tracing:
     enabled: true
   options:


### PR DESCRIPTION
Since v3.8.0 https://github.com/getsentry/sentry-php, the SDK NoOps without a DSN set. This fixes the E2E tests.