### PR TITLE
ref: Add proper HTTP client span descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## Unreleased
 
-- feat: Add support for tracing of the Symfony HTTP client requests (#606)
+- feat: Add support for tracing of Symfony HTTP client requests (#606)
+    - feat: Add support for HTTP client baggage propagation (#663)
+    - ref: Add proper HTTP client span descriptions (#680)
 - feat: Support logging the impersonator user, if any (#647)
 - ref: Use constant for the SDK version (#662)
-- Add support for HTTP client baggage propagation (#663)
 
 ## 4.4.0 (2022-10-20)
 

--- a/src/Tracing/HttpClient/AbstractTraceableHttpClient.php
+++ b/src/Tracing/HttpClient/AbstractTraceableHttpClient.php
@@ -115,6 +115,6 @@ abstract class AbstractTraceableHttpClient implements HttpClientInterface, Reset
     private function formatUri(Uri $uri): string
     {
         // Instead of relying on Uri::__toString, we only use a sub set of the URI
-        return Uri::composeComponents($uri->getScheme(), $uri->getAuthority(), $uri->getPath(), null, null);
+        return Uri::composeComponents($uri->getScheme(), $uri->getHost(), $uri->getPath(), null, null);
     }
 }

--- a/tests/Tracing/HttpClient/TraceableHttpClientTest.php
+++ b/tests/Tracing/HttpClient/TraceableHttpClientTest.php
@@ -63,12 +63,12 @@ final class TraceableHttpClientTest extends TestCase
         $mockResponse = new MockResponse();
         $decoratedHttpClient = new MockHttpClient($mockResponse);
         $httpClient = new TraceableHttpClient($decoratedHttpClient, $this->hub);
-        $response = $httpClient->request('GET', 'https://www.example.com/test-page?foo=bar#baz');
+        $response = $httpClient->request('GET', 'https://username:password@www.example.com/test-page?foo=bar#baz');
 
         $this->assertInstanceOf(AbstractTraceableResponse::class, $response);
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('GET', $response->getInfo('http_method'));
-        $this->assertSame('https://www.example.com/test-page?foo=bar#baz', $response->getInfo('url'));
+        $this->assertSame('https://username:password@www.example.com/test-page?foo=bar#baz', $response->getInfo('url'));
         $this->assertSame(['sentry-trace: ' . $transaction->toTraceparent()], $mockResponse->getRequestOptions()['normalized_headers']['sentry-trace']);
         $this->assertArrayNotHasKey('baggage', $mockResponse->getRequestOptions()['normalized_headers']);
         $this->assertNotNull($transaction->getSpanRecorder());

--- a/tests/Tracing/HttpClient/TraceableHttpClientTest.php
+++ b/tests/Tracing/HttpClient/TraceableHttpClientTest.php
@@ -63,12 +63,12 @@ final class TraceableHttpClientTest extends TestCase
         $mockResponse = new MockResponse();
         $decoratedHttpClient = new MockHttpClient($mockResponse);
         $httpClient = new TraceableHttpClient($decoratedHttpClient, $this->hub);
-        $response = $httpClient->request('GET', 'https://www.example.com/test-page');
+        $response = $httpClient->request('GET', 'https://www.example.com/test-page?foo=bar#baz');
 
         $this->assertInstanceOf(AbstractTraceableResponse::class, $response);
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('GET', $response->getInfo('http_method'));
-        $this->assertSame('https://www.example.com/test-page', $response->getInfo('url'));
+        $this->assertSame('https://www.example.com/test-page?foo=bar#baz', $response->getInfo('url'));
         $this->assertSame(['sentry-trace: ' . $transaction->toTraceparent()], $mockResponse->getRequestOptions()['normalized_headers']['sentry-trace']);
         $this->assertArrayNotHasKey('baggage', $mockResponse->getRequestOptions()['normalized_headers']);
         $this->assertNotNull($transaction->getSpanRecorder());
@@ -82,7 +82,7 @@ final class TraceableHttpClientTest extends TestCase
         $this->assertCount(2, $spans);
         $this->assertNull($spans[1]->getEndTimestamp());
         $this->assertSame('http.client', $spans[1]->getOp());
-        $this->assertSame('HTTP GET', $spans[1]->getDescription());
+        $this->assertSame('GET https://www.example.com/test-page', $spans[1]->getDescription());
         $this->assertSame($expectedTags, $spans[1]->getTags());
     }
 
@@ -130,7 +130,7 @@ final class TraceableHttpClientTest extends TestCase
         $this->assertCount(2, $spans);
         $this->assertNull($spans[1]->getEndTimestamp());
         $this->assertSame('http.client', $spans[1]->getOp());
-        $this->assertSame('HTTP PUT', $spans[1]->getDescription());
+        $this->assertSame('PUT https://www.example.com/test-page', $spans[1]->getDescription());
         $this->assertSame($expectedTags, $spans[1]->getTags());
     }
 
@@ -178,7 +178,7 @@ final class TraceableHttpClientTest extends TestCase
         $this->assertCount(2, $spans);
         $this->assertNull($spans[1]->getEndTimestamp());
         $this->assertSame('http.client', $spans[1]->getOp());
-        $this->assertSame('HTTP POST', $spans[1]->getDescription());
+        $this->assertSame('POST https://www.example.com/test-page', $spans[1]->getDescription());
         $this->assertSame($expectedTags, $spans[1]->getTags());
     }
 
@@ -214,7 +214,7 @@ final class TraceableHttpClientTest extends TestCase
         $this->assertCount(2, $spans);
         $this->assertNotNull($spans[1]->getEndTimestamp());
         $this->assertSame('http.client', $spans[1]->getOp());
-        $this->assertSame('HTTP GET', $spans[1]->getDescription());
+        $this->assertSame('GET https://www.example.com/test-page', $spans[1]->getDescription());
         $this->assertSame($expectedTags, $spans[1]->getTags());
 
         $loopIndex = 0;


### PR DESCRIPTION
To make HTTP client tracing more useful, instead of setting `HTTP GET`, we now set `scheme://authority/path` as the span description.

The query and fragments parts are committed on purpose, see [RFC 42](https://github.com/getsentry/rfcs/blob/main/text/0042-gocd-succeeds-freight-as-our-cd-solution.md)