### PR TITLE
Add cron monitoring feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,22 @@ The parameter `options` allows to fine-tune exceptions. To discover more options
 [the Unified APIs](https://docs.sentry.io/development/sdk-dev/unified-api/#options) options and
 the [PHP specific](https://docs.sentry.io/platforms/php/#php-specific-options) ones.
 
+### Monitor scheduled jobs (crontabs)
+Add cron monitoring slug and schedule to your command parameters. ref.
+>      --cron-monitor-slug=CRON-MONITOR-SLUG                  if command should be monitored then pass cron monitor slug
+>      --cron-monitor-schedule=CRON-MONITOR-SCHEDULE          if command should be monitored then pass cron monitor schedule
+>      --cron-monitor-max-time=CRON-MONITOR-MAX-TIME          if command should be monitored then pass cron monitor max execution time
+>      --cron-monitor-check-margin=CRON-MONITOR-CHECK-MARGIN  if command should be monitored then pass cron monitor check margin
+example usage in crontab
+```
+0 0 * * *   user    /app/bin/console app:statistics:update --cron-monitor-slug=statistics_update_midnight --cron-monitor-schedule "0 0 * * *"
+```
+Optionally you can also set max run time and check margin (see https://docs.sentry.io/platforms/php/crons/for ref.)
+
+```
+0 0 * * *   user    /app/bin/console app:statistics:update --cron-monitor-slug=statistics_update_midnight --cron-monitor-schedule "0 0 * * *" --cron-monitor-max-time=5 --cron-monitor-check-margin=2
+```
+
 #### Optional: use custom HTTP factory/transport
 
 Since the SDK 2.0 uses HTTPlug to remain transport-agnostic, you need to install two packages that provide

--- a/src/CronMonitoring/CronMonitor.php
+++ b/src/CronMonitoring/CronMonitor.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\CronMonitoring;
+
+use Sentry\CheckInStatus;
+use Sentry\MonitorConfig;
+use Sentry\State\HubInterface;
+
+class CronMonitor
+{
+    /**
+     * @var MonitorConfig
+     */
+    private $monitorConfig;
+
+    /**
+     * @var HubInterface
+     */
+    private $hub;
+
+    /**
+     * @var string
+     */
+    private $slug;
+
+    /**
+     * @var string
+     */
+    private $checkInId;
+
+    public function __construct(HubInterface $hub, MonitorConfig $monitorConfig, string $slug)
+    {
+        $this->hub = $hub;
+        $this->monitorConfig = $monitorConfig;
+        $this->slug = $slug;
+    }
+
+    public function start(): void
+    {
+        $this->checkInId = $this->hub->captureCheckIn(
+            $this->slug,
+            CheckInStatus::inProgress(),
+            null,
+            $this->monitorConfig
+        );
+    }
+
+    public function finishSuccess(): ?string
+    {
+        return $this->hub->captureCheckIn(
+            $this->slug,
+            CheckInStatus::OK(),
+            null,
+            $this->monitorConfig,
+            $this->checkInId
+        );
+    }
+
+    public function finishError(): ?string
+    {
+        return $this->hub->captureCheckIn(
+            $this->slug,
+            CheckInStatus::error(),
+            null,
+            $this->monitorConfig,
+            $this->checkInId
+        );
+    }
+}

--- a/src/CronMonitoring/CronMonitorFactory.php
+++ b/src/CronMonitoring/CronMonitorFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\CronMonitoring;
+
+use Sentry\MonitorConfig;
+use Sentry\MonitorSchedule;
+use Sentry\State\HubInterface;
+
+class CronMonitorFactory
+{
+    /**
+     * @var HubInterface
+     */
+    private $hub;
+
+    public function __construct(HubInterface $hub)
+    {
+        $this->hub = $hub;
+    }
+
+    public function create(string $slug, string $schedule, ?int $checkMarginMinutes = null, ?int $maxRuntimeMinutes = null): CronMonitor
+    {
+        $monitorSchedule = MonitorSchedule::crontab($schedule);
+        $monitorConfig = new MonitorConfig(
+            $monitorSchedule,
+            $checkMarginMinutes,
+            $maxRuntimeMinutes,
+            date_default_timezone_get()
+        );
+
+        return new CronMonitor($this->hub, $monitorConfig, $slug);
+    }
+}

--- a/src/CronMonitoring/EventSubscriber/CronMonitorSubscriber.php
+++ b/src/CronMonitoring/EventSubscriber/CronMonitorSubscriber.php
@@ -40,7 +40,7 @@ class CronMonitorSubscriber implements EventSubscriberInterface
         $checkMargin = $event->getInput()->getOption('cron-monitor-check-margin');
 
         if ($slug && $schedule) {
-            $this->cronMonitor = $this->cronMonitorFactory->create($slug, $schedule, (int) $checkMargin, (int) $maxTime);
+            $this->cronMonitor = $this->cronMonitorFactory->create($slug, $schedule, $checkMargin ? (int) $checkMargin : null, $maxTime ? (int) $maxTime : null);
             $this->cronMonitor->start();
         }
     }

--- a/src/CronMonitoring/EventSubscriber/CronMonitorSubscriber.php
+++ b/src/CronMonitoring/EventSubscriber/CronMonitorSubscriber.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\CronMonitoring\EventSubscriber;
+
+use Sentry\SentryBundle\CronMonitoring\CronMonitor;
+use Sentry\SentryBundle\CronMonitoring\CronMonitorFactory;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class CronMonitorSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var CronMonitorFactory
+     */
+    private $cronMonitorFactory;
+
+    /**
+     * @var ?CronMonitor
+     */
+    private $cronMonitor = null;
+
+    public function __construct(CronMonitorFactory $cronMonitorFactory)
+    {
+        $this->cronMonitorFactory = $cronMonitorFactory;
+    }
+
+    public function onConsoleCommandStart(ConsoleCommandEvent $event)
+    {
+        if (!$event->getInput()->hasOption('cron-monitor-slug')) {
+            return; // Cron monitor not enabled in application
+        }
+        $slug = $event->getInput()->getOption('cron-monitor-slug');
+        $schedule = $event->getInput()->getOption('cron-monitor-schedule');
+        $maxTime = $event->getInput()->getOption('cron-monitor-max-time');
+        $checkMargin = $event->getInput()->getOption('cron-monitor-check-margin');
+
+        if ($slug && $schedule) {
+            $this->cronMonitor = $this->cronMonitorFactory->create($slug, $schedule, (int) $checkMargin, (int) $maxTime);
+            $this->cronMonitor->start();
+        }
+    }
+
+    public function onConsoleCommandTerminate(ConsoleTerminateEvent $event)
+    {
+        if ($this->cronMonitor) {
+            if (Command::SUCCESS === $event->getExitCode()) {
+                $this->cronMonitor->finishSuccess();
+            } else {
+                $this->cronMonitor->finishError();
+            }
+        }
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ConsoleEvents::COMMAND => 'onConsoleCommandStart',
+            ConsoleEvents::TERMINATE => 'onConsoleCommandTerminate',
+        ];
+    }
+}

