### PR TITLE
Clean up impossible test conditions and fix broken CI

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -96,7 +96,7 @@ parameters:
 			path: src/DependencyInjection/SentryExtension.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function array_filter expects callable\\(mixed\\)\\: mixed, Closure\\(string\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#2 \\$callback of function array_filter expects \\(callable\\(mixed\\)\\: mixed\\)\\|null, Closure\\(string\\)\\: bool given\\.$#"
 			count: 1
 			path: src/DependencyInjection/SentryExtension.php
 

--- a/tests/End2End/App/Kernel.php
+++ b/tests/End2End/App/Kernel.php
@@ -48,6 +48,10 @@ class Kernel extends SymfonyKernel
             $loader->load(__DIR__ . '/deprecations_for_6.yml');
         }
 
+        if (self::VERSION_ID >= 60400) {
+            $loader->load(__DIR__ . '/deprecations_for_64.yml');
+        }
+
         if (interface_exists(MessageBusInterface::class) && self::VERSION_ID >= 40300) {
             $loader->load(__DIR__ . '/messenger.yml');
         }

--- a/tests/End2End/App/config.yml
+++ b/tests/End2End/App/config.yml
@@ -13,6 +13,9 @@ framework:
   router: { resource: "%routing_config_dir%/routing.yml" }
   secret: secret
   test: ~
+  annotations: false
+  php_errors:
+    log: true
 
 services:
   test.hub:

--- a/tests/End2End/App/deprecations_for_64.yml
+++ b/tests/End2End/App/deprecations_for_64.yml
@@ -1,0 +1,2 @@
+framework:
+  handle_all_throwables: true

--- a/tests/Integration/RequestFetcherTest.php
+++ b/tests/Integration/RequestFetcherTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sentry\SentryBundle\Test\Integration;
+namespace Sentry\SentryBundle\Tests\Integration;
 
 use GuzzleHttp\Psr7\ServerRequest;
 use PHPUnit\Framework\MockObject\MockObject;


### PR DESCRIPTION
After the new release of `symfony/psr-http-message-bridge`, the return type of `HttpMessageFactoryInterface::createRequest()` was added at language-level. This triggered PHPStan and PHPUnit to report that `null` cannot be returned from such method, but an assertion of a test case was expecting that it happened. This PR refactors the broken tests by cleaning up the conditions that cannot happen in real life.

In addition to this, an error message from PHPStan was updated and no longer matched our baseline. Finally, I also fixed some deprecations that were breaking the end-to-end tests after the release of Symfony `6.4`