### PR TITLE
Send span origin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": "^7.2||^8.0",
         "guzzlehttp/psr7": "^2.1.1",
         "jean85/pretty-package-versions": "^1.5||^2.0",
-        "sentry/sentry": "^4.6.1",
+        "sentry/sentry": "^4.9.0",
         "symfony/cache-contracts": "^1.1||^2.4||^3.0",
         "symfony/config": "^4.4.20||^5.0.11||^6.0||^7.0",
         "symfony/console": "^4.4.20||^5.0.11||^6.0||^7.0",

--- a/src/EventListener/TracingConsoleListener.php
+++ b/src/EventListener/TracingConsoleListener.php
@@ -69,7 +69,8 @@ final class TracingConsoleListener
         } else {
             $span = $currentSpan->startChild(
                 SpanContext::make()
-                    ->setOp('console.console')
+                    ->setOp('console.command')
+                    ->setOrigin('auto.console')
                     ->setDescription($this->getSpanName($command))
             );
         }

--- a/src/EventListener/TracingConsoleListener.php
+++ b/src/EventListener/TracingConsoleListener.php
@@ -59,18 +59,19 @@ final class TracingConsoleListener
         $currentSpan = $this->hub->getSpan();
 
         if (null === $currentSpan) {
-            $transactionContext = new TransactionContext();
-            $transactionContext->setOp('console.command');
-            $transactionContext->setName($this->getSpanName($command));
-            $transactionContext->setSource(TransactionSource::task());
-
-            $span = $this->hub->startTransaction($transactionContext);
+            $span = $this->hub->startTransaction(
+                TransactionContext::make()
+                    ->setOp('console.command')
+                    ->setOrigin('auto.console')
+                    ->setName($this->getSpanName($command))
+                    ->setSource(TransactionSource::task())
+            );
         } else {
-            $spanContext = new SpanContext();
-            $spanContext->setOp('console.command');
-            $spanContext->setDescription($this->getSpanName($command));
-
-            $span = $currentSpan->startChild($spanContext);
+            $span = $currentSpan->startChild(
+                SpanContext::make()
+                    ->setOp('console.console')
+                    ->setDescription($this->getSpanName($command))
+            );
         }
 
         $this->hub->setSpan($span);

--- a/src/EventListener/TracingRequestListener.php
+++ b/src/EventListener/TracingRequestListener.php
@@ -42,7 +42,9 @@ final class TracingRequestListener extends AbstractTracingRequestListener
             $request->headers->get('sentry-trace') ?? $request->headers->get('traceparent', ''),
             $request->headers->get('baggage', '')
         );
+
         $context->setOp('http.server');
+        $context->setOrigin('auto.http.server');
 
         $routeName = $request->attributes->get('_route');
         if (null !== $routeName && \is_string($routeName)) {

--- a/src/EventListener/TracingSubRequestListener.php
+++ b/src/EventListener/TracingSubRequestListener.php
@@ -34,16 +34,19 @@ final class TracingSubRequestListener extends AbstractTracingRequestListener
             return;
         }
 
