### PR TITLE
Remove monolog dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
         "doctrine/dbal": "^2.13||^3.0",
         "doctrine/doctrine-bundle": "^1.12||^2.5",
         "friendsofphp/php-cs-fixer": "^2.19||<=3.16.0",
-        "monolog/monolog": "^1.3||^2.0||^3.0",
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^1.3",
         "phpstan/phpstan-phpunit": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "doctrine/dbal": "^2.13||^3.0",
         "doctrine/doctrine-bundle": "^1.12||^2.5",
         "friendsofphp/php-cs-fixer": "^2.19||<=3.16.0",
-        "monolog/monolog": "^1.3||^2.0",
+        "monolog/monolog": "^1.3||^2.0||^3.0",
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^1.3",
         "phpstan/phpstan-phpunit": "^1.0",


### PR DESCRIPTION
Monolog repository is not used directly by this repository; so we can remove it ;) 