--- a/src/DependencyInjection/Compiler/AddCronMonitorOptionsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddCronMonitorOptionsCompilerPass.php
@@ -13,10 +13,10 @@ class AddCronMonitorOptionsCompilerPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         $optionsArguments = [
-            ['--cron-monitor-slug', '-cm', InputOption::VALUE_REQUIRED, 'if command should be monitored then pass cron monitor slug'],
-            ['--cron-monitor-schedule', '-cms', InputOption::VALUE_REQUIRED, 'if command should be monitored then pass cron monitor schedule'],
-            ['--cron-monitor-max-time', '-cmt', InputOption::VALUE_REQUIRED, 'if command should be monitored then pass cron monitor max execution time'],
-            ['--cron-monitor-check-margin', '-cmcm', InputOption::VALUE_REQUIRED, 'if command should be monitored then pass cron monitor check margin'],
+            ['--cron-monitor-slug', null, InputOption::VALUE_REQUIRED, 'if command should be monitored then pass cron monitor slug'],
+            ['--cron-monitor-schedule', null, InputOption::VALUE_REQUIRED, 'if command should be monitored then pass cron monitor schedule'],
+            ['--cron-monitor-max-time', null, InputOption::VALUE_REQUIRED, 'if command should be monitored then pass cron monitor max execution time'],
+            ['--cron-monitor-check-margin', null, InputOption::VALUE_REQUIRED, 'if command should be monitored then pass cron monitor check margin'],
         ];
 
         $consoleCommands = $container->findTaggedServiceIds('console.command');

