### PR TITLE
Silence `TokenInterface::isAuthenticated` deprecation in LoginListener

### DIFF
--- a/src/EventListener/LoginListener.php
+++ b/src/EventListener/LoginListener.php
@@ -109,7 +109,7 @@ final class LoginListener
 
     private function isTokenAuthenticated(TokenInterface $token): bool
     {
-        if (method_exists($token, 'isAuthenticated') && !$token->isAuthenticated()) {
+        if (method_exists($token, 'isAuthenticated') && !$token->isAuthenticated(false)) {
             return false;
         }
 


### PR DESCRIPTION
Before #720, we already silenced this deprecation in this same way: https://github.com/ste93cry/sentry-symfony/blob/251114f07d8a18c4cf07adad3b5a46a6c4f0c83e/src/EventListener/RequestListener.php#L135

This PR restores the silencing of the deprecation, since we check for the method existence immediately before.