### PR TITLE
Add jobs for PHP `8.3` to the CI

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.2'
 
       - name: Install dependencies
         run: composer update --no-progress --no-interaction --prefer-dist

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
 
       - name: Install dependencies
         run: composer update --no-progress --no-interaction --prefer-dist
@@ -37,7 +37,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
 
       - name: Install dependencies
         run: composer update --no-progress --no-interaction --prefer-dist
@@ -55,7 +55,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
 
       - name: Install dependencies
         run: composer update --no-progress --no-interaction --prefer-dist

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,6 +24,7 @@ jobs:
           - '8.0'
           - '8.1'
           - '8.2'
+          - '8.3'
         symfony-version:
           - 4.4.*
           - 5.*
@@ -99,9 +100,7 @@ jobs:
           - php: '8.0'
             dependencies: lowest
             symfony-version: 4.4.*
-          - php: '8.1'
-            dependencies: highest
-          - php: '8.2'
+          - php: '8.3'
             dependencies: highest
 
     steps:


### PR DESCRIPTION
With PHP `8.3` coming in November 2023, it's time to run the CI for that version as well so that we're ready for its release.