### PR TITLE
style: Update CS

### DIFF
--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Sentry\SentryBundle\DependencyInjection;
 
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
-use LogicException;
 use Psr\Log\NullLogger;
 use Sentry\Client;
 use Sentry\ClientBuilder;
@@ -204,7 +203,7 @@ final class SentryExtension extends ConfigurableExtension
             && $this->isConfigEnabled($container, $config['dbal']);
 
         if ($isConfigEnabled && !class_exists(DoctrineBundle::class)) {
-            throw new LogicException('DBAL tracing support cannot be enabled because the doctrine/doctrine-bundle Composer package is not installed.');
+            throw new \LogicException('DBAL tracing support cannot be enabled because the doctrine/doctrine-bundle Composer package is not installed.');
         }
 
         $container->setParameter('sentry.tracing.dbal.enabled', $isConfigEnabled);
@@ -225,7 +224,7 @@ final class SentryExtension extends ConfigurableExtension
             && $this->isConfigEnabled($container, $config['twig']);
 
         if ($isConfigEnabled && !class_exists(TwigBundle::class)) {
-            throw new LogicException('Twig tracing support cannot be enabled because the symfony/twig-bundle Composer package is not installed.');
+            throw new \LogicException('Twig tracing support cannot be enabled because the symfony/twig-bundle Composer package is not installed.');
         }
 
         if (!$isConfigEnabled) {
@@ -242,7 +241,7 @@ final class SentryExtension extends ConfigurableExtension
             && $this->isConfigEnabled($container, $config['cache']);
 
         if ($isConfigEnabled && !class_exists(CacheItem::class)) {
-            throw new LogicException('Cache tracing support cannot be enabled because the symfony/cache Composer package is not installed.');
+            throw new \LogicException('Cache tracing support cannot be enabled because the symfony/cache Composer package is not installed.');
         }
 
         $container->setParameter('sentry.tracing.cache.enabled', $isConfigEnabled);
@@ -257,7 +256,7 @@ final class SentryExtension extends ConfigurableExtension
             && $this->isConfigEnabled($container, $config['http_client']);
 
         if ($isConfigEnabled && !class_exists(HttpClient::class)) {
-            throw new LogicException('Http client tracing support cannot be enabled because the symfony/http-client Composer package is not installed.');
+            throw new \LogicException('Http client tracing support cannot be enabled because the symfony/http-client Composer package is not installed.');
         }
 
         $container->setParameter('sentry.tracing.http_client.enabled', $isConfigEnabled);

--- a/src/Tracing/Twig/TwigTracingExtension.php
+++ b/src/Tracing/Twig/TwigTracingExtension.php
@@ -7,7 +7,6 @@ namespace Sentry\SentryBundle\Tracing\Twig;
 use Sentry\State\HubInterface;
 use Sentry\Tracing\Span;
 use Sentry\Tracing\SpanContext;
-use SplObjectStorage;
 use Twig\Extension\AbstractExtension;
 use Twig\Profiler\NodeVisitor\ProfilerNodeVisitor;
 use Twig\Profiler\Profile;
@@ -20,7 +19,7 @@ final class TwigTracingExtension extends AbstractExtension
     private $hub;
 
     /**
-     * @var SplObjectStorage<object, Span> The currently active spans
+     * @var \SplObjectStorage<object, Span> The currently active spans
      */
     private $spans;
 
@@ -30,7 +29,7 @@ final class TwigTracingExtension extends AbstractExtension
     public function __construct(HubInterface $hub)
     {
         $this->hub = $hub;
-        $this->spans = new SplObjectStorage();
+        $this->spans = new \SplObjectStorage();
     }
 
     /**

--- a/tests/EventListener/TracingConsoleListenerTest.php
+++ b/tests/EventListener/TracingConsoleListenerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Sentry\SentryBundle\Tests\EventListener;
 
-use Generator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sentry\SentryBundle\EventListener\TracingConsoleListener;
@@ -65,9 +64,9 @@ final class TracingConsoleListenerTest extends TestCase
     }
 
     /**
-     * @return Generator<mixed>
+     * @return \Generator<mixed>
      */
-    public function handleConsoleCommandEventStartsTransactionIfNoSpanIsSetOnHubDataProvider(): Generator
+    public function handleConsoleCommandEventStartsTransactionIfNoSpanIsSetOnHubDataProvider(): \Generator
     {
         $transactionContext = new TransactionContext();
         $transactionContext->setOp('console.command');
@@ -121,9 +120,9 @@ final class TracingConsoleListenerTest extends TestCase
     }
 
     /**
-     * @return Generator<mixed>
+     * @return \Generator<mixed>
      */
-    public function handleConsoleCommandEventStartsChildSpanIfSpanIsSetOnHubDataProvider(): Generator
+    public function handleConsoleCommandEventStartsChildSpanIfSpanIsSetOnHubDataProvider(): \Generator
     {
         yield [
             new Command(),


### PR DESCRIPTION
As of https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.13.0, global namespace imports are no longer a thing.