### PR TITLE
Introduce TracingDriverForV32 for DBAL `>= 3.2`

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,6 +30,8 @@ jobs:
           - 6.*
         dependencies:
           - highest
+        doctrine-dbal:
+          - highest
         exclude:
           - php: '7.2'
             symfony-version: 6.*
@@ -41,12 +43,18 @@ jobs:
           - php: '7.2'
             symfony-version: 4.4.*
             dependencies: lowest
+            doctrine-dbal: '^2.13'
           - php: '7.2'
             symfony-version: 5.*
             dependencies: lowest
+            doctrine-dbal: '^2.13'
           - php: '8.0'
             symfony-version: 6.*
             dependencies: lowest
+            doctrine-dbal: '^2.13'
+          - php: '8.0'
+            symfony-version: 6.*
+            doctrine-dbal: '<3.2'
 
     steps:
       - name: Checkout
@@ -67,6 +75,10 @@ jobs:
       - name: Update PHPUnit
         run: composer require --dev phpunit/phpunit ^9.3.9 --no-update
         if: matrix.php == '8.0' && matrix.dependencies == 'lowest'
+
+      - name: Update Doctrine DBAL
+        run: composer require --dev doctrine/dbal "${{ matrix.doctrine-dbal }}" --no-update
+        if: matrix.doctrine-dbal != 'highest'
 
       - name: Install dependencies
         uses: ramsey/composer-install@v1

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "require-dev": {
         "doctrine/dbal": "^2.13||^3.0",
         "doctrine/doctrine-bundle": "^1.12||^2.5",
-        "friendsofphp/php-cs-fixer": "^2.19||=3.16.0",
+        "friendsofphp/php-cs-fixer": "^2.19||<=3.16.0",
         "jangregor/phpstan-prophecy": "^1.0",
         "monolog/monolog": "^1.3||^2.0",
         "phpspec/prophecy": "!=1.11.0",

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "require-dev": {
         "doctrine/dbal": "^2.13||^3.0",
         "doctrine/doctrine-bundle": "^1.12||^2.5",
-        "friendsofphp/php-cs-fixer": "^2.19||^3.6",
+        "friendsofphp/php-cs-fixer": "^2.19||=3.16.0",
         "jangregor/phpstan-prophecy": "^1.0",
         "monolog/monolog": "^1.3||^2.0",
         "phpspec/prophecy": "!=1.11.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -231,7 +231,7 @@ parameters:
 			path: src/Tracing/Doctrine/DBAL/TracingServerInfoAwareDriverConnection.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of method Sentry\\\\SentryBundle\\\\Tracing\\\\Doctrine\\\\DBAL\\\\AbstractTracingStatement\\:\\:traceFunction\\(\\) expects callable\\(\\.\\.\\.mixed\\)\\: Doctrine\\\\DBAL\\\\Driver\\\\Result, array\\{Doctrine\\\\DBAL\\\\Driver\\\\Statement, 'execute'\\} given\\.$#"
+			message: "#^Parameter \\#2 \\$callback of method Sentry\\\\SentryBundle\\\\Tracing\\\\Doctrine\\\\DBAL\\\\AbstractTracingStatement\\:\\:traceFunction\\(\\) expects callable\\(mixed \\.\\.\\.\\)\\: Doctrine\\\\DBAL\\\\Driver\\\\Result, array\\{Doctrine\\\\DBAL\\\\Driver\\\\Statement, 'execute'\\} given\\.$#"
 			count: 1
 			path: src/Tracing/Doctrine/DBAL/TracingStatementForV3.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -50,6 +50,17 @@
       <code>$params</code>
     </MoreSpecificImplementedParamType>
   </file>
+  <file src="src/Tracing/Doctrine/DBAL/TracingDriverForV32.php">
+    <InvalidReturnStatement occurrences="1">
+      <code>$this-&gt;decoratedDriver-&gt;getSchemaManager($conn, $platform)</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>AbstractSchemaManager&lt;T&gt;</code>
+    </InvalidReturnType>
+    <MoreSpecificImplementedParamType occurrences="1">
+      <code>$params</code>
+    </MoreSpecificImplementedParamType>
+  </file>
   <file src="src/Tracing/HttpClient/TraceableResponseForV5.php">
     <UndefinedInterfaceMethod occurrences="1">
       <code>toStream</code>

--- a/src/Tracing/Doctrine/DBAL/TracingDriverForV32.php
+++ b/src/Tracing/Doctrine/DBAL/TracingDriverForV32.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tracing\Doctrine\DBAL;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\API\ExceptionConverter;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+
+/**
+ * This is a simple implementation of the {@see Driver} interface that decorates
+ * an existing driver to support distributed tracing capabilities. This implementation
+ * is compatible with all versions of Doctrine DBAL >= 3.2.
+ *
+ * @internal
+ *
+ * @phpstan-import-type Params from \Doctrine\DBAL\DriverManager as ConnectionParams
+ */
+final class TracingDriverForV32 implements Driver
+{
+    /**
+     * @var TracingDriverConnectionFactoryInterface The connection factory
+     */
+    private $connectionFactory;
+
+    /**
+     * @var Driver The instance of the decorated driver
+     */
+    private $decoratedDriver;
+
+    /**
+     * Constructor.
+     *
+     * @param TracingDriverConnectionFactoryInterface $connectionFactory The connection factory
+     * @param Driver                                  $decoratedDriver   The instance of the driver to decorate
+     */
+    public function __construct(TracingDriverConnectionFactoryInterface $connectionFactory, Driver $decoratedDriver)
+    {
+        $this->connectionFactory = $connectionFactory;
+        $this->decoratedDriver = $decoratedDriver;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @phpstan-param ConnectionParams $params
+     */
+    public function connect(array $params): TracingDriverConnectionInterface
+    {
+        return $this->connectionFactory->create(
+            $this->decoratedDriver->connect($params),
+            $this->decoratedDriver->getDatabasePlatform(),
+            $params
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDatabasePlatform(): AbstractPlatform
+    {
+        return $this->decoratedDriver->getDatabasePlatform();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @phpstan-template T of AbstractPlatform
+     *
+     * @phpstan-param T $platform
+     *
+     * @phpstan-return AbstractSchemaManager<T>
+     */
+    public function getSchemaManager(Connection $conn, AbstractPlatform $platform): AbstractSchemaManager
+    {
+        return $this->decoratedDriver->getSchemaManager($conn, $platform);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExceptionConverter(): ExceptionConverter
+    {
+        return $this->decoratedDriver->getExceptionConverter();
+    }
+}

--- a/src/aliases.php
+++ b/src/aliases.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sentry\SentryBundle;
 
+use Doctrine\DBAL\Exception\SchemaDoesNotExist;
 use Doctrine\DBAL\Result;
 use Sentry\SentryBundle\Tracing\Cache\TraceableCacheAdapter;
 use Sentry\SentryBundle\Tracing\Cache\TraceableCacheAdapterForV2;
@@ -14,6 +15,7 @@ use Sentry\SentryBundle\Tracing\Cache\TraceableTagAwareCacheAdapterForV3;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriver;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverForV2;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverForV3;
+use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverForV32;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingStatement;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingStatementForV2;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingStatementForV3;
@@ -53,7 +55,12 @@ if (interface_exists(AdapterInterface::class)) {
 if (!class_exists(TracingStatement::class)) {
     if (class_exists(Result::class)) {
         class_alias(TracingStatementForV3::class, TracingStatement::class);
-        class_alias(TracingDriverForV3::class, TracingDriver::class);
+
+        if (class_exists(SchemaDoesNotExist::class)) {
+            class_alias(TracingDriverForV32::class, TracingDriver::class);
+        } else {
+            class_alias(TracingDriverForV3::class, TracingDriver::class);
+        }
     } elseif (interface_exists(Result::class)) {
         class_alias(TracingStatementForV2::class, TracingStatement::class);
         class_alias(TracingDriverForV2::class, TracingDriver::class);

--- a/tests/DoctrineTestCase.php
+++ b/tests/DoctrineTestCase.php
@@ -7,6 +7,7 @@ namespace Sentry\SentryBundle\Tests;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\ResultStatement;
+use Doctrine\DBAL\Exception\SchemaDoesNotExist;
 use PHPUnit\Framework\TestCase;
 
 abstract class DoctrineTestCase extends TestCase
@@ -26,6 +27,12 @@ abstract class DoctrineTestCase extends TestCase
     {
         return self::isDoctrineDBALInstalled()
             && !self::isDoctrineDBALVersion2Installed();
+    }
+
+    protected static function isDoctrineDBALVersion32Installed(): bool
+    {
+        return self::isDoctrineDBALInstalled()
+            && class_exists(SchemaDoesNotExist::class);
     }
 
     protected static function isDoctrineBundlePackageInstalled(): bool

--- a/tests/End2End/App/Command/MainCommand.php
+++ b/tests/End2End/App/Command/MainCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class MainCommand extends Command
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->addOption('option1', null, InputOption::VALUE_NONE)

--- a/tests/Tracing/Doctrine/DBAL/TracingStatementForV3Test.php
+++ b/tests/Tracing/Doctrine/DBAL/TracingStatementForV3Test.php
@@ -55,6 +55,9 @@ final class TracingStatementForV3Test extends DoctrineTestCase
         $this->assertTrue($this->statement->bindValue('foo', 'bar', ParameterType::INTEGER));
     }
 
+    /**
+     * @group legacy
+     */
     public function testBindParam(): void
     {
         $variable = 'bar';


### PR DESCRIPTION
This driver does not implement the deprecated `VersionAwarePlatformDriver`.

It's automatically picked when `doctrine/dbal` version `3.2.0` or higher is installed.

Fixes #579