### PR TITLE
Replace sentry/sdk by sentry/sentry 3.14

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
     "require": {
         "php": "^7.2||^8.0",
         "jean85/pretty-package-versions": "^1.5 || ^2.0",
-        "php-http/discovery": "^1.11",
-        "sentry/sdk": "^3.3",
+        "php-http/discovery": "^1.15",
+        "sentry/sentry": "^3.14",
         "symfony/cache-contracts": "^1.1||^2.4||^3.0",
         "symfony/config": "^4.4.20||^5.0.11||^6.0",
         "symfony/console": "^4.4.20||^5.0.11||^6.0",


### PR DESCRIPTION
Needs https://github.com/getsentry/sentry-php/pull/1459 and sentry/sentry 3.14.0 to be tagged.

Related to https://github.com/getsentry/sentry-php-sdk/pull/16