-        $spanContext = new SpanContext();
-        $spanContext->setOp('http.server');
-        $spanContext->setDescription(\sprintf('%s %s%s%s', $request->getMethod(), $request->getSchemeAndHttpHost(), $request->getBaseUrl(), $request->getPathInfo()));
-        $spanContext->setData([
-            'http.request.method' => $request->getMethod(),
-            'http.url' => $request->getUri(),
-            'route' => $this->getRouteName($request),
-        ]);
-
-        $this->hub->setSpan($span->startChild($spanContext));
+        $this->hub->setSpan(
+            $span->startChild(
+                SpanContext::make()
+                    ->setOp('http.server')
+                    ->setData([
+                        'http.request.method' => $request->getMethod(),
+                        'http.url' => $request->getUri(),
+                        'route' => $this->getRouteName($request),
+                    ])
+                    ->setOrigin('auto.http.server')
+                    ->setDescription(\sprintf('%s %s%s%s', $request->getMethod(), $request->getSchemeAndHttpHost(), $request->getBaseUrl(), $request->getPathInfo()))
+            )
+        );
     }
 
     /**

--- a/src/Tracing/Cache/TraceableCacheAdapterTrait.php
+++ b/src/Tracing/Cache/TraceableCacheAdapterTrait.php
@@ -173,8 +173,10 @@ trait TraceableCacheAdapterTrait
         $span = $this->hub->getSpan();
 
         if (null !== $span) {
-            $spanContext = new SpanContext();
-            $spanContext->setOp($spanOperation);
+            $spanContext = SpanContext::make()
+                ->setOp($spanOperation)
+                ->setOrigin('auto.cache');
+
             if (null !== $spanDescription) {
                 $spanContext->setDescription(urldecode($spanDescription));
             }

--- a/src/Tracing/Doctrine/DBAL/TracingDriverConnectionForV2V3.php
+++ b/src/Tracing/Doctrine/DBAL/TracingDriverConnectionForV2V3.php
@@ -223,12 +223,13 @@ final class TracingDriverConnectionForV2V3 implements TracingDriverConnectionInt
         $span = $this->hub->getSpan();
 
         if (null !== $span) {
-            $spanContext = new SpanContext();
-            $spanContext->setOp($spanOperation);
-            $spanContext->setDescription($spanDescription);
-            $spanContext->setData($this->spanData);
-
-            $span = $span->startChild($spanContext);
+            $span = $span->startChild(
+                SpanContext::make()
+                    ->setOp($spanOperation)
+                    ->setData($this->spanData)
+                    ->setOrigin('auto.db')
+                    ->setDescription($spanDescription)
+            );
         }
 
         try {

--- a/src/Tracing/Doctrine/DBAL/TracingDriverConnectionForV4.php
+++ b/src/Tracing/Doctrine/DBAL/TracingDriverConnectionForV4.php
@@ -221,12 +221,13 @@ final class TracingDriverConnectionForV4 implements TracingDriverConnectionInter
         $span = $this->hub->getSpan();
 
         if (null !== $span) {
-            $spanContext = new SpanContext();
-            $spanContext->setOp($spanOperation);
-            $spanContext->setDescription($spanDescription);
-            $spanContext->setData($this->spanData);
-
-            $span = $span->startChild($spanContext);
+            $span = $span->startChild(
+                SpanContext::make()
+                    ->setOp($spanOperation)
+                    ->setData($this->spanData)
+                    ->setOrigin('auto.db')
+                    ->setDescription($spanDescription)
+            );
         }
 
         try {

--- a/src/Tracing/Doctrine/DBAL/TracingStatementForV2.php
+++ b/src/Tracing/Doctrine/DBAL/TracingStatementForV2.php
@@ -116,10 +116,11 @@ final class TracingStatementForV2 extends AbstractTracingStatement implements \I
      */
     public function execute($params = null): bool
     {
-        $spanContext = new SpanContext();
-        $spanContext->setOp(self::SPAN_OP_STMT_EXECUTE);
-        $spanContext->setDescription($this->sqlQuery);
-        $spanContext->setData($this->spanData);
+        $spanContext = SpanContext::make()
+            ->setOp(self::SPAN_OP_STMT_EXECUTE)
+            ->setData($this->spanData)
+            ->setOrigin('auto.db')
+            ->setDescription($this->sqlQuery);
 
         return $this->traceFunction($spanContext, [$this->decoratedStatement, 'execute'], $params);
     }

--- a/src/Tracing/Doctrine/DBAL/TracingStatementForV3.php
+++ b/src/Tracing/Doctrine/DBAL/TracingStatementForV3.php
@@ -35,10 +35,11 @@ final class TracingStatementForV3 extends AbstractTracingStatement implements St
      */
     public function execute($params = null): Result
     {
-        $spanContext = new SpanContext();
-        $spanContext->setOp(self::SPAN_OP_STMT_EXECUTE);
-        $spanContext->setDescription($this->sqlQuery);
-        $spanContext->setData($this->spanData);
+        $spanContext = SpanContext::make()
+            ->setOp(self::SPAN_OP_STMT_EXECUTE)
+            ->setData($this->spanData)
+            ->setOrigin('auto.db')
+            ->setDescription($this->sqlQuery);
 
         return $this->traceFunction($spanContext, [$this->decoratedStatement, 'execute'], $params);
     }

--- a/src/Tracing/Doctrine/DBAL/TracingStatementForV4.php
+++ b/src/Tracing/Doctrine/DBAL/TracingStatementForV4.php
@@ -27,10 +27,11 @@ final class TracingStatementForV4 extends AbstractTracingStatement implements St
      */
     public function execute(): Result
     {
-        $spanContext = new SpanContext();
-        $spanContext->setOp(self::SPAN_OP_STMT_EXECUTE);
-        $spanContext->setDescription($this->sqlQuery);
-        $spanContext->setData($this->spanData);
+        $spanContext = SpanContext::make()
+            ->setOp(self::SPAN_OP_STMT_EXECUTE)
+            ->setData($this->spanData)
+            ->setOrigin('auto.db')
+            ->setDescription($this->sqlQuery);
 
         return $this->traceFunction($spanContext, [$this->decoratedStatement, 'execute']);
     }

