### PR TITLE
Set the span status when tracing an HTTP client request

### DIFF
--- a/src/Tracing/HttpClient/AbstractTraceableResponse.php
+++ b/src/Tracing/HttpClient/AbstractTraceableResponse.php
@@ -139,7 +139,7 @@ abstract class AbstractTraceableResponse implements ResponseInterface
         // If the returned status code is 0, it means that this info isn't available
         // yet (e.g. an error happened before the request was sent), hence we cannot
         // determine what happened.
-        if ($statusCode === 0) {
+        if (0 === $statusCode) {
             $this->span->setStatus(SpanStatus::unknownError());
         } else {
             $this->span->setStatus(SpanStatus::createFromHttpStatusCode($statusCode));


### PR DESCRIPTION
Partially fixes #681: the status of the span is now set according to the HTTP response status when tracing a request using the Symfony HTTP client. If the status code is not available when needed, for example because the request failed to be sent due to some transport error, the documentation says that `0` is returned. In that case, I decided to set the status to `unknwon_error` instead of `internal_error` like it was done in the [`GuzzleMiddleware`](https://github.com/getsentry/sentry-php/blob/15a028d4aa3925b06b083cd65c1175828fa6e409/src/Tracing/GuzzleTracingMiddleware.php#L93) middleware. Reason of this choice is that we cannot determine in a reliable way the error, so telling the user that there was an internal error may be misleading.