### PR TITLE
Harden GitHub Workflows permissions

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -10,6 +10,9 @@ on:
         description: Force a release even when there are release-blockers (optional)
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -8,6 +8,9 @@ on:
       - develop
       - release/**
 
+permissions:
+  contents: read
+
 jobs:
   php-cs-fixer:
     name: PHP-CS-Fixer

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,6 +8,9 @@ on:
       - develop
       - release/**
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Tests


### PR DESCRIPTION
It is important to apply the principle of least privilege to restrict the amount of damage that a compromised GitHub Workflow can do. To do so, within this PR I'm setting the token permissions to read-only. Since by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token), by specifying any permission explicitly all others are set to none.