--- a/src/DependencyInjection/Compiler/AddCronMonitorOptionsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddCronMonitorOptionsCompilerPass.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class AddCronMonitorOptionsCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $optionsArguments = [
+            ['--cron-monitor-slug', '-cm', InputOption::VALUE_REQUIRED, 'if command should be monitored then pass cron monitor slug'],
+            ['--cron-monitor-schedule', '-cms', InputOption::VALUE_REQUIRED, 'if command should be monitored then pass cron monitor schedule'],
+            ['--cron-monitor-max-time', '-cmt', InputOption::VALUE_REQUIRED, 'if command should be monitored then pass cron monitor max execution time'],
+            ['--cron-monitor-check-margin', '-cmcm', InputOption::VALUE_REQUIRED, 'if command should be monitored then pass cron monitor check margin'],
+        ];
+
+        $consoleCommands = $container->findTaggedServiceIds('console.command');
+        foreach ($consoleCommands as $name => $consoleCommand) {
+            $definition = $container->getDefinition($name);
+            foreach ($optionsArguments as $optionArguments) {
+                $definition->addMethodCall('addOption', $optionArguments);
+            }
+        }
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -143,5 +143,8 @@
         <service id="Sentry\SentryBundle\Twig\SentryExtension" class="Sentry\SentryBundle\Twig\SentryExtension">
             <tag name="twig.extension" />
         </service>
+
+        <service id="Sentry\SentryBundle\CronMonitoring\CronMonitorFactory" class="Sentry\SentryBundle\CronMonitoring\CronMonitorFactory" autowire="true" />
+        <service id="Sentry\SentryBundle\CronMonitoring\EventSubscriber\CronMonitorSubscriber" class="Sentry\SentryBundle\CronMonitoring\EventSubscriber\CronMonitorSubscriber" autowire="true" autoconfigure="true" />
     </services>
 </container>

--- a/src/SentryBundle.php
+++ b/src/SentryBundle.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sentry\SentryBundle;
 
+use Sentry\SentryBundle\DependencyInjection\Compiler\AddCronMonitorOptionsCompilerPass;
 use Sentry\SentryBundle\DependencyInjection\Compiler\AddLoginListenerTagPass;
 use Sentry\SentryBundle\DependencyInjection\Compiler\CacheTracingPass;
 use Sentry\SentryBundle\DependencyInjection\Compiler\DbalTracingPass;
@@ -25,5 +26,6 @@ final class SentryBundle extends Bundle
         $container->addCompilerPass(new CacheTracingPass());
         $container->addCompilerPass(new HttpClientTracingPass());
         $container->addCompilerPass(new AddLoginListenerTagPass());
+        $container->addCompilerPass(new AddCronMonitorOptionsCompilerPass());
     }
 }

