### PR TITLE
Fix regex of ignored errors in PHPStan baseline

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -96,7 +96,7 @@ parameters:
 			path: src/DependencyInjection/SentryExtension.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function array_filter expects \\(callable\\(mixed\\)\\: mixed\\)\\|null, Closure\\(string\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#2 \\$callback of function array_filter expects \\(callable\\(mixed\\)\\: bool\\)\\|null, Closure\\(string\\)\\: bool given\\.$#"
 			count: 1
 			path: src/DependencyInjection/SentryExtension.php
 


### PR DESCRIPTION
As per title, after a recent update of PHPStan, the error message does not match anymore the one of the baseline, leading the build to fail.