### PR TITLE
Fix the HTTP client decoration when no `http_client` service is registered

### DIFF
--- a/src/DependencyInjection/Compiler/HttpClientTracingPass.php
+++ b/src/DependencyInjection/Compiler/HttpClientTracingPass.php
@@ -34,6 +34,10 @@ final class HttpClientTracingPass implements CompilerPassInterface
 
         $decoratedService = $this->getDecoratedService($container);
 
+        if (null === $decoratedService) {
+            return;
+        }
+
         $container->register(TraceableHttpClient::class, TraceableHttpClient::class)
             ->setArgument(0, new Reference(TraceableHttpClient::class . '.inner'))
             ->setArgument(1, new Reference(HubInterface::class))
@@ -41,9 +45,9 @@ final class HttpClientTracingPass implements CompilerPassInterface
     }
 
     /**
-     * @return array{string, int}
+     * @return array{string, int}|null
      */
-    private function getDecoratedService(ContainerBuilder $container): array
+    private function getDecoratedService(ContainerBuilder $container): ?array
     {
         // Starting from Symfony 6.3, the raw HTTP client that serves as adapter
         // for the transport is registered as a separate service, so that the
@@ -66,6 +70,10 @@ final class HttpClientTracingPass implements CompilerPassInterface
             }
         }
 
-        return ['http_client', 15];
+        if ($container->hasDefinition('http_client')) {
+            return ['http_client', 15];
+        }
+
+        return null;
     }
 }

--- a/tests/DependencyInjection/Compiler/HttpClientTracingPassTest.php
+++ b/tests/DependencyInjection/Compiler/HttpClientTracingPassTest.php
@@ -54,6 +54,14 @@ final class HttpClientTracingPassTest extends TestCase
         ];
     }
 
+    public function testProcessDoesNothingIfHttpClientServiceCannotBeFound(): void
+    {
+        $container = $this->createContainerBuilder(true, true, null);
+        $container->compile();
+
+        $this->assertFalse($container->hasDefinition('http_client'));
+    }
+
     /**
      * @dataProvider processDoesNothingIfConditionsForEnablingTracingAreMissingDataProvider
      */
@@ -86,7 +94,7 @@ final class HttpClientTracingPassTest extends TestCase
         ];
     }
 
-    private function createContainerBuilder(bool $isTracingEnabled, bool $isHttpClientTracingEnabled, string $httpClientServiceId): ContainerBuilder
+    private function createContainerBuilder(bool $isTracingEnabled, bool $isHttpClientTracingEnabled, ?string $httpClientServiceId): ContainerBuilder
     {
         $container = new ContainerBuilder();
         $container->addCompilerPass(new HttpClientTracingPass());
@@ -96,8 +104,10 @@ final class HttpClientTracingPassTest extends TestCase
         $container->register(HubInterface::class, HubInterface::class)
             ->setPublic(true);
 
-        $container->register($httpClientServiceId, HttpClientInterface::class)
-            ->setPublic(true);
+        if (null !== $httpClientServiceId) {
+            $container->register($httpClientServiceId, HttpClientInterface::class)
+                ->setPublic(true);
+        }
 
         return $container;
     }


### PR DESCRIPTION
Fixes #791. During the development of #786, I completely forgot to handle the case where the `http_client` service is not registered in the container. This PR addresses the issue by checking that the service exists before decorating it.