### PR TITLE
fix(tests): Pin symfony/http-client to ﻿<5.4.22 || <6.2.8

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -119,7 +119,7 @@ jobs:
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Remove optional packages
-        run: composer remove doctrine/dbal doctrine/doctrine-bundle symfony/messenger symfony/twig-bundle symfony/cache symfony/http-client --dev --no-update
+        run: composer remove doctrine/dbal doctrine/doctrine-bundle symfony/messenger symfony/twig-bundle symfony/cache --dev --no-update
 
       - name: Install dependencies
         uses: ramsey/composer-install@v1

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "symfony/cache": "^4.4.20||^5.0.11||^6.0",
         "symfony/dom-crawler": "^4.4.20||^5.0.11||^6.0",
         "symfony/framework-bundle": "^4.4.20||^5.0.11||^6.0",
-        "symfony/http-client": "^4.4.20||^5.0.11||^6.0",
+        "symfony/http-client": "^4.4.20||^5.0.11 <5.4.22||^6.0 <6.2.8",
         "symfony/messenger": "^4.4.20||^5.0.11||^6.0",
         "symfony/monolog-bundle": "^3.4",
         "symfony/phpunit-bridge": "^5.2.6||^6.0",


### PR DESCRIPTION
Changes in `symfony/http-client v5.4.22||v6.2.8` seem to introduce some regression in our tests.
Pinning to `﻿<5.4.22 || <6.2.8` for the time being to get CI green again.

Opened https://github.com/symfony/symfony/issues/49925 upstream.