### PR TITLE
Update symfony/psr-http-message-bridge dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "symfony/event-dispatcher": "^4.4.20||^5.0.11||^6.0",
         "symfony/http-kernel": "^4.4.20||^5.0.11||^6.0",
         "symfony/polyfill-php80": "^1.22",
-        "symfony/psr-http-message-bridge": "^1.2||^2.0",
+        "symfony/psr-http-message-bridge": "^1.2||^2.0||^6.4",
         "symfony/security-core": "^4.4.20||^5.0.11||^6.0",
         "symfony/security-http": "^4.4.20||^5.0.11||^6.0"
     },


### PR DESCRIPTION
The Symfony team is preparing the [psr-http-message-bridge](https://github.com/symfony/psr-http-message-bridge) to be included in the main Symfony release schedule, moving it from the current version 2.3 to version 6.4 and 7.0 simultaneously. This is going to cause issues for developers using Symfony as described in my issue [here](https://github.com/symfony/flex/issues/998).

To fix this, I've added the `^6.4` constraint for the package in composer.json.