### PR TITLE
fix TraceableResponseForV4::getInfo  to be compatible with symfony-contracts in symfony-sentry 5.0.0

### DIFF
--- a/src/Tracing/HttpClient/TraceableResponseForV4.php
+++ b/src/Tracing/HttpClient/TraceableResponseForV4.php
@@ -12,7 +12,7 @@ final class TraceableResponseForV4 extends AbstractTraceableResponse
     /**
      * {@inheritdoc}
      */
-    public function getInfo(string $type = null)
+    public function getInfo(string $type = null): mixed
     {
         return $this->response->getInfo($type);
     }


### PR DESCRIPTION
Hi!
I found this issue https://github.com/getsentry/sentry-symfony/issues/834 about a wrong signature in method `getInfo`
on `Sentry\SentryBundle\Tracing\HttpClient\TraceableResponseForV4` using version 5.0.0.

Here you can see the change to make compatible the method.

I hope that it will help, let me know if you need any update