### PR TITLE
Add direct dependency for `guzzlehttp/psr7`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,13 @@
         "sort-packages": true,
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
-            "phpstan/extension-installer": true
+            "phpstan/extension-installer": true,
+            "php-http/discovery": false
         }
     },
     "require": {
         "php": "^7.2||^8.0",
+        "guzzlehttp/psr7": "^1.7 || ^2.0",
         "jean85/pretty-package-versions": "^1.5 || ^2.0",
         "sentry/sdk": "^3.3",
         "sentry/sentry": "^3.15",


### PR DESCRIPTION
Since `sentry/sentry` no longer depends on `guzzlehttp/psr7` (getsentry/sentry-php#1504) and `sentry/sdk` also could not be not installed (doesn't directly depends on `guzzlehttp/psr7` either) we should be good citizens and directly depend on a dependency we [depend on](https://github.com/getsentry/sentry-symfony/blob/bcdbd3d13376473a514c0ec97566b0c7cdc5a1fc/src/Tracing/HttpClient/AbstractTraceableHttpClient.php) 😄 

Fixes #707.