--- a/tests/CronMonitoring/CronMonitorFactoryTest.php
+++ b/tests/CronMonitoring/CronMonitorFactoryTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\CronMonitoring;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\SentryBundle\CronMonitoring\CronMonitor;
+use Sentry\SentryBundle\CronMonitoring\CronMonitorFactory;
+use Sentry\State\HubInterface;
+
+final class CronMonitorFactoryTest extends TestCase
+{
+    /**
+     * @dataProvider createDataProvider
+     */
+    public function testCreate(string $slug, string $schedule, ?int $checkMarginMinutes, ?int $maxRuntimeMinutes)
+    {
+        $hub = $this->createMock(HubInterface::class);
+
+        $cronMonitorFactory = new CronMonitorFactory($hub);
+        $cronMonitor = $cronMonitorFactory->create($slug, $schedule, $checkMarginMinutes, $maxRuntimeMinutes);
+
+        $this->assertInstanceOf(CronMonitor::class, $cronMonitor);
+    }
+
+    public function createDataProvider(): array
+    {
+        return [
+            ['slug', '* * * * *', 1, 1],
+            ['slug2', '* * * * *', null, 2],
+            ['example_slug', '2 * * * *', 3, null],
+            ['example_slug2', '2/5 * * * *', null, null],
+        ];
+    }
+}

--- a/tests/CronMonitoring/CronMonitorTest.php
+++ b/tests/CronMonitoring/CronMonitorTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\CronMonitoring;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\CheckInStatus;
+use Sentry\MonitorConfig;
+use Sentry\MonitorSchedule;
+use Sentry\SentryBundle\CronMonitoring\CronMonitor;
+use Sentry\SentryBundle\Tests\Stubs\TestableHubInterface;
+
+final class CronMonitorTest extends TestCase
+{
+    /**
+     * @dataProvider monitorDataProvider
+     */
+    public function testSuccess(string $slug, string $schedule, ?int $checkMarginMinutes, ?int $maxRuntimeMinutes, CheckInStatus $testedStatus)
+    {
+        // Arrange
+        $hub = $this->createMock(TestableHubInterface::class);
+        $monitorSchedule = MonitorSchedule::crontab($schedule);
+        $monitorConfig = new MonitorConfig(
+            $monitorSchedule,
+            $checkMarginMinutes,
+            $maxRuntimeMinutes,
+            date_default_timezone_get()
+        );
+
+        $checkInId = uniqid('checkInId');
+        $inProgressCalled = $finishCalled = false;
+        $hub
+            ->expects($this->exactly(2))
+            ->method('captureCheckIn')
+            ->willReturnCallback(
+                function (string $callSlug, CheckInStatus $callStatus, ?int $callDuration, MonitorConfig $callMonitorConfig, $callCheckInId) use ($slug, $monitorConfig, $testedStatus, &$checkInId, &$inProgressCalled, &$finishCalled) {
+                    if ($callSlug === $slug && $callStatus === CheckInStatus::inProgress() && null === $callDuration && $callMonitorConfig === $monitorConfig) {
+                        $inProgressCalled = true;
+
+                        return $checkInId;
+                    }
+                    if ($callSlug === $slug && $callStatus === $testedStatus && null === $callDuration && $callMonitorConfig === $monitorConfig && $callCheckInId === $checkInId) {
+                        $finishCalled = true;
+
+                        return null;
+                    }
+                    $this->fail('Unexpected call to Hub::captureCheckIn');
+                });
+
+        $cronMonitor = new CronMonitor($hub, $monitorConfig, $slug);
+        $cronMonitor->start();
+
+        // Act
+        if ($testedStatus === CheckInStatus::ok()) {
+            $cronMonitor->finishSuccess();
+        } else {
+            $cronMonitor->finishError();
+        }
+
+        // Assert
+        $this->assertTrue($inProgressCalled);
+        $this->assertTrue($finishCalled);
+    }
+
+    public function monitorDataProvider(): array
+    {
+        return [
+            ['slug', '* * * * *', 1, 1, CheckInStatus::ok()],
+            ['slug2', '* * * * *', null, 2, CheckInStatus::ok()],
+            ['example_slug', '2 * * * *', 3, null, CheckInStatus::ok()],
+            ['example_slug2', '2/5 * * * *', null, null, CheckInStatus::ok()],
+            ['slug', '* * * * *', 1, 1, CheckInStatus::error()],
+        ];
+    }
+}