--- a/src/Tracing/HttpClient/AbstractTraceableHttpClient.php
+++ b/src/Tracing/HttpClient/AbstractTraceableHttpClient.php
@@ -74,9 +74,10 @@ abstract class AbstractTraceableHttpClient implements HttpClientInterface, Reset
             'path' => $uri->getPath(),
         ]);
 
-        $context = new SpanContext();
-        $context->setOp('http.client');
-        $context->setDescription($method . ' ' . (string) $partialUri);
+        $context = SpanContext::make()
+            ->setOp('http.client')
+            ->setOrigin('auto.http.client')
+            ->setDescription($method . ' ' . (string) $partialUri);
 
         $contextData = [
             'http.url' => (string) $partialUri,

--- a/src/Tracing/Twig/TwigTracingExtension.php
+++ b/src/Tracing/Twig/TwigTracingExtension.php
@@ -46,11 +46,12 @@ final class TwigTracingExtension extends AbstractExtension
             return;
         }
 
-        $spanContext = new SpanContext();
-        $spanContext->setOp('view.render');
-        $spanContext->setDescription($this->getSpanDescription($profile));
-
-        $this->spans[$profile] = $transaction->startChild($spanContext);
+        $this->spans[$profile] = $transaction->startChild(
+            SpanContext::make()
+                ->setOp('view.render')
+                ->setOrigin('auto.view')
+                ->setDescription($this->getSpanDescription($profile))
+        );
     }
 
     /**

--- a/tests/End2End/App/Messenger/FooMessageHandler.php
+++ b/tests/End2End/App/Messenger/FooMessageHandler.php
@@ -11,7 +11,7 @@ class FooMessageHandler
     public function __invoke(FooMessage $message): void
     {
         if (!$message->shouldRetry()) {
-            throw new class() extends \Exception implements UnrecoverableExceptionInterface { };
+            throw new class extends \Exception implements UnrecoverableExceptionInterface { };
         }
 
         throw new \Exception('This is an intentional failure while handling a message of class ' . \get_class($message));

--- a/tests/EventListener/LoginListenerTest.php
+++ b/tests/EventListener/LoginListenerTest.php
@@ -275,7 +275,7 @@ final class LoginListenerTest extends TestCase
 
         if (version_compare(Kernel::VERSION, '5.0', '<')) {
             yield 'If the user is an object implementing the Stringable interface, then the __toString() method is invoked' => [
-                new LegacyAuthenticatedTokenStub(new class() implements \Stringable {
+                new LegacyAuthenticatedTokenStub(new class implements \Stringable {
                     public function __toString(): string
                     {
                         return 'foo_user';
@@ -286,7 +286,7 @@ final class LoginListenerTest extends TestCase
             ];
         } else {
             yield 'If the user is an object implementing the Stringable interface, then the __toString() method is invoked' => [
-                new AuthenticatedTokenStub(new class() implements \Stringable {
+                new AuthenticatedTokenStub(new class implements \Stringable {
                     public function __toString(): string
                     {
                         return 'foo_user';

--- a/tests/EventListener/TracingConsoleListenerTest.php
+++ b/tests/EventListener/TracingConsoleListenerTest.php
@@ -71,6 +71,7 @@ final class TracingConsoleListenerTest extends TestCase
         $transactionContext = new TransactionContext();
         $transactionContext->setOp('console.command');
         $transactionContext->setName('<unnamed command>');
+        $transactionContext->setOrigin('auto.console');
         $transactionContext->setSource(TransactionSource::task());
 
         yield [
@@ -81,6 +82,7 @@ final class TracingConsoleListenerTest extends TestCase
         $transactionContext = new TransactionContext();
         $transactionContext->setOp('console.command');
         $transactionContext->setName('app:command');
+        $transactionContext->setOrigin('auto.console');
         $transactionContext->setSource(TransactionSource::task());
 
         yield [

--- a/tests/EventListener/TracingRequestListenerTest.php
+++ b/tests/EventListener/TracingRequestListenerTest.php
@@ -347,7 +347,7 @@ final class TracingRequestListenerTest extends TestCase
 
         $request = Request::create('http://www.example.com/');
         $request->server->set('REQUEST_TIME_FLOAT', 1613493597.010275);
-        $request->attributes->set('_controller', [new class() {}, 'indexAction']);
+        $request->attributes->set('_controller', [new class {}, 'indexAction']);
 
         $transactionContext = new TransactionContext();
         $transactionContext->setName('GET http://www.example.com/');

--- a/tests/EventListener/TracingRequestListenerTest.php
+++ b/tests/EventListener/TracingRequestListenerTest.php
@@ -97,6 +97,7 @@ final class TracingRequestListenerTest extends TestCase
         $transactionContext->setName('GET http://www.example.com/');
         $transactionContext->setSource(TransactionSource::url());
         $transactionContext->setOp('http.server');
+        $transactionContext->setOrigin('auto.http.server');
         $transactionContext->setStartTimestamp(1613493597.010275);
         $transactionContext->setData([
             'net.host.port' => '80',
@@ -134,6 +135,7 @@ final class TracingRequestListenerTest extends TestCase
         $transactionContext->setName('GET http://www.example.com/');
         $transactionContext->setSource(TransactionSource::url());
         $transactionContext->setOp('http.server');
+        $transactionContext->setOrigin('auto.http.server');
         $transactionContext->setStartTimestamp(1613493597.010275);
         $transactionContext->setData([
             'net.host.port' => '80',
@@ -171,6 +173,7 @@ final class TracingRequestListenerTest extends TestCase
         $transactionContext->setName('GET http://www.example.com/');
         $transactionContext->setSource(TransactionSource::url());
         $transactionContext->setOp('http.server');
+        $transactionContext->setOrigin('auto.http.server');
         $transactionContext->setStartTimestamp(1613493597.010275);
         $transactionContext->setData([
             'net.host.port' => '80',
@@ -203,6 +206,7 @@ final class TracingRequestListenerTest extends TestCase
         $transactionContext->setName('GET http://www.example.com/');
         $transactionContext->setSource(TransactionSource::url());
         $transactionContext->setOp('http.server');
+        $transactionContext->setOrigin('auto.http.server');
         $transactionContext->setStartTimestamp(1613493597.010275);
         $transactionContext->setData([
             'net.host.port' => '80',
@@ -226,6 +230,7 @@ final class TracingRequestListenerTest extends TestCase
         $transactionContext->setName('GET http://127.0.0.1/');
         $transactionContext->setSource(TransactionSource::url());
         $transactionContext->setOp('http.server');
+        $transactionContext->setOrigin('auto.http.server');
         $transactionContext->setStartTimestamp(1613493597.010275);
         $transactionContext->setData([
             'net.host.port' => '80',
@@ -257,6 +262,7 @@ final class TracingRequestListenerTest extends TestCase
         $transactionContext->setName('GET app_homepage');
         $transactionContext->setSource(TransactionSource::route());
         $transactionContext->setOp('http.server');
+        $transactionContext->setOrigin('auto.http.server');
         $transactionContext->setStartTimestamp(1613493597.010275);
         $transactionContext->setData([
             'net.host.port' => '80',
@@ -281,6 +287,7 @@ final class TracingRequestListenerTest extends TestCase
         $transactionContext->setName('GET http://www.example.com/path');
         $transactionContext->setSource(TransactionSource::url());
         $transactionContext->setOp('http.server');
+        $transactionContext->setOrigin('auto.http.server');
         $transactionContext->setStartTimestamp(1613493597.010275);
         $transactionContext->setData([
             'net.host.port' => '80',
@@ -305,6 +312,7 @@ final class TracingRequestListenerTest extends TestCase
         $transactionContext->setName('GET http://www.example.com/');
         $transactionContext->setSource(TransactionSource::url());
         $transactionContext->setOp('http.server');
+        $transactionContext->setOrigin('auto.http.server');
         $transactionContext->setStartTimestamp(1613493597.010275);
         $transactionContext->setData([
             'net.host.port' => '80',
@@ -329,6 +337,7 @@ final class TracingRequestListenerTest extends TestCase
         $transactionContext->setName('GET http://www.example.com/');
         $transactionContext->setSource(TransactionSource::url());
         $transactionContext->setOp('http.server');
+        $transactionContext->setOrigin('auto.http.server');
         $transactionContext->setStartTimestamp(1613493597.010275);
         $transactionContext->setData([
             'net.host.port' => '80',
@@ -353,6 +362,7 @@ final class TracingRequestListenerTest extends TestCase
         $transactionContext->setName('GET http://www.example.com/');
         $transactionContext->setSource(TransactionSource::url());
         $transactionContext->setOp('http.server');
+        $transactionContext->setOrigin('auto.http.server');
         $transactionContext->setStartTimestamp(1613493597.010275);
         $transactionContext->setData([
             'net.host.port' => '80',
@@ -377,6 +387,7 @@ final class TracingRequestListenerTest extends TestCase
         $transactionContext->setName('GET http://www.example.com/');
         $transactionContext->setSource(TransactionSource::url());
         $transactionContext->setOp('http.server');
+        $transactionContext->setOrigin('auto.http.server');
         $transactionContext->setStartTimestamp(1613493597.010275);
         $transactionContext->setData([
             'net.host.port' => '80',
@@ -401,6 +412,7 @@ final class TracingRequestListenerTest extends TestCase
         $transactionContext->setName('GET http://www.example.com/');
         $transactionContext->setSource(TransactionSource::url());
         $transactionContext->setOp('http.server');
+        $transactionContext->setOrigin('auto.http.server');
         $transactionContext->setStartTimestamp(1613493597.010275);
         $transactionContext->setData([
             'net.host.port' => '80',
@@ -425,6 +437,7 @@ final class TracingRequestListenerTest extends TestCase
         $transactionContext->setName('GET http://:/');
         $transactionContext->setSource(TransactionSource::url());
         $transactionContext->setOp('http.server');
+        $transactionContext->setOrigin('auto.http.server');
         $transactionContext->setStartTimestamp(1613493597.010275);
         $transactionContext->setData([
             'net.host.port' => '',

--- a/tests/EventListener/TracingSubRequestListenerTest.php
+++ b/tests/EventListener/TracingSubRequestListenerTest.php
@@ -104,7 +104,7 @@ final class TracingSubRequestListenerTest extends TestCase
         ];
 
         $request = Request::create('http://www.example.com/');
-        $request->attributes->set('_controller', [new class() {}, 'indexAction']);
+        $request->attributes->set('_controller', [new class {}, 'indexAction']);
 
         $span = new Span();
         $span->setOp('http.server');

--- a/tests/Integration/IntegrationConfiguratorTest.php
+++ b/tests/Integration/IntegrationConfiguratorTest.php
@@ -50,7 +50,7 @@ final class IntegrationConfiguratorTest extends TestCase
         $environmentIntegration = new EnvironmentIntegration();
         $modulesIntegration = new ModulesIntegration();
 
-        $userIntegration1 = new class() implements IntegrationInterface {
+        $userIntegration1 = new class implements IntegrationInterface {
             public function setupOnce(): void
             {
             }

--- a/tests/Tracing/Doctrine/DBAL/TracingDriverConnectionForV2V3Test.php
+++ b/tests/Tracing/Doctrine/DBAL/TracingDriverConnectionForV2V3Test.php
@@ -418,7 +418,7 @@ final class TracingDriverConnectionForV2V3Test extends DoctrineTestCase
 
     public function testGetNativeConnection(): void
     {
-        $nativeConnection = new class() {
+        $nativeConnection = new class {
         };
 
         $decoratedConnection = $this->createMock(NativeDriverConnectionInterfaceStub::class);

--- a/tests/Tracing/Doctrine/DBAL/TracingDriverConnectionForV4Test.php
+++ b/tests/Tracing/Doctrine/DBAL/TracingDriverConnectionForV4Test.php
@@ -412,7 +412,7 @@ final class TracingDriverConnectionForV4Test extends DoctrineTestCase
 
     public function testGetNativeConnection(): void
     {
-        $nativeConnection = new class() {
+        $nativeConnection = new class {
         };
 
         $decoratedConnection = $this->createMock(NativeDriverConnectionInterfaceStub::class);

--- a/tests/Tracing/Doctrine/DBAL/TracingServerInfoAwareDriverConnectionTest.php
+++ b/tests/Tracing/Doctrine/DBAL/TracingServerInfoAwareDriverConnectionTest.php
@@ -264,7 +264,7 @@ final class TracingServerInfoAwareDriverConnectionTest extends DoctrineTestCase
 
     public function testGetNativeConnection(): void
     {
-        $nativeConnection = new class() {
+        $nativeConnection = new class {
         };
 
         $decoratedConnection = $this->createMock(NativeDriverConnectionInterfaceStub::class);

--- a/tests/Tracing/Doctrine/DBAL/TracingStatementForV3Test.php
+++ b/tests/Tracing/Doctrine/DBAL/TracingStatementForV3Test.php
@@ -70,7 +70,7 @@ final class TracingStatementForV3Test extends DoctrineTestCase
     public function testBindParamForwardsLengthParamOnlyWhenExplicitlySet(): void
     {
         $variable = 'bar';
-        $decoratedStatement = new class() implements Statement {
+        $decoratedStatement = new class implements Statement {
             /**
              * @var int
              */


### PR DESCRIPTION
- Bumps SDK requirement for getsentry/sentry-php#1566
- Add span origins to all SDK generated spans
- Refactor context creation where possible to use `Context::make()` to cleanup code
- Applied CS fixes needed because updates to php-cs-fixer (CS commit)

Fixes #745