### PR TITLE
feat: Add support for Dynamic Sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## Unreleased
 
+## 4.4.0 (2022-10-20)
+
 - feat: Add support for Dynamic Sampling (#665)
 
 ## 4.3.1 (2022-10-10)
 
-fix: Update span ops (#655)
+- fix: Update span ops (#655)
 
 ## 4.3.0 (2022-05-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- feat: Add support for Dynamic Sampling
+
 ## 4.3.1 (2022-10-10)
 
 fix: Update span ops (#655)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- feat: Add support for Dynamic Sampling
+- feat: Add support for Dynamic Sampling (#665)
 
 ## 4.3.1 (2022-10-10)
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "php": "^7.2||^8.0",
         "jean85/pretty-package-versions": "^1.5 || ^2.0",
         "php-http/discovery": "^1.11",
-        "sentry/sdk": "^3.2",
+        "sentry/sdk": "^3.3",
         "symfony/cache-contracts": "^1.1||^2.4||^3.0",
         "symfony/config": "^3.4.44||^4.4.20||^5.0.11||^6.0",
         "symfony/console": "^3.4.44||^4.4.20||^5.0.11||^6.0",

--- a/composer.json
+++ b/composer.json
@@ -97,7 +97,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "4.3.x-dev",
+            "dev-master": "4.4.x-dev",
             "releases/3.2.x": "3.2.x-dev",
             "releases/2.x": "2.x-dev",
             "releases/1.x": "1.x-dev"

--- a/src/EventListener/TracingConsoleListener.php
+++ b/src/EventListener/TracingConsoleListener.php
@@ -9,6 +9,7 @@ use Sentry\Tracing\Span;
 use Sentry\Tracing\SpanContext;
 use Sentry\Tracing\Transaction;
 use Sentry\Tracing\TransactionContext;
+use Sentry\Tracing\TransactionSource;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
@@ -61,6 +62,7 @@ final class TracingConsoleListener
             $transactionContext = new TransactionContext();
             $transactionContext->setOp('console.command');
             $transactionContext->setName($this->getSpanName($command));
+            $transactionContext->setSource(TransactionSource::task());
 
             $span = $this->hub->startTransaction($transactionContext);
         } else {

--- a/src/EventListener/TracingRequestListener.php
+++ b/src/EventListener/TracingRequestListener.php
@@ -6,6 +6,7 @@ namespace Sentry\SentryBundle\EventListener;
 
 use Sentry\Tracing\Transaction;
 use Sentry\Tracing\TransactionContext;
+use Sentry\Tracing\TransactionSource;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -34,9 +35,13 @@ final class TracingRequestListener extends AbstractTracingRequestListener
         /** @var float $requestStartTime */
         $requestStartTime = $request->server->get('REQUEST_TIME_FLOAT', microtime(true));
 
-        $context = TransactionContext::fromSentryTrace($request->headers->get('sentry-trace', ''));
+        $context = TransactionContext::fromHeaders(
+            $request->headers->get('sentry-trace', ''),
+            $request->headers->get('baggage', '')
+        );
         $context->setOp('http.server');
         $context->setName(sprintf('%s %s%s%s', $request->getMethod(), $request->getSchemeAndHttpHost(), $request->getBaseUrl(), $request->getPathInfo()));
+        $context->setSource(TransactionSource::url());
         $context->setStartTimestamp($requestStartTime);
         $context->setTags($this->getTags($request));
 

--- a/src/Twig/SentryExtension.php
+++ b/src/Twig/SentryExtension.php
@@ -30,6 +30,7 @@ final class SentryExtension extends AbstractExtension
     {
         return [
             new TwigFunction('sentry_trace_meta', [$this, 'getTraceMeta'], ['is_safe' => ['html']]),
+            new TwigFunction('sentry_baggage_meta', [$this, 'getBaggageMeta'], ['is_safe' => ['html']]),
         ];
     }
 
@@ -41,5 +42,15 @@ final class SentryExtension extends AbstractExtension
         $span = $this->hub->getSpan();
 
         return sprintf('<meta name="sentry-trace" content="%s" />', null !== $span ? $span->toTraceparent() : '');
+    }
+
+    /**
+     * Returns an HTML meta tag named `baggage`.
+     */
+    public function getBaggageMeta(): string
+    {
+        $span = $this->hub->getSpan();
+
+        return sprintf('<meta name="baggage" content="%s" />', null !== $span ? $span->toBaggage() : '');
     }
 }

--- a/tests/EventListener/TracingConsoleListenerTest.php
+++ b/tests/EventListener/TracingConsoleListenerTest.php
@@ -12,6 +12,7 @@ use Sentry\State\HubInterface;
 use Sentry\Tracing\Span;
 use Sentry\Tracing\Transaction;
 use Sentry\Tracing\TransactionContext;
+use Sentry\Tracing\TransactionSource;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
@@ -71,6 +72,7 @@ final class TracingConsoleListenerTest extends TestCase
         $transactionContext = new TransactionContext();
         $transactionContext->setOp('console.command');
         $transactionContext->setName('<unnamed command>');
+        $transactionContext->setSource(TransactionSource::task());
 
         yield [
             new Command(),
@@ -80,6 +82,7 @@ final class TracingConsoleListenerTest extends TestCase
         $transactionContext = new TransactionContext();
         $transactionContext->setOp('console.command');
         $transactionContext->setName('app:command');
+        $transactionContext->setSource(TransactionSource::task());
 
         yield [
             new Command('app:command'),

--- a/tests/EventListener/TracingRequestListenerTest.php
+++ b/tests/EventListener/TracingRequestListenerTest.php
@@ -13,11 +13,13 @@ use Sentry\SentryBundle\EventListener\RequestListenerResponseEvent;
 use Sentry\SentryBundle\EventListener\RequestListenerTerminateEvent;
 use Sentry\SentryBundle\EventListener\TracingRequestListener;
 use Sentry\State\HubInterface;
+use Sentry\Tracing\DynamicSamplingContext;
 use Sentry\Tracing\SpanId;
 use Sentry\Tracing\SpanStatus;
 use Sentry\Tracing\TraceId;
 use Sentry\Tracing\Transaction;
 use Sentry\Tracing\TransactionContext;
+use Sentry\Tracing\TransactionSource;
 use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -85,11 +87,15 @@ final class TracingRequestListenerTest extends TestCase
      */
     public function handleKernelRequestEventDataProvider(): \Generator
     {
+        $samplingContext = DynamicSamplingContext::fromHeader('');
+        $samplingContext->freeze();
+
         $transactionContext = new TransactionContext();
         $transactionContext->setTraceId(new TraceId('566e3688a61d4bc888951642d6f14a19'));
         $transactionContext->setParentSpanId(new SpanId('566e3688a61d4bc8'));
         $transactionContext->setParentSampled(true);
         $transactionContext->setName('GET http://www.example.com/');
+        $transactionContext->setSource(TransactionSource::url());
         $transactionContext->setOp('http.server');
         $transactionContext->setStartTimestamp(1613493597.010275);
         $transactionContext->setTags([
@@ -100,6 +106,7 @@ final class TracingRequestListenerTest extends TestCase
             'route' => '<unknown>',
             'net.host.name' => 'www.example.com',
         ]);
+        $transactionContext->getMetadata()->setDynamicSamplingContext($samplingContext);
 
         yield 'request.headers.sentry-trace EXISTS' => [
             new Options(),
@@ -117,8 +124,47 @@ final class TracingRequestListenerTest extends TestCase
             $transactionContext,
         ];
 
+        $samplingContext = DynamicSamplingContext::fromHeader('sentry-trace_id=566e3688a61d4bc888951642d6f14a19,sentry-public_key=public,sentry-sample_rate=1');
+        $samplingContext->freeze();
+
+        $transactionContext = new TransactionContext();
+        $transactionContext->setTraceId(new TraceId('566e3688a61d4bc888951642d6f14a19'));
+        $transactionContext->setParentSpanId(new SpanId('566e3688a61d4bc8'));
+        $transactionContext->setParentSampled(true);
+        $transactionContext->setName('GET http://www.example.com/');
+        $transactionContext->setSource(TransactionSource::url());
+        $transactionContext->setOp('http.server');
+        $transactionContext->setStartTimestamp(1613493597.010275);
+        $transactionContext->setTags([
+            'net.host.port' => '80',
+            'http.method' => 'GET',
+            'http.url' => 'http://www.example.com/',
+            'http.flavor' => '1.1',
+            'route' => '<unknown>',
+            'net.host.name' => 'www.example.com',
+        ]);
+        $transactionContext->getMetadata()->setDynamicSamplingContext($samplingContext);
+
+        yield 'request.headers.sentry-trace and headers.baggage EXISTS' => [
+            new Options(),
+            Request::create(
+                'http://www.example.com',
+                'GET',
+                [],
+                [],
+                [],
+                [
+                    'REQUEST_TIME_FLOAT' => 1613493597.010275,
+                    'HTTP_sentry-trace' => '566e3688a61d4bc888951642d6f14a19-566e3688a61d4bc8-1',
+                    'HTTP_baggage' => 'sentry-trace_id=566e3688a61d4bc888951642d6f14a19,sentry-public_key=public,sentry-sample_rate=1',
+                ]
+            ),
+            $transactionContext,
+        ];
+
         $transactionContext = new TransactionContext();
         $transactionContext->setName('GET http://www.example.com/');
+        $transactionContext->setSource(TransactionSource::url());
         $transactionContext->setOp('http.server');
         $transactionContext->setStartTimestamp(1613493597.010275);
         $transactionContext->setTags([
@@ -141,6 +187,7 @@ final class TracingRequestListenerTest extends TestCase
 
         $transactionContext = new TransactionContext();
         $transactionContext->setName('GET http://127.0.0.1/');
+        $transactionContext->setSource(TransactionSource::url());
         $transactionContext->setOp('http.server');
         $transactionContext->setStartTimestamp(1613493597.010275);
         $transactionContext->setTags([
@@ -171,6 +218,7 @@ final class TracingRequestListenerTest extends TestCase
 
         $transactionContext = new TransactionContext();
         $transactionContext->setName('GET http://www.example.com/path');
+        $transactionContext->setSource(TransactionSource::url());
         $transactionContext->setOp('http.server');
         $transactionContext->setStartTimestamp(1613493597.010275);
         $transactionContext->setTags([
@@ -194,6 +242,7 @@ final class TracingRequestListenerTest extends TestCase
 
         $transactionContext = new TransactionContext();
         $transactionContext->setName('GET http://www.example.com/path');
+        $transactionContext->setSource(TransactionSource::url());
         $transactionContext->setOp('http.server');
         $transactionContext->setStartTimestamp(1613493597.010275);
         $transactionContext->setTags([
@@ -217,6 +266,7 @@ final class TracingRequestListenerTest extends TestCase
 
         $transactionContext = new TransactionContext();
         $transactionContext->setName('GET http://www.example.com/');
+        $transactionContext->setSource(TransactionSource::url());
         $transactionContext->setOp('http.server');
         $transactionContext->setStartTimestamp(1613493597.010275);
         $transactionContext->setTags([
@@ -240,6 +290,7 @@ final class TracingRequestListenerTest extends TestCase
 
         $transactionContext = new TransactionContext();
         $transactionContext->setName('GET http://www.example.com/');
+        $transactionContext->setSource(TransactionSource::url());
         $transactionContext->setOp('http.server');
         $transactionContext->setStartTimestamp(1613493597.010275);
         $transactionContext->setTags([
@@ -263,6 +314,7 @@ final class TracingRequestListenerTest extends TestCase
 
         $transactionContext = new TransactionContext();
         $transactionContext->setName('GET http://www.example.com/');
+        $transactionContext->setSource(TransactionSource::url());
         $transactionContext->setOp('http.server');
         $transactionContext->setStartTimestamp(1613493597.010275);
         $transactionContext->setTags([
@@ -286,6 +338,7 @@ final class TracingRequestListenerTest extends TestCase
 
         $transactionContext = new TransactionContext();
         $transactionContext->setName('GET http://www.example.com/');
+        $transactionContext->setSource(TransactionSource::url());
         $transactionContext->setOp('http.server');
         $transactionContext->setStartTimestamp(1613493597.010275);
         $transactionContext->setTags([
@@ -309,6 +362,7 @@ final class TracingRequestListenerTest extends TestCase
 
         $transactionContext = new TransactionContext();
         $transactionContext->setName('GET http://www.example.com/');
+        $transactionContext->setSource(TransactionSource::url());
         $transactionContext->setOp('http.server');
         $transactionContext->setStartTimestamp(1613493597.010275);
         $transactionContext->setTags([
@@ -332,6 +386,7 @@ final class TracingRequestListenerTest extends TestCase
 
         $transactionContext = new TransactionContext();
         $transactionContext->setName('GET http://:/');
+        $transactionContext->setSource(TransactionSource::url());
         $transactionContext->setOp('http.server');
         $transactionContext->setStartTimestamp(1613493597.010275);
         $transactionContext->setTags([


### PR DESCRIPTION
To get Dynamic Sampling out sooner, we decided to release this as a new 4.4, not containing the changes currently in `develop` and/or `5.x`.

I'm also ok with recreating `develop` from `master` and targeting this branch instead.
Changes won't be lost, as they are in `5.x`.

These are the same changes as in https://github.com/getsentry/sentry-symfony/pull/661

