### PR TITLE
fix: http client aliases

### DIFF
--- a/src/aliases.php
+++ b/src/aliases.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sentry\SentryBundle;
 
+use Composer\InstalledVersions;
 use Doctrine\DBAL\Result;
 use Sentry\SentryBundle\Tracing\Cache\TraceableCacheAdapter;
 use Sentry\SentryBundle\Tracing\Cache\TraceableCacheAdapterForV2;
@@ -27,7 +28,6 @@ use Sentry\SentryBundle\Tracing\HttpClient\TraceableResponseForV5;
 use Sentry\SentryBundle\Tracing\HttpClient\TraceableResponseForV6;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\DoctrineProvider;
-use Symfony\Component\HttpClient\Response\StreamableInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 if (interface_exists(AdapterInterface::class)) {
@@ -61,14 +61,15 @@ if (!class_exists(TracingStatement::class)) {
 }
 
 if (!class_exists(TraceableResponse::class) && interface_exists(ResponseInterface::class)) {
-    if (!interface_exists(StreamableInterface::class)) {
-        class_alias(TraceableResponseForV4::class, TraceableResponse::class);
-        class_alias(TraceableHttpClientForV4::class, TraceableHttpClient::class);
-    } elseif (version_compare(\PHP_VERSION, '8.0', '>=')) {
+    $httpClientVersion = InstalledVersions::getVersion('symfony/http-client');
+    if (version_compare($httpClientVersion, '6.0', '>=')) {
         class_alias(TraceableResponseForV6::class, TraceableResponse::class);
         class_alias(TraceableHttpClientForV6::class, TraceableHttpClient::class);
-    } else {
+    } elseif (version_compare($httpClientVersion, '5.0', '>=')) {
         class_alias(TraceableResponseForV5::class, TraceableResponse::class);
         class_alias(TraceableHttpClientForV5::class, TraceableHttpClient::class);
+    } else {
+        class_alias(TraceableResponseForV4::class, TraceableResponse::class);
+        class_alias(TraceableHttpClientForV4::class, TraceableHttpClient::class);
     }
 }


### PR DESCRIPTION
Hello,

Attempt to fix #794.

Since theres is no specific changes from http-client 5.4 to 6.0 ([see changelog](https://github.com/symfony/symfony/blob/v6.0.0/src/Symfony/Component/HttpClient/CHANGELOG.md)), there is no way to know the version with the current way of doing things (i.e. checking if class / interface / methods exist or not) i propose to use `InstalledVersions::getVersion` of composer.

I saw the `jean85/pretty-package-versions` package but it's "overkill" in this specific case IMO (we just need the package version, not an object to deal with)

Thanks for your review !