--- a/tests/CronMonitoring/EventSubscriber/CronMonitorSubscriberTest.php
+++ b/tests/CronMonitoring/EventSubscriber/CronMonitorSubscriberTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\CronMonitoring\EventSubscriber;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\CheckInStatus;
+use Sentry\SentryBundle\CronMonitoring\CronMonitor;
+use Sentry\SentryBundle\CronMonitoring\CronMonitorFactory;
+use Sentry\SentryBundle\CronMonitoring\EventSubscriber\CronMonitorSubscriber;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+class CronMonitorSubscriberTest extends TestCase
+{
+    /**
+     * @dataProvider onConsoleCommandStartProvider
+     */
+    public function testOnConsoleCommandStart(string $slug, string $schedule, ?int $checkMargin, ?int $maxTime)
+    {
+        // Arrange
+        $cronMonitor = $this->createMock(CronMonitor::class);
+        //$cronMonitor->expects($this->once())->method('start');
+
+        $cronMonitorFactory = $this->createMock(CronMonitorFactory::class);
+        $cronMonitorFactory
+            ->expects($this->once())
+            ->method('create')
+            ->with($slug, $schedule, $checkMargin, $maxTime)
+            ->willReturn($cronMonitor);
+
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addSubscriber(new CronMonitorSubscriber($cronMonitorFactory));
+
+        // Act
+        $input = new ArrayInput([
+            '--cron-monitor-slug' => $slug,
+            '--cron-monitor-schedule' => $schedule,
+        ], $this->getCronMonitorInputDefinition());
+        if ($checkMargin) {
+            $input->setOption('cron-monitor-check-margin', $checkMargin);
+        }
+        if ($maxTime) {
+            $input->setOption('cron-monitor-max-time', $maxTime);
+        }
+        $command = new Command('test:command');
+        $event = new ConsoleCommandEvent($command, $input, new NullOutput());
+
+        $eventDispatcher->dispatch($event, ConsoleEvents::COMMAND);
+
+        // Assert
+        // Not easily possible with phpunit :( Main assert is in Arrange section
+    }
+
+    public function onConsoleCommandStartProvider(): array
+    {
+        return [
+            ['slug', '* * * * *', 1, 1, CheckInStatus::ok()],
+            ['slug2', '* * * * *', null, 2, CheckInStatus::ok()],
+            ['example_slug', '2 * * * *', 3, null, CheckInStatus::ok()],
+            ['example_slug2', '2/5 * * * *', null, null, CheckInStatus::ok()],
+            ['slug', '* * * * *', 1, 1, CheckInStatus::error()],
+        ];
+    }
+
+    public function testOnConsoleCommandStartDisabled()
+    {
+        // Arrange
+        $cronMonitorFactory = $this->createMock(CronMonitorFactory::class);
+
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addSubscriber(new CronMonitorSubscriber($cronMonitorFactory));
+
+        // Act
+        $inputDefinition = new InputDefinition();
+        $input = new ArrayInput([], $inputDefinition);
+        $event = new ConsoleCommandEvent(null, $input, new NullOutput());
+
+        $eventDispatcher->dispatch($event, ConsoleEvents::COMMAND);
+
+        // Assert
+        // Not easily possible with phpunit :( Main assert is in Arrange section
+    }
+
+    public function testOnConsoleCommandTerminate()
+    {
+        // Arrange
+        $cronMonitor = $this->createMock(CronMonitor::class);
+        $cronMonitor->expects($this->once())->method('start');
+        $cronMonitor->expects($this->once())->method('finishSuccess');
+
+        $cronMonitorFactory = $this->createMock(CronMonitorFactory::class);
+        $cronMonitorFactory
+            ->expects($this->once())
+            ->method('create')
+            ->willReturn($cronMonitor);
+
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addSubscriber(new CronMonitorSubscriber($cronMonitorFactory));
+
+        // Act
+        $input = new ArrayInput([
+            '--cron-monitor-slug' => 'test_slug',
+            '--cron-monitor-schedule' => 'test_schedule',
+        ], $this->getCronMonitorInputDefinition());
+        $commandEvent = new ConsoleCommandEvent(null, $input, new NullOutput());
+        $command = new Command('test:command');
+        $terminateEvent = new ConsoleTerminateEvent($command, $input, new NullOutput(), 0);
+
+        $eventDispatcher->dispatch($commandEvent, ConsoleEvents::COMMAND);
+        $eventDispatcher->dispatch($terminateEvent, ConsoleEvents::TERMINATE);
+
+        // Assert
+        // Not easily possible with phpunit :( Main assert is in Arrange section
+    }
+
+    public function testOnConsoleCommandTerminateNon0Status()
+    {
+        // Arrange
+        $cronMonitor = $this->createMock(CronMonitor::class);
+        $cronMonitor->expects($this->once())->method('start');
+        $cronMonitor->expects($this->once())->method('finishError');
+
+        $cronMonitorFactory = $this->createMock(CronMonitorFactory::class);
+        $cronMonitorFactory
+            ->expects($this->once())
+            ->method('create')
+            ->willReturn($cronMonitor);
+
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addSubscriber(new CronMonitorSubscriber($cronMonitorFactory));
+
+        // Act
+        $input = new ArrayInput([
+            '--cron-monitor-slug' => 'test_slug',
+            '--cron-monitor-schedule' => 'test_schedule',
+        ], $this->getCronMonitorInputDefinition());
+        $commandEvent = new ConsoleCommandEvent(null, $input, new NullOutput());
+        $command = new Command('test:command');
+        $terminateEvent = new ConsoleTerminateEvent($command, $input, new NullOutput(), 1);
+
+        $eventDispatcher->dispatch($commandEvent, ConsoleEvents::COMMAND);
+        $eventDispatcher->dispatch($terminateEvent, ConsoleEvents::TERMINATE);
+
+        // Assert
+        // Not easily possible with phpunit :( Main assert is in Arrange section
+    }
+
+    private function getCronMonitorInputDefinition(): InputDefinition
+    {
+        $inputDefinition = new InputDefinition();
+        $optionsArguments = [
+            ['--cron-monitor-slug', '-cm', InputOption::VALUE_REQUIRED, 'if command should be monitored then pass cron monitor slug'],
+            ['--cron-monitor-schedule', '-cms', InputOption::VALUE_REQUIRED, 'if command should be monitored then pass cron monitor schedule'],
+            ['--cron-monitor-max-time', '-cmt', InputOption::VALUE_REQUIRED, 'if command should be monitored then pass cron monitor max execution time'],
+            ['--cron-monitor-check-margin', '-cmcm', InputOption::VALUE_REQUIRED, 'if command should be monitored then pass cron monitor check margin'],
+        ];
+        foreach ($optionsArguments as $optionArguments) {
+            $inputDefinition->addOption(new InputOption(...$optionArguments));
+        }
+
+        return $inputDefinition;
+    }
+}

