### PR TITLE
Allow `logger` to be a service reference

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -171,6 +171,21 @@ parameters:
 			path: src/EventListener/LoginListener.php
 
 		-
+			message: "#^Instanceof between Throwable and Symfony\\\\Component\\\\Messenger\\\\Exception\\\\DelayedMessageHandlingException will always evaluate to false\\.$#"
+			count: 1
+			path: src/EventListener/MessengerListener.php
+
+		-
+			message: "#^Instanceof between Throwable and Symfony\\\\Component\\\\Messenger\\\\Exception\\\\HandlerFailedException will always evaluate to false\\.$#"
+			count: 1
+			path: src/EventListener/MessengerListener.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 2
+			path: src/EventListener/MessengerListener.php
+
+		-
 			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpKernel\\\\Event\\\\KernelEvent\\:\\:isMasterRequest\\(\\)\\.$#"
 			count: 1
 			path: src/EventListener/RequestListener.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -71,6 +71,11 @@ parameters:
 			path: src/DependencyInjection/SentryExtension.php
 
 		-
+			message: "#^Cannot access offset 'logger' on mixed\\.$#"
+			count: 1
+			path: src/DependencyInjection/SentryExtension.php
+
+		-
 			message: "#^Cannot access offset 'traces_sampler' on mixed\\.$#"
 			count: 1
 			path: src/DependencyInjection/SentryExtension.php
@@ -92,7 +97,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$id of class Symfony\\\\Component\\\\DependencyInjection\\\\Reference constructor expects string, mixed given\\.$#"
-			count: 9
+			count: 10
 			path: src/DependencyInjection/SentryExtension.php
 
 		-

--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -94,6 +94,10 @@ final class SentryExtension extends ConfigurableExtension
             });
         }
 
+        if (isset($options['logger'])) {
+            $options['logger'] = new Reference($options['logger']);
+        }
+
         if (isset($options['traces_sampler'])) {
             $options['traces_sampler'] = new Reference($options['traces_sampler']);
         }

--- a/tests/DependencyInjection/Fixtures/php/full.php
+++ b/tests/DependencyInjection/Fixtures/php/full.php
@@ -21,7 +21,7 @@ $container->loadFromExtension('sentry', [
         'attach_metric_code_locations' => true,
         'context_lines' => 0,
         'environment' => 'development',
-        'logger' => 'php',
+        'logger' => Sentry\Logger\DebugStdOutLogger::class,
         'spotlight' => true,
         'spotlight_url' => 'http://localhost:8969',
         'release' => '4.0.x-dev',

--- a/tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/tests/DependencyInjection/Fixtures/xml/full.xml
@@ -20,7 +20,7 @@
                         attach-metric-code-locations="true"
                         context-lines="0"
                         environment="development"
-                        logger="php"
+                        logger="Sentry\Logger\DebugStdOutLogger"
                         spotlight="true"
                         spotlight-url="http://localhost:8969"
                         release="4.0.x-dev"

--- a/tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/tests/DependencyInjection/Fixtures/yml/full.yml
@@ -16,7 +16,7 @@ sentry:
         attach_metric_code_locations: true
         context_lines: 0
         environment: development
-        logger: php
+        logger: Sentry\Logger\DebugStdOutLogger
         spotlight: true
         spotlight_url: http://localhost:8969
         release: 4.0.x-dev

--- a/tests/DependencyInjection/SentryExtensionTest.php
+++ b/tests/DependencyInjection/SentryExtensionTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Sentry\SentryBundle\Tests\DependencyInjection;
 
-use Sentry\Logger\DebugStdOutLogger;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Jean85\PrettyVersions;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Sentry\ClientInterface;
+use Sentry\Logger\DebugStdOutLogger;
 use Sentry\Options;
 use Sentry\SentryBundle\DependencyInjection\SentryExtension;
 use Sentry\SentryBundle\EventListener\ConsoleListener;

--- a/tests/DependencyInjection/SentryExtensionTest.php
+++ b/tests/DependencyInjection/SentryExtensionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sentry\SentryBundle\Tests\DependencyInjection;
 
+use Sentry\Logger\DebugStdOutLogger;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Jean85\PrettyVersions;
 use PHPUnit\Framework\TestCase;
@@ -211,7 +212,7 @@ abstract class SentryExtensionTest extends TestCase
             'attach_metric_code_locations' => true,
             'context_lines' => 0,
             'environment' => 'development',
-            'logger' => 'php',
+            'logger' => new Reference(DebugStdOutLogger::class),
             'spotlight' => true,
             'spotlight_url' => 'http://localhost:8969',
             'release' => '4.0.x-dev',

--- a/tests/EventListener/Fixtures/UserWithIdentifierStub.php
+++ b/tests/EventListener/Fixtures/UserWithIdentifierStub.php
@@ -9,20 +9,29 @@ use Symfony\Component\Security\Core\User\UserInterface;
 final class UserWithIdentifierStub implements UserInterface
 {
     /**
-     * @var string
+     * @var non-empty-string
      */
     private $username;
 
+    /**
+     * @param non-empty-string $username
+     */
     public function __construct(string $username = 'foo_user')
     {
         $this->username = $username;
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function getUserIdentifier(): string
     {
         return $this->getUsername();
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function getUsername(): string
     {
         return $this->username;


### PR DESCRIPTION
Fixes #892