### PR TITLE
Remove php-http/discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
     "require": {
         "php": "^7.2||^8.0",
         "jean85/pretty-package-versions": "^1.5 || ^2.0",
-        "php-http/discovery": "^1.11",
         "sentry/sdk": "^3.3",
         "symfony/cache-contracts": "^1.1||^2.4||^3.0",
         "symfony/config": "^4.4.20||^5.0.11||^6.0",


### PR DESCRIPTION
`php-http/discovery` is already required by the base SDK.