--- a/tests/DependencyInjection/Compiler/AddCronMonitorOptionsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddCronMonitorOptionsCompilerPassTest.php
@@ -22,10 +22,10 @@ final class AddCronMonitorOptionsCompilerPassTest extends TestCase
         $commandDefinition = $container->getDefinition(SentryTestCommand::class);
 
         $this->assertSame([
-            ['addOption', ['--cron-monitor-slug', '-cm', InputOption::VALUE_REQUIRED, 'if command should be monitored then pass cron monitor slug']],
-            ['addOption', ['--cron-monitor-schedule', '-cms', InputOption::VALUE_REQUIRED, 'if command should be monitored then pass cron monitor schedule']],
-            ['addOption', ['--cron-monitor-max-time', '-cmt', InputOption::VALUE_REQUIRED, 'if command should be monitored then pass cron monitor max execution time']],
-            ['addOption', ['--cron-monitor-check-margin', '-cmcm', InputOption::VALUE_REQUIRED, 'if command should be monitored then pass cron monitor check margin']],
+            ['addOption', ['--cron-monitor-slug', null, InputOption::VALUE_REQUIRED, 'if command should be monitored then pass cron monitor slug']],
+            ['addOption', ['--cron-monitor-schedule', null, InputOption::VALUE_REQUIRED, 'if command should be monitored then pass cron monitor schedule']],
+            ['addOption', ['--cron-monitor-max-time', null, InputOption::VALUE_REQUIRED, 'if command should be monitored then pass cron monitor max execution time']],
+            ['addOption', ['--cron-monitor-check-margin', null, InputOption::VALUE_REQUIRED, 'if command should be monitored then pass cron monitor check margin']],
         ], $commandDefinition->getMethodCalls());
     }
 }

