### PR TITLE
Make TracingDriverForV32 implements VersionAwarePlatformDriver to handle platform version

### DIFF
--- a/src/Tracing/Doctrine/DBAL/TracingDriverForV32.php
+++ b/src/Tracing/Doctrine/DBAL/TracingDriverForV32.php
@@ -86,4 +86,20 @@ final class TracingDriverForV32 implements Driver
     {
         return $this->decoratedDriver->getExceptionConverter();
     }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @phpstan-param string $version
+     *
+     * @phpstan-return AbstractPlatform
+     */
+    public function createDatabasePlatformForVersion($version): AbstractPlatform
+    {
+        if (method_exists($this->decoratedDriver, 'createDatabasePlatformForVersion')) {
+            return $this->decoratedDriver->createDatabasePlatformForVersion($version);
+        }
+
+        return $this->getDatabasePlatform();
+    }
 }

--- a/tests/Tracing/Doctrine/DBAL/TracingDriverForV32Test.php
+++ b/tests/Tracing/Doctrine/DBAL/TracingDriverForV32Test.php
@@ -109,4 +109,40 @@ final class TracingDriverForV32Test extends DoctrineTestCase
 
         $this->assertSame($exceptionConverter, $driver->getExceptionConverter());
     }
+
+    public function testCreateDatabasePlatform(): void
+    {
+        $databasePlatform = $this->createMock(AbstractPlatform::class);
+
+        $decoratedDriver = $this->createMock(DriverInterface::class);
+        $decoratedDriver->expects($this->once())
+            ->method('getDatabasePlatform')
+            ->willReturn($databasePlatform);
+
+        $driver = new TracingDriverForV32($this->connectionFactory, $decoratedDriver);
+
+        $this->assertSame($databasePlatform, $driver->createDatabasePlatformForVersion('5.7'));
+    }
+
+    public function testCreateDatabasePlatformForVersionWhenDriverDefinedCreateDatabasePlatformForVersion(): void
+    {
+        $databasePlatform = $this->createMock(AbstractPlatform::class);
+
+        $decoratedDriver = $this->createMock(StubCreateDatabasePlatformForVersionDriver::class);
+        $decoratedDriver->expects($this->once())
+            ->method('createDatabasePlatformForVersion')
+            ->with('5.7')
+            ->willReturn($databasePlatform);
+
+        $driver = new TracingDriverForV32($this->connectionFactory, $decoratedDriver);
+
+        $this->assertSame($databasePlatform, $driver->createDatabasePlatformForVersion('5.7'));
+    }
+}
+
+if (interface_exists(DriverInterface::class)) {
+    interface StubCreateDatabasePlatformForVersionDriver extends DriverInterface
+    {
+        public function createDatabasePlatformForVersion(string $version): AbstractPlatform;
+    }
 }


### PR DESCRIPTION
Fix https://github.com/getsentry/sentry-symfony/issues/730

As discussed in the issue, I had the `createDatabasePlatformForVersion` method to handle the platform version.