### PR TITLE
Individual captures of DelayedMessageHandlingException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.12.0
+
+### Features
+
+- Report individual exceptions from `DelayedMessageHandlingException` [(#760)](https://github.com/getsentry/sentry-symfony/pull/760)
+
 ## 4.11.0
 
 The Sentry SDK team is happy to announce the immediate availability of Sentry Symfony SDK v4.11.0.
@@ -167,7 +173,7 @@ This release contains a colorful bouquet of new features.
   ```
 
 - Use the `_route` attribute as the transaction name [(#692)](https://github.com/getsentry/sentry-symfony/pull/692)
-  
+
   If you're using named routes, the SDK will default to use this attribute as the transaction name.
   With this change, you should be able to see a full list of your transactions on the performance page,
   instead of `<< unparameterized >>`.

--- a/tests/EventListener/MessengerListenerTest.php
+++ b/tests/EventListener/MessengerListenerTest.php
@@ -15,6 +15,7 @@ use Sentry\State\Scope;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageHandledEvent;
+use Symfony\Component\Messenger\Exception\DelayedMessageHandlingException;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\BusNameStamp;
@@ -106,6 +107,16 @@ final class MessengerListenerTest extends TestCase
         yield 'envelope.throwable INSTANCEOF HandlerFailedException' => [
             $exceptions,
             $this->getMessageFailedEvent($envelope, 'receiver', new HandlerFailedException($envelope, $exceptions), false),
+            [
+                'messenger.receiver_name' => 'receiver',
+                'messenger.message_class' => \get_class($envelope->getMessage()),
+            ],
+            false,
+        ];
+
+        yield 'envelope.throwable INSTANCEOF DelayedMessageHandlingException' => [
+            $exceptions,
+            $this->getMessageFailedEvent($envelope, 'receiver', new DelayedMessageHandlingException($exceptions), false),
             [
                 'messenger.receiver_name' => 'receiver',
                 'messenger.message_class' => \get_class($envelope->getMessage()),


### PR DESCRIPTION
Thrown by https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/Messenger/Middleware/DispatchAfterCurrentBusMiddleware.php#L100 with any exceptions thrown after the current bus.