### PR TITLE
Fix broken build and update PHPStan baseline

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12,22 +12,22 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'before_breadcrumb' on mixed\\.$#"
-			count: 3
+			count: 1
 			path: src/DependencyInjection/SentryExtension.php
 
 		-
 			message: "#^Cannot access offset 'before_send' on mixed\\.$#"
-			count: 3
+			count: 1
 			path: src/DependencyInjection/SentryExtension.php
 
 		-
 			message: "#^Cannot access offset 'before_send…' on mixed\\.$#"
-			count: 3
+			count: 1
 			path: src/DependencyInjection/SentryExtension.php
 
 		-
 			message: "#^Cannot access offset 'class_serializers' on mixed\\.$#"
-			count: 3
+			count: 1
 			path: src/DependencyInjection/SentryExtension.php
 
 		-
@@ -62,7 +62,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'traces_sampler' on mixed\\.$#"
-			count: 3
+			count: 1
 			path: src/DependencyInjection/SentryExtension.php
 
 		-

--- a/tests/EventListener/MessengerListenerTest.php
+++ b/tests/EventListener/MessengerListenerTest.php
@@ -116,7 +116,7 @@ final class MessengerListenerTest extends TestCase
 
         yield 'envelope.throwable INSTANCEOF DelayedMessageHandlingException' => [
             $exceptions,
-            $this->getMessageFailedEvent($envelope, 'receiver', new DelayedMessageHandlingException($exceptions), false),
+            $this->getMessageFailedEvent($envelope, 'receiver', new DelayedMessageHandlingException($exceptions, $envelope), false),
             [
                 'messenger.receiver_name' => 'receiver',
                 'messenger.message_class' => \get_class($envelope->getMessage()),


### PR DESCRIPTION
With some recent changes in PHPStan, the current build is broken because some errors are reported fewer times than before, likely because the tool got smarter in understanding how to narrow types. Also, Symfony introduced a breaking change in #51468 which breaks the build because of a new required param of `DelayedMessageHandlingException::__construct()`. Although the signature is gonna be fixed, within this PR I'm proactively adapting our code to the new signature so that we don't have to wait for the patch version 