--- a/tests/DependencyInjection/Compiler/AddCronMonitorOptionsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddCronMonitorOptionsCompilerPassTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\SentryBundle\Command\SentryTestCommand;
+use Sentry\SentryBundle\DependencyInjection\Compiler\AddCronMonitorOptionsCompilerPass;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class AddCronMonitorOptionsCompilerPassTest extends TestCase
+{
+    public function testProcess(): void
+    {
+        $container = new ContainerBuilder();
+        $container->register(SentryTestCommand::class)->setPublic(true)->addTag('console.command');
+        $container->addCompilerPass(new AddCronMonitorOptionsCompilerPass());
+        $container->compile();
+
+        $commandDefinition = $container->getDefinition(SentryTestCommand::class);
+
+        $this->assertSame([
+            ['addOption', ['--cron-monitor-slug', '-cm', InputOption::VALUE_REQUIRED, 'if command should be monitored then pass cron monitor slug']],
+            ['addOption', ['--cron-monitor-schedule', '-cms', InputOption::VALUE_REQUIRED, 'if command should be monitored then pass cron monitor schedule']],
+            ['addOption', ['--cron-monitor-max-time', '-cmt', InputOption::VALUE_REQUIRED, 'if command should be monitored then pass cron monitor max execution time']],
+            ['addOption', ['--cron-monitor-check-margin', '-cmcm', InputOption::VALUE_REQUIRED, 'if command should be monitored then pass cron monitor check margin']],
+        ], $commandDefinition->getMethodCalls());
+    }
+}

--- a/tests/End2End/App/Command/SuccessCommand.php
+++ b/tests/End2End/App/Command/SuccessCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\End2End\App\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SuccessCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this
+            ->addOption('option1', null, InputOption::VALUE_NONE)
+            ->addOption('option2', 'o2', InputOption::VALUE_OPTIONAL)
+            ->addArgument('id');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        return Command::SUCCESS;
+    }
+}

--- a/tests/End2End/App/config.yml
+++ b/tests/End2End/App/config.yml
@@ -19,6 +19,10 @@ services:
     alias: Sentry\State\HubInterface
     public: true
 
+  test.Sentry\SentryBundle\CronMonitoring\CronMonitorFactory:
+    alias: Sentry\SentryBundle\CronMonitoring\CronMonitorFactory
+    public: true
+
   Sentry\SentryBundle\Tests\End2End\StubTransportFactory: ~
 
   Sentry\Transport\TransportFactoryInterface:
@@ -31,6 +35,9 @@ services:
 
   Sentry\SentryBundle\Tests\End2End\App\Command\MainCommand:
     tags: [{ name: 'console.command', command: 'main-command' }]
+
+  Sentry\SentryBundle\Tests\End2End\App\Command\SuccessCommand:
+    tags: [{ name: 'console.command', command: 'success-command' }]
 
 monolog:
   handlers:

