### PR TITLE
Fix the decoration of the HTTP client when tracing is enabled

### DIFF
--- a/src/DependencyInjection/Compiler/HttpClientTracingPass.php
+++ b/src/DependencyInjection/Compiler/HttpClientTracingPass.php
@@ -13,6 +13,17 @@ use Symfony\Component\DependencyInjection\Reference;
 final class HttpClientTracingPass implements CompilerPassInterface
 {
     /**
+     * List of service IDs that can be registered in the container by the
+     * framework when decorating the mock client. The order is from the
+     * outermost decorator to the innermost.
+     */
+    private const MOCK_HTTP_CLIENT_SERVICE_IDS = [
+        'http_client.retryable.inner.mock_client',
+        '.debug.http_client.inner.mock_client',
+        'http_client.mock_client',
+    ];
+
+    /**
      * {@inheritdoc}
      */
     public function process(ContainerBuilder $container): void
@@ -21,12 +32,40 @@ final class HttpClientTracingPass implements CompilerPassInterface
             return;
         }
 
-        foreach ($container->findTaggedServiceIds('http_client.client') as $id => $tags) {
-            $container->register('.sentry.traceable.' . $id, TraceableHttpClient::class)
-                ->setDecoratedService($id)
-                ->setArgument(0, new Reference('.sentry.traceable.' . $id . '.inner'))
-                ->setArgument(1, new Reference(HubInterface::class))
-                ->addTag('kernel.reset', ['method' => 'reset']);
+        $decoratedService = $this->getDecoratedService($container);
+
+        $container->register(TraceableHttpClient::class, TraceableHttpClient::class)
+            ->setArgument(0, new Reference(TraceableHttpClient::class . '.inner'))
+            ->setArgument(1, new Reference(HubInterface::class))
+            ->setDecoratedService($decoratedService[0], null, $decoratedService[1]);
+    }
+
+    /**
+     * @return array{string, int}
+     */
+    private function getDecoratedService(ContainerBuilder $container): array
+    {
+        // Starting from Symfony 6.3, the raw HTTP client that serves as adapter
+        // for the transport is registered as a separate service, so that the
+        // scoped clients can inject it before any decoration is applied on them.
+        // Since we need to access the full URL of the request, and such information
+        // is available after the `ScopingHttpClient` class did its job, we have
+        // to decorate such service. For more details, see https://github.com/symfony/symfony/pull/49513.
+        if ($container->hasDefinition('http_client.transport')) {
+            return ['http_client.transport', -15];
         }
+
+        // On versions of Symfony prior to 6.3, when the mock client is in-use,
+        // each HTTP client is decorated by referencing explicitly the innermost
+        // service rather than by using the standard decoration feature. Hence,
+        // we have to look for the specific names of those services, and decorate
+        // them instead of the raw HTTP client.
+        foreach (self::MOCK_HTTP_CLIENT_SERVICE_IDS as $httpClientServiceId) {
+            if ($container->hasDefinition($httpClientServiceId)) {
+                return [$httpClientServiceId, 15];
+            }
+        }
+
+        return ['http_client', 15];
     }
 }

--- a/tests/DependencyInjection/SentryExtensionTest.php
+++ b/tests/DependencyInjection/SentryExtensionTest.php
@@ -40,6 +40,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBa
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\ErrorHandler\Error\FatalError;
 use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\TraceableHttpClient;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageHandledEvent;
@@ -373,6 +374,7 @@ abstract class SentryExtensionTest extends TestCase
         $this->assertFalse($container->hasDefinition(TracingDriverMiddleware::class));
         $this->assertFalse($container->hasDefinition(ConnectionConfigurator::class));
         $this->assertFalse($container->hasDefinition(TwigTracingExtension::class));
+        $this->assertFalse($container->hasDefinition(TraceableHttpClient::class));
         $this->assertFalse($container->getParameter('sentry.tracing.enabled'));
         $this->assertEmpty($container->getParameter('sentry.tracing.dbal.connections'));
     }


### PR DESCRIPTION
The distributed tracing functionality for the HTTP client has been broken for a long time: first, the decoration of the raw HTTP client does not happen correctly, leading to a double presence of our instrumentation in the decoration chain. Second, but not least, because our instrumentation runs before we have the complete URL of the request, the reported span includes incomplete and/or misleading information.

This PR is an attempt to fix #700 based on @simonberger's contribution in #704. Starting from Symfony `6.3`, the framework decoration strategy was revisited and this made the fix quite simple. However, on older versions of the framework, each built-in decorator of the HTTP client (e.g. the `RetryableHttpClient`), references in the constructor the `.inner` service of the client being decorated, making impossible to inject our own client at a given position because no real decoration chain exists. For this reason, I had to hardcode and decorate the specific services created by the framework in [`FrameworkExtension`](https://github.com/symfony/symfony/blob/ce95b8763a168756e4e050a39ae7ca5258a2bde0/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L2334), rather than the raw HTTP client.