### PR TITLE
Change the way the Doctrine tracing middleware is registered in DBAL `>=3.x`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     },
     "require-dev": {
         "doctrine/dbal": "^2.13||^3.0",
-        "doctrine/doctrine-bundle": "^1.12||^2.5",
+        "doctrine/doctrine-bundle": "^2.6",
         "friendsofphp/php-cs-fixer": "^2.19||^3.40",
         "masterminds/html5": "^2.8",
         "phpstan/extension-installer": "^1.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,11 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$arrays of function array_merge expects array, mixed given\\.$#"
-			count: 1
-			path: src/DependencyInjection/Compiler/DbalTracingPass.php
-
-		-
 			message: "#^Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\TreeBuilder\\:\\:root\\(\\)\\.$#"
 			count: 1
 			path: src/DependencyInjection/Configuration.php

--- a/src/DependencyInjection/Compiler/DbalTracingPass.php
+++ b/src/DependencyInjection/Compiler/DbalTracingPass.php
@@ -9,7 +9,6 @@ use Sentry\SentryBundle\Tracing\Doctrine\DBAL\ConnectionConfigurator;
 use Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverMiddleware;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
 final class DbalTracingPass implements CompilerPassInterface
@@ -19,12 +18,6 @@ final class DbalTracingPass implements CompilerPassInterface
      * services for each connection.
      */
     private const CONNECTION_SERVICE_NAME_FORMAT = 'doctrine.dbal.%s_connection';
-
-    /**
-     * This is the format used by the DoctrineBundle bundle to register the
-     * services for each connection's configuration.
-     */
-    private const CONNECTION_CONFIG_SERVICE_NAME_FORMAT = 'doctrine.dbal.%s_connection.configuration';
 
     /**
      * {@inheritdoc}
@@ -66,33 +59,14 @@ final class DbalTracingPass implements CompilerPassInterface
 
     private function configureConnectionForDoctrineDBALVersion3(ContainerBuilder $container, string $connectionName): void
     {
-        $configurationDefinition = $container->getDefinition(sprintf(self::CONNECTION_CONFIG_SERVICE_NAME_FORMAT, $connectionName));
-        $setMiddlewaresMethodCallArguments = $this->getSetMiddlewaresMethodCallArguments($configurationDefinition);
-        $setMiddlewaresMethodCallArguments[0] = array_merge($setMiddlewaresMethodCallArguments[0] ?? [], [new Reference(TracingDriverMiddleware::class)]);
-
-        $configurationDefinition
-            ->removeMethodCall('setMiddlewares')
-            ->addMethodCall('setMiddlewares', $setMiddlewaresMethodCallArguments);
+        $tracingMiddlewareDefinition = $container->getDefinition(TracingDriverMiddleware::class);
+        $tracingMiddlewareDefinition->addTag('doctrine.middleware', ['connection' => $connectionName]);
     }
 
     private function configureConnectionForDoctrineDBALVersion2(ContainerBuilder $container, string $connectionName): void
     {
         $connectionDefinition = $container->getDefinition(sprintf(self::CONNECTION_SERVICE_NAME_FORMAT, $connectionName));
         $connectionDefinition->setConfigurator([new Reference(ConnectionConfigurator::class), 'configure']);
-    }
-
-    /**
-     * @return mixed[]
-     */
-    private function getSetMiddlewaresMethodCallArguments(Definition $definition): array
-    {
-        foreach ($definition->getMethodCalls() as $methodCall) {
-            if ('setMiddlewares' === $methodCall[0]) {
-                return $methodCall[1];
-            }
-        }
-
-        return [];
     }
 
     private function assertRequiredDbalVersion(): void

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -106,6 +106,7 @@
             <argument type="service" id="Sentry\State\HubInterface" />
         </service>
 
+        <!-- TODO: make this service abstract (see DoctrineBundle MiddlewarePass) when DBAL 2.x support is dropped -->
         <service id="Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverMiddleware" class="Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverMiddleware">
             <argument type="service" id="Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingDriverConnectionFactoryInterface" />
         </service>

--- a/src/SentryBundle.php
+++ b/src/SentryBundle.php
@@ -8,6 +8,7 @@ use Sentry\SentryBundle\DependencyInjection\Compiler\AddLoginListenerTagPass;
 use Sentry\SentryBundle\DependencyInjection\Compiler\CacheTracingPass;
 use Sentry\SentryBundle\DependencyInjection\Compiler\DbalTracingPass;
 use Sentry\SentryBundle\DependencyInjection\Compiler\HttpClientTracingPass;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -21,7 +22,7 @@ final class SentryBundle extends Bundle
     {
         parent::build($container);
 
-        $container->addCompilerPass(new DbalTracingPass());
+        $container->addCompilerPass(new DbalTracingPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 10);
         $container->addCompilerPass(new CacheTracingPass());
         $container->addCompilerPass(new HttpClientTracingPass());
         $container->addCompilerPass(new AddLoginListenerTagPass());


### PR DESCRIPTION
Fixes #805. The problem that was reported is that the `MiddlewarePass` compiler pass in `DoctrineBundle` [adds](https://github.com/doctrine/DoctrineBundle/blob/fb22c9320383caa2829c32dc3b84c1b5e0f1ceaf/DependencyInjection/Compiler/MiddlewaresPass.php#L81-L83) a new call to `setMiddlewares()`, which means that all the middlewares added before get lost. Technically speaking, if you load `SentryBundle` after `DoctrineBundle`, it works as expected, because our code appends our middleware to the existing list instead of replacing it entirely. However, as noted by @fridtjof, a better integration approach is to tag our middleware as `doctrine.middleware` and let the Doctrine bundle do all the rest of the work to properly configure the connection.