--- a/tests/End2End/CronMonitoringTest.php
+++ b/tests/End2End/CronMonitoringTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\End2End;
+
+use Sentry\SentryBundle\CronMonitoring\CronMonitor;
+use Sentry\SentryBundle\CronMonitoring\CronMonitorFactory;
+use Sentry\SentryBundle\Tests\End2End\App\Kernel;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class CronMonitoringTest extends KernelTestCase
+{
+    protected static function getKernelClass(): string
+    {
+        return Kernel::class;
+    }
+
+    /**
+     * @dataProvider cronMonitorSuccessDataProvider
+     */
+    public function testCronMonitorSuccess(string $slug, string $schedule, ?int $checkMarginMinutes, ?int $maxRuntimeMinutes, string $command)
+    {
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+        $application->setAutoExit(false);
+
+        $cronMonitor = $this->createMock(CronMonitor::class);
+        $cronMonitor->expects($this->once())->method('start');
+        if ('success-command' === $command) {
+            $cronMonitor->expects($this->once())->method('finishSuccess');
+            $cronMonitor->expects($this->never())->method('finishError');
+        } else {
+            $cronMonitor->expects($this->never())->method('finishSuccess');
+            $cronMonitor->expects($this->once())->method('finishError');
+        }
+
+        $cronMonitorFactory = $this->createMock(CronMonitorFactory::class);
+        $cronMonitorFactory
+            ->expects($this->once())
+            ->method('create')
+            ->with($slug, $schedule, $checkMarginMinutes, $maxRuntimeMinutes)
+            ->willReturn($cronMonitor);
+
+        $kernel->boot();
+        $kernel->getContainer()->set('test.' . CronMonitorFactory::class, $cronMonitorFactory);
+
+        $arguments = ['bin/console', $command, '--cron-monitor-slug', $slug, '--cron-monitor-schedule', $schedule];
+        if ($checkMarginMinutes) {
+            $arguments[] = '--cron-monitor-check-margin';
+            $arguments[] = (string) $checkMarginMinutes;
+        }
+        if ($maxRuntimeMinutes) {
+            $arguments[] = '--cron-monitor-max-time';
+            $arguments[] = (string) $maxRuntimeMinutes;
+        }
+        $input = new ArgvInput($arguments);
+
+        $exitCode = $application->run($input, new NullOutput());
+
+        $this->assertEquals('success-command' === $command ? 0 : 1, $exitCode);
+    }
+
+    public function cronMonitorSuccessDataProvider(): array
+    {
+        return [
+            ['slug', '* * * * *', 1, 1, 'success-command'],
+            ['slug2', '* * * * *', null, 2, 'success-command'],
+            ['example_slug', '2 * * * *', 3, null, 'success-command'],
+            ['example_slug2', '2/5 * * * *', null, null, 'success-command'],
+            ['slug', '* * * * *', 1, 1, 'success-command'],
+            ['slug', '* * * * *', 1, 1, 'main-command'],
+        ];
+    }
+}

--- a/tests/Stubs/TestableHubInterface.php
+++ b/tests/Stubs/TestableHubInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\Stubs;
+
+use Sentry\CheckInStatus;
+use Sentry\MonitorConfig;
+use Sentry\State\HubInterface;
+
+interface TestableHubInterface extends HubInterface
+{
+    /**
+     * @param int|float|null $duration
+     */
+    public function captureCheckIn(string $slug, CheckInStatus $status, $duration = null, ?MonitorConfig $monitorConfig = null, ?string $checkInId = null): ?string;
+}


### PR DESCRIPTION
This is implementation of https://docs.sentry.io/platforms/php/crons/
This approach will allow it to be used with crontab as welll as any other scheduler (k8s, etc.).
Just need to add proper options to your console command eg.
```
bin/console any_command --cron-monitor-slug=the_slug --cron-monitor-schedule "0 0 * * *" --cron-monitor-max-time=5 --cron-monitor-check-margin=2
```
max-time and check-margin is optional
Downside is readability and that you have to manually pass the schedule (which often is a duplicate). But couldn't come up with anything better.
