### PR TITLE
feat: Add before_send_transaction

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,6 +21,11 @@ parameters:
 			path: src/DependencyInjection/SentryExtension.php
 
 		-
+			message: "#^Cannot access offset 'before_send…' on mixed\\.$#"
+			count: 3
+			path: src/DependencyInjection/SentryExtension.php
+
+		-
 			message: "#^Cannot access offset 'class_serializers' on mixed\\.$#"
 			count: 3
 			path: src/DependencyInjection/SentryExtension.php
@@ -77,7 +82,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$id of class Symfony\\\\Component\\\\DependencyInjection\\\\Reference constructor expects string, mixed given\\.$#"
-			count: 5
+			count: 6
 			path: src/DependencyInjection/SentryExtension.php
 
 		-

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -92,6 +92,7 @@ final class Configuration implements ConfigurationInterface
                         ->end()
                         ->scalarNode('server_name')->end()
                         ->scalarNode('before_send')->end()
+                        ->scalarNode('before_send_transaction')->end()
                         ->arrayNode('tags')
                             ->useAttributeAsKey('name')
                             ->normalizeKeys(false)

--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -102,6 +102,10 @@ final class SentryExtension extends ConfigurableExtension
             $options['before_send'] = new Reference($options['before_send']);
         }
 
+        if (isset($options['before_send_transaction'])) {
+            $options['before_send_transaction'] = new Reference($options['before_send_transaction']);
+        }
+
         if (isset($options['before_breadcrumb'])) {
             $options['before_breadcrumb'] = new Reference($options['before_breadcrumb']);
         }

--- a/src/Resources/config/schema/sentry-1.0.xsd
+++ b/src/Resources/config/schema/sentry-1.0.xsd
@@ -45,6 +45,7 @@
         <xsd:attribute name="release" type="xsd:string" />
         <xsd:attribute name="server-name" type="xsd:string" />
         <xsd:attribute name="before-send" type="xsd:string" />
+        <xsd:attribute name="before-send-transaction" type="xsd:string" />
         <xsd:attribute name="error-types" type="xsd:string" />
         <xsd:attribute name="max-breadcrumbs" type="xsd:integer" />
         <xsd:attribute name="before-breadcrumb" type="xsd:string" />

--- a/tests/DependencyInjection/Fixtures/php/full.php
+++ b/tests/DependencyInjection/Fixtures/php/full.php
@@ -26,6 +26,7 @@ $container->loadFromExtension('sentry', [
         'release' => '4.0.x-dev',
         'server_name' => 'localhost',
         'before_send' => 'App\\Sentry\\BeforeSendCallback',
+        'before_send_transaction' => 'App\\Sentry\\BeforeSendTransactionCallback',
         'tags' => [
             'context' => 'development',
         ],

--- a/tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/tests/DependencyInjection/Fixtures/xml/full.xml
@@ -24,6 +24,7 @@
                         release="4.0.x-dev"
                         server-name="localhost"
                         before-send="App\Sentry\BeforeSendCallback"
+                        before-send-transaction="App\Sentry\BeforeSendTransactionCallback"
                         error-types="E_ALL"
                         max-breadcrumbs="1"
                         before-breadcrumb="App\Sentry\BeforeBreadcrumbCallback"

--- a/tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/tests/DependencyInjection/Fixtures/yml/full.yml
@@ -22,6 +22,7 @@ sentry:
         release: 4.0.x-dev
         server_name: localhost
         before_send: App\Sentry\BeforeSendCallback
+        before_send_transaction: App\Sentry\BeforeSendTransactionCallback
         tags:
             context: development
         error_types: !php/const E_ALL

--- a/tests/DependencyInjection/SentryExtensionTest.php
+++ b/tests/DependencyInjection/SentryExtensionTest.php
@@ -214,6 +214,7 @@ abstract class SentryExtensionTest extends TestCase
             'release' => '4.0.x-dev',
             'server_name' => 'localhost',
             'before_send' => new Reference('App\\Sentry\\BeforeSendCallback'),
+            'before_send_transaction' => new Reference('App\\Sentry\\BeforeSendTransactionCallback'),
             'tags' => ['context' => 'development'],
             'error_types' => \E_ALL,
             'max_breadcrumbs' => 1,


### PR DESCRIPTION
Expose the new `before_send_transaction` option, introduced in https://github.com/getsentry/sentry-php/issues/1423