### PR TITLE
Use AbstractDriverMiddleware class instead of own implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "symfony/security-http": "^4.4.20||^5.0.11||^6.0||^7.0"
     },
     "require-dev": {
-        "doctrine/dbal": "^2.13||^3.0",
+        "doctrine/dbal": "^2.13||^3.3",
         "doctrine/doctrine-bundle": "^2.6",
         "friendsofphp/php-cs-fixer": "^2.19||^3.40",
         "masterminds/html5": "^2.8",

--- a/src/Tracing/Doctrine/DBAL/TracingDriverForV3.php
+++ b/src/Tracing/Doctrine/DBAL/TracingDriverForV3.php
@@ -6,10 +6,7 @@ namespace Sentry\SentryBundle\Tracing\Doctrine\DBAL;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
-use Doctrine\DBAL\Driver\API\ExceptionConverter;
-use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Schema\AbstractSchemaManager;
-use Doctrine\DBAL\VersionAwarePlatformDriver;
+use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
 
 /**
  * This is a simple implementation of the {@see Driver} interface that decorates
@@ -20,17 +17,12 @@ use Doctrine\DBAL\VersionAwarePlatformDriver;
  *
  * @phpstan-import-type Params from \Doctrine\DBAL\DriverManager as ConnectionParams
  */
-final class TracingDriverForV3 implements Driver, VersionAwarePlatformDriver
+final class TracingDriverForV3 extends AbstractDriverMiddleware
 {
     /**
      * @var TracingDriverConnectionFactoryInterface The connection factory
      */
     private $connectionFactory;
-
-    /**
-     * @var Driver|VersionAwarePlatformDriver The instance of the decorated driver
-     */
-    private $decoratedDriver;
 
     /**
      * Constructor.
@@ -40,8 +32,8 @@ final class TracingDriverForV3 implements Driver, VersionAwarePlatformDriver
      */
     public function __construct(TracingDriverConnectionFactoryInterface $connectionFactory, Driver $decoratedDriver)
     {
+        parent::__construct($decoratedDriver);
         $this->connectionFactory = $connectionFactory;
-        $this->decoratedDriver = $decoratedDriver;
     }
 
     /**
@@ -52,51 +44,9 @@ final class TracingDriverForV3 implements Driver, VersionAwarePlatformDriver
     public function connect(array $params): TracingDriverConnectionInterface
     {
         return $this->connectionFactory->create(
-            $this->decoratedDriver->connect($params),
-            $this->decoratedDriver->getDatabasePlatform(),
+            parent::connect($params),
+            $this->getDatabasePlatform(),
             $params
         );
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getDatabasePlatform(): AbstractPlatform
-    {
-        return $this->decoratedDriver->getDatabasePlatform();
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @phpstan-template T of AbstractPlatform
-     *
-     * @phpstan-param T $platform
-     *
-     * @phpstan-return AbstractSchemaManager<T>
-     */
-    public function getSchemaManager(Connection $conn, AbstractPlatform $platform): AbstractSchemaManager
-    {
-        return $this->decoratedDriver->getSchemaManager($conn, $platform);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getExceptionConverter(): ExceptionConverter
-    {
-        return $this->decoratedDriver->getExceptionConverter();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function createDatabasePlatformForVersion($version): AbstractPlatform
-    {
-        if ($this->decoratedDriver instanceof VersionAwarePlatformDriver) {
-            return $this->decoratedDriver->createDatabasePlatformForVersion($version);
-        }
-
-        return $this->getDatabasePlatform();
     }
 }

--- a/src/Tracing/Doctrine/DBAL/TracingDriverForV3.php
+++ b/src/Tracing/Doctrine/DBAL/TracingDriverForV3.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Sentry\SentryBundle\Tracing\Doctrine\DBAL;
 
-use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
 
@@ -33,6 +32,7 @@ final class TracingDriverForV3 extends AbstractDriverMiddleware
     public function __construct(TracingDriverConnectionFactoryInterface $connectionFactory, Driver $decoratedDriver)
     {
         parent::__construct($decoratedDriver);
+
         $this->connectionFactory = $connectionFactory;
     }
 


### PR DESCRIPTION
Use AbstractDriverMiddleware class instead of own implementation, by reusing common abstract class it's possible to unwind wrappedDriver.

I have a case https://github.com/DamienHarper/auditor/issues/184 when auditor & sentry don't play well.

- While working on fix noticed that sentry does not utilize AbstractDriverMiddleware and implements everything.
- Also it's impossible to detect if driver was wrapped.