### PR TITLE
Prefer the `SENTRY_RELEASE` environment variable over the package root version

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -291,6 +291,16 @@ parameters:
 			path: tests/DependencyInjection/ConfigurationTest.php
 
 		-
+			message: "#^Function Symfony\\\\Component\\\\DependencyInjection\\\\Loader\\\\Configurator\\\\ref not found\\.$#"
+			count: 1
+			path: tests/DependencyInjection/Fixtures/php/release_option_fallback_to_env_var.php
+
+		-
+			message: "#^Used function Symfony\\\\Component\\\\DependencyInjection\\\\Loader\\\\Configurator\\\\ref not found\\.$#"
+			count: 1
+			path: tests/DependencyInjection/Fixtures/php/release_option_fallback_to_env_var.php
+
+		-
 			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
 			count: 1
 			path: tests/DependencyInjection/SentryExtensionTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -306,6 +306,11 @@ parameters:
 			path: tests/DependencyInjection/SentryExtensionTest.php
 
 		-
+			message: "#^Cannot access offset 'release' on mixed\\.$#"
+			count: 1
+			path: tests/DependencyInjection/SentryExtensionTest.php
+
+		-
 			message: "#^Class Symfony\\\\Component\\\\Debug\\\\Exception\\\\FatalErrorException not found\\.$#"
 			count: 1
 			path: tests/DependencyInjection/SentryExtensionTest.php

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Sentry\SentryBundle\DependencyInjection;
 
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
-use Jean85\PrettyVersions;
 use Sentry\Options;
 use Sentry\SentryBundle\ErrorTypesParser;
 use Sentry\Transport\TransportFactoryInterface;
@@ -102,7 +101,7 @@ final class Configuration implements ConfigurationInterface
                         ->scalarNode('logger')->end()
                         ->scalarNode('release')
                             ->cannotBeEmpty()
-                            ->defaultValue(PrettyVersions::getRootPackageVersion()->getPrettyVersion())
+                            ->defaultValue('%env(default::SENTRY_RELEASE)%')
                         ->end()
                         ->scalarNode('server_name')->end()
                         ->scalarNode('before_send')->end()

--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sentry\SentryBundle\DependencyInjection;
 
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use Jean85\PrettyVersions;
 use Psr\Log\NullLogger;
 use Sentry\Client;
 use Sentry\ClientBuilder;
