### PR TITLE
Add compatibility with Symfony 6.4 applications

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "symfony/event-dispatcher": "^4.4.20||^5.0.11||^6.0",
         "symfony/http-kernel": "^4.4.20||^5.0.11||^6.0",
         "symfony/polyfill-php80": "^1.22",
-        "symfony/psr-http-message-bridge": "^1.2||^2.0",
+        "symfony/psr-http-message-bridge": "^1.2||^2.0||^6.4",
         "symfony/security-core": "^4.4.20||^5.0.11||^6.0",
         "symfony/security-http": "^4.4.20||^5.0.11||^6.0"
     },


### PR DESCRIPTION
I'm updating some Symfony apps to 6.4 (and later, 7.0). Without this change, I can't update the project because of this conflict:

```
Problem 1
- sentry/sentry-symfony[4.0.0, ..., 4.0.3] require symfony/config ^3.4.43||^4.4.11||^5.0.11 -> found symfony/config[v3.4.43, ..., v3.4.47, v4.4.11, ..., v4.4.44, v5.0.11, ..., v5.4.26] but these were not loaded, likely because it conflicts with another require.
- sentry/sentry-symfony[4.1.0, ..., 4.2.4] require symfony/config ^3.4.44||^4.4.20||^5.0.11 -> found symfony/config[v3.4.44, v3.4.45, v3.4.46, v3.4.47, v4.4.20, ..., v4.4.44, v5.0.11, ..., v5.4.26] but these were not loaded, likely because it conflicts with another require.
- sentry/sentry-symfony[4.2.5, ..., 4.11.0] require symfony/psr-http-message-bridge ^1.2||^2.0 -> found symfony/psr-http-message-bridge[v1.2.0, v1.3.0, v2.0.0, ..., v2.3.1] but these were not loaded, likely because it conflicts with another require.
- Root composer.json requires sentry/sentry-symfony ^4.0 -> satisfiable by sentry/sentry-symfony[4.0.0, ..., 4.11.0].
```

We should add `||^7.0` too ... but there's already a PR for adding Symfony 7.0 support in tis project (see #761), so let's not do that here.

Thanks!