### PR TITLE
Flush metrics on console termination

### DIFF
--- a/src/EventListener/TracingConsoleListener.php
+++ b/src/EventListener/TracingConsoleListener.php
@@ -14,6 +14,8 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 
+use function Sentry\metrics;
+
 /**
  * This listener either starts a {@see Transaction} or a child {@see Span} when
  * a console command is executed to allow measuring the application performances.
@@ -86,6 +88,8 @@ final class TracingConsoleListener
      */
     public function handleConsoleTerminateEvent(ConsoleTerminateEvent $event): void
     {
+        metrics()->flush();
+
         if ($this->isCommandExcluded($event->getCommand())) {
             return;
         }


### PR DESCRIPTION
This PR addresses the issue where metrics were not being flushed to Sentry when queued from a console command.

I’d appreciate any guidance on whether this is actually the optimal location for flushing the metrics. I followed the existing logic of [`TracingRequestListener`](https://github.com/getsentry/sentry-symfony/blob/aa42014be3fa91febe46eca62e5eff3eada857af/src/EventListener/TracingRequestListener.php#L79), but I’m not convinced that tying metrics collection so closely to tracing (which feels like a different feature, even in the Sentry UI) is the best approach.

Ideally, I believe separate listeners for both request and console events would be more flexible, allowing metrics collection even if built-in tracing is disabled. However, implementing that would go beyond the scope of this PR.