@@ -66,6 +67,8 @@ final class SentryExtension extends ConfigurableExtension
     {
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');
+
+        $container->setParameter('env(SENTRY_RELEASE)', PrettyVersions::getRootPackageVersion()->getPrettyVersion());
 
         $this->registerConfiguration($container, $mergedConfig);
         $this->registerErrorListenerConfiguration($container, $mergedConfig);

--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -68,7 +68,9 @@ final class SentryExtension extends ConfigurableExtension
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');
 
-        $container->setParameter('env(SENTRY_RELEASE)', PrettyVersions::getRootPackageVersion()->getPrettyVersion());
+        if (!$container->hasParameter('env(SENTRY_RELEASE)')) {
+            $container->setParameter('env(SENTRY_RELEASE)', PrettyVersions::getRootPackageVersion()->getPrettyVersion());
+        }
 
         $this->registerConfiguration($container, $mergedConfig);
         $this->registerErrorListenerConfiguration($container, $mergedConfig);

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Sentry\SentryBundle\Tests\DependencyInjection;
 
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
-use Jean85\PrettyVersions;
 use PHPUnit\Framework\TestCase;
 use Sentry\SentryBundle\DependencyInjection\Configuration;
 use Symfony\Bundle\TwigBundle\TwigBundle;
@@ -29,7 +28,7 @@ final class ConfigurationTest extends TestCase
                 'integrations' => [],
                 'prefixes' => array_merge(['%kernel.project_dir%'], array_filter(explode(\PATH_SEPARATOR, get_include_path() ?: ''))),
                 'environment' => '%kernel.environment%',
-                'release' => PrettyVersions::getRootPackageVersion()->getPrettyVersion(),
+                'release' => '%env(default::SENTRY_RELEASE)%',
                 'tags' => [],
                 'in_app_exclude' => [
                     '%kernel.cache_dir%',

--- a/tests/DependencyInjection/Fixtures/StubEnvVarLoader.php
+++ b/tests/DependencyInjection/Fixtures/StubEnvVarLoader.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\DependencyInjection\Fixtures;
+
+use Symfony\Component\DependencyInjection\EnvVarLoaderInterface;
+
+final class StubEnvVarLoader implements EnvVarLoaderInterface
+{
+    /**
+     * @var array<string, string>
+     */
+    private $envs = [];
+
+    /**
+     * @param array<string, string> $envs
+     */
+    public function __construct(array $envs)
+    {
+        $this->envs = $envs;
+    }
+
+    public function loadEnvVars(): array
+    {
+        return $this->envs;
+    }
+}

--- a/tests/DependencyInjection/Fixtures/php/release_option_fallback_to_composer_version.php
+++ b/tests/DependencyInjection/Fixtures/php/release_option_fallback_to_composer_version.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/** @var ContainerBuilder $container */
+$container->loadFromExtension('sentry', []);

--- a/tests/DependencyInjection/Fixtures/php/release_option_fallback_to_env_var.php
+++ b/tests/DependencyInjection/Fixtures/php/release_option_fallback_to_env_var.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/** @var ContainerBuilder $container */
+$container->setParameter('env(SENTRY_RELEASE)', '1.0.x-dev');
+$container->loadFromExtension('sentry', []);

--- a/tests/DependencyInjection/Fixtures/php/release_option_fallback_to_env_var.php
+++ b/tests/DependencyInjection/Fixtures/php/release_option_fallback_to_env_var.php
@@ -2,8 +2,25 @@
 
 declare(strict_types=1);
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Sentry\SentryBundle\Tests\DependencyInjection\Fixtures\StubEnvVarLoader;
+use Symfony\Component\DependencyInjection\EnvVarProcessor;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-/** @var ContainerBuilder $container */
-$container->setParameter('env(SENTRY_RELEASE)', '1.0.x-dev');
-$container->loadFromExtension('sentry', []);
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
+
+return static function (ContainerConfigurator $container): void {
+    $container->extension('sentry', []);
+
+    $container->services()
+        ->set(StubEnvVarLoader::class)
+        ->tag('container.env_var_loader')
+        ->args([['SENTRY_RELEASE' => '1.0.x-dev']])
+
+        ->set(EnvVarProcessor::class)
+        ->tag('container.env_var_processor')
+        ->args([
+            service('service_container'),
+            tagged_iterator('container.env_var_loader'),
+        ]);
+};

--- a/tests/DependencyInjection/Fixtures/php/release_option_fallback_to_env_var.php
+++ b/tests/DependencyInjection/Fixtures/php/release_option_fallback_to_env_var.php
@@ -6,6 +6,7 @@ use Sentry\SentryBundle\Tests\DependencyInjection\Fixtures\StubEnvVarLoader;
 use Symfony\Component\DependencyInjection\EnvVarProcessor;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
+use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
 
@@ -20,7 +21,7 @@ return static function (ContainerConfigurator $container): void {
         ->set(EnvVarProcessor::class)
         ->tag('container.env_var_processor')
         ->args([
-            service('service_container'),
+            function_exists('Symfony\\Component\\DependencyInjection\\Loader\\Configurator\\service') ? service('service_container') : ref('service_container'),
             tagged_iterator('container.env_var_loader'),
         ]);
 };

--- a/tests/DependencyInjection/Fixtures/php/release_option_from_config.php
+++ b/tests/DependencyInjection/Fixtures/php/release_option_from_config.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/** @var ContainerBuilder $container */
+$container->loadFromExtension('sentry', [
+    'options' => [
+        'release' => '1.0.x-dev',
+    ],
+]);

--- a/tests/DependencyInjection/Fixtures/php/release_option_from_env_var.php
+++ b/tests/DependencyInjection/Fixtures/php/release_option_from_env_var.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/** @var ContainerBuilder $container */
+$container->setParameter('env(APP_RELEASE)', '1.0.x-dev');
+$container->loadFromExtension('sentry', [
+    'options' => [
+        'release' => '%env(APP_RELEASE)%',
+    ],
+]);

--- a/tests/DependencyInjection/Fixtures/xml/release_option_fallback_to_composer_version.xml
+++ b/tests/DependencyInjection/Fixtures/xml/release_option_fallback_to_composer_version.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:sentry="https://sentry.io/schema/dic/sentry-symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                               https://sentry.io/schema/dic/sentry-symfony https://sentry.io/schema/dic/sentry-symfony/sentry-1.0.xsd">
+
+    <sentry:config />
+</container>

--- a/tests/DependencyInjection/Fixtures/xml/release_option_fallback_to_env_var.xml
+++ b/tests/DependencyInjection/Fixtures/xml/release_option_fallback_to_env_var.xml
@@ -6,9 +6,22 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                                https://sentry.io/schema/dic/sentry-symfony https://sentry.io/schema/dic/sentry-symfony/sentry-1.0.xsd">
 
-    <parameters>
-        <parameter key="env(SENTRY_RELEASE)">1.0.x-dev</parameter>
-    </parameters>
+    <services>
+        <service id="Sentry\SentryBundle\Tests\DependencyInjection\Fixtures\StubEnvVarLoader" class="Sentry\SentryBundle\Tests\DependencyInjection\Fixtures\StubEnvVarLoader">
+            <argument type="collection">
+                <argument type="string" key="SENTRY_RELEASE">1.0.x-dev</argument>
+            </argument>
+
+            <tag name="container.env_var_loader" />
+        </service>
+
+        <service id="Symfony\Component\DependencyInjection\EnvVarProcessor" class="Symfony\Component\DependencyInjection\EnvVarProcessor">
+            <argument type="service" id="service_container" />
+            <argument type="tagged_iterator" tag="container.env_var_loader" />
+
+            <tag name="container.env_var_processor" />
+        </service>
+    </services>
 
     <sentry:config />
 </container>

--- a/tests/DependencyInjection/Fixtures/xml/release_option_fallback_to_env_var.xml
+++ b/tests/DependencyInjection/Fixtures/xml/release_option_fallback_to_env_var.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:sentry="https://sentry.io/schema/dic/sentry-symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                               https://sentry.io/schema/dic/sentry-symfony https://sentry.io/schema/dic/sentry-symfony/sentry-1.0.xsd">
+
+    <parameters>
+        <parameter key="env(SENTRY_RELEASE)">1.0.x-dev</parameter>
+    </parameters>
+
+    <sentry:config />
+</container>

--- a/tests/DependencyInjection/Fixtures/xml/release_option_from_config.xml
+++ b/tests/DependencyInjection/Fixtures/xml/release_option_from_config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:sentry="https://sentry.io/schema/dic/sentry-symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                               https://sentry.io/schema/dic/sentry-symfony https://sentry.io/schema/dic/sentry-symfony/sentry-1.0.xsd">
+
+    <sentry:config>
+        <sentry:options release="1.0.x-dev" />
+    </sentry:config>
+</container>

--- a/tests/DependencyInjection/Fixtures/xml/release_option_from_env_var.xml
+++ b/tests/DependencyInjection/Fixtures/xml/release_option_from_env_var.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:sentry="https://sentry.io/schema/dic/sentry-symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                               https://sentry.io/schema/dic/sentry-symfony https://sentry.io/schema/dic/sentry-symfony/sentry-1.0.xsd">
+
+    <parameters>
+        <parameter key="env(APP_RELEASE)">1.0.x-dev</parameter>
+    </parameters>
+
+    <sentry:config>
+        <sentry:options release="%env(APP_RELEASE)%" />
+    </sentry:config>
+</container>

--- a/tests/DependencyInjection/Fixtures/yml/release_option_fallback_to_composer_version.yml
+++ b/tests/DependencyInjection/Fixtures/yml/release_option_fallback_to_composer_version.yml
@@ -1,0 +1,2 @@
+sentry:
+    options: ~

--- a/tests/DependencyInjection/Fixtures/yml/release_option_fallback_to_env_var.yml
+++ b/tests/DependencyInjection/Fixtures/yml/release_option_fallback_to_env_var.yml
@@ -1,5 +1,16 @@
-parameters:
-    env(SENTRY_RELEASE): 1.0.x-dev
+services:
+    Sentry\SentryBundle\Tests\DependencyInjection\Fixtures\StubEnvVarLoader:
+        arguments:
+            - { SENTRY_RELEASE: 1.0.x-dev }
+        tags:
+            - { name: container.env_var_loader }
+
+    Symfony\Component\DependencyInjection\EnvVarProcessor:
+        arguments:
+            - '@service_container'
+            - !tagged_iterator container.env_var_loader
+        tags:
+            - { name: container.env_var_processor }
 
 sentry:
     options: ~

--- a/tests/DependencyInjection/Fixtures/yml/release_option_fallback_to_env_var.yml
+++ b/tests/DependencyInjection/Fixtures/yml/release_option_fallback_to_env_var.yml
@@ -1,0 +1,5 @@
+parameters:
+    env(SENTRY_RELEASE): 1.0.x-dev
+
+sentry:
+    options: ~

--- a/tests/DependencyInjection/Fixtures/yml/release_option_from_config.yml
+++ b/tests/DependencyInjection/Fixtures/yml/release_option_from_config.yml
@@ -1,0 +1,3 @@
+sentry:
+    options:
+        release: 1.0.x-dev

--- a/tests/DependencyInjection/Fixtures/yml/release_option_from_env_var.yml
+++ b/tests/DependencyInjection/Fixtures/yml/release_option_from_env_var.yml
@@ -1,0 +1,6 @@
+parameters:
+    env(APP_RELEASE): 1.0.x-dev
+
+sentry:
+    options:
+        release: '%env(APP_RELEASE)%'

--- a/tests/DependencyInjection/SentryExtensionTest.php
+++ b/tests/DependencyInjection/SentryExtensionTest.php
@@ -32,6 +32,7 @@ use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Debug\Exception\FatalErrorException;
 use Symfony\Component\DependencyInjection\Compiler\ResolveParameterPlaceHoldersPass;
+use Symfony\Component\DependencyInjection\Compiler\ResolveTaggedIteratorArgumentPass;
 use Symfony\Component\DependencyInjection\Compiler\ValidateEnvPlaceholdersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -503,6 +504,7 @@ abstract class SentryExtensionTest extends TestCase
         $container->getCompilerPassConfig()->setOptimizationPasses([
             new ValidateEnvPlaceholdersPass(),
             new ResolveParameterPlaceHoldersPass(),
+            new ResolveTaggedIteratorArgumentPass(),
         ]);
 
         $this->loadFixture($container, $fixtureFile);

--- a/tests/DependencyInjection/SentryExtensionTest.php
+++ b/tests/DependencyInjection/SentryExtensionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sentry\SentryBundle\Tests\DependencyInjection;
 
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use Jean85\PrettyVersions;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Sentry\ClientInterface;
@@ -30,6 +31,8 @@ use Sentry\Transport\TransportFactoryInterface;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Debug\Exception\FatalErrorException;
+use Symfony\Component\DependencyInjection\Compiler\ResolveParameterPlaceHoldersPass;
+use Symfony\Component\DependencyInjection\Compiler\ValidateEnvPlaceholdersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
@@ -448,20 +451,59 @@ abstract class SentryExtensionTest extends TestCase
         $this->assertDefinitionMethodCallAt($methodCalls[5], 'setLogger', [new Reference(NullLogger::class, ContainerBuilder::IGNORE_ON_INVALID_REFERENCE)]);
     }
 
+    /**
+     * @dataProvider releaseOptionDataProvider
+     */
+    public function testReleaseOption(string $fixtureFile, string $expectedRelease): void
+    {
+        $container = $this->createContainerFromFixture($fixtureFile);
+        $optionsDefinition = $container->getDefinition('sentry.client.options');
+
+        $this->assertSame(Options::class, $optionsDefinition->getClass());
+        $this->assertSame($expectedRelease, $container->resolveEnvPlaceholders($optionsDefinition->getArgument(0)['release'], true));
+    }
+
+    public function releaseOptionDataProvider(): \Generator
+    {
+        yield 'If the release option is set to a concrete value, then no fallback occurs' => [
+            'release_option_from_config',
+            '1.0.x-dev',
+        ];
+
+        yield 'If the release option is set and references an environment variable, then no fallback occurs' => [
+            'release_option_from_env_var',
+            '1.0.x-dev',
+        ];
+
+        yield 'If the release option is unset and the SENTRY_RELEASE environment variable is set, then the latter is used as fallback' => [
+            'release_option_fallback_to_env_var',
+            '1.0.x-dev',
+        ];
+
+        yield 'If both the release option and the SENTRY_RELEASE environment variable are unset, then the root package version is used as fallback' => [
+            'release_option_fallback_to_composer_version',
+            PrettyVersions::getRootPackageVersion()->getPrettyVersion(),
+        ];
+    }
+
     private function createContainerFromFixture(string $fixtureFile): ContainerBuilder
     {
         $container = new ContainerBuilder(new EnvPlaceholderParameterBag([
             'kernel.cache_dir' => __DIR__,
             'kernel.build_dir' => __DIR__,
             'kernel.project_dir' => __DIR__,
+            'kernel.environment' => 'dev',
             'doctrine.default_connection' => 'default',
             'doctrine.connections' => ['default'],
         ]));
 
         $container->registerExtension(new SentryExtension());
-        $container->getCompilerPassConfig()->setOptimizationPasses([]);
         $container->getCompilerPassConfig()->setRemovingPasses([]);
         $container->getCompilerPassConfig()->setAfterRemovingPasses([]);
+        $container->getCompilerPassConfig()->setOptimizationPasses([
+            new ValidateEnvPlaceholdersPass(),
+            new ResolveParameterPlaceHoldersPass(),
+        ]);
 
         $this->loadFixture($container, $fixtureFile);
 


### PR DESCRIPTION
Fixes #623. Since the default value for the `release` option is hardcoded to be the root package version, the `SENTRY_RELEASE` environment variable is never considered unless explicitly referenced in the config by the user. With these changes, the environment variable is used as default value. If its value is an empty string or the variable is not set, the root package version is used as a fallback.

This is technically speaking a change in the behaviour of the config, so it may be worth to document it. Also, this may be considered a bugfix rather than an improvement since it was never intended to prefer the root package version over the environment variable.