### PR TITLE
Allow to install the bundle without Symfony security

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,7 @@
         "symfony/event-dispatcher": "^4.4.20||^5.0.11||^6.0||^7.0",
         "symfony/http-kernel": "^4.4.20||^5.0.11||^6.0||^7.0",
         "symfony/polyfill-php80": "^1.22",
-        "symfony/psr-http-message-bridge": "^1.2||^2.0||^6.4||^7.0",
-        "symfony/security-core": "^4.4.20||^5.0.11||^6.0||^7.0",
-        "symfony/security-http": "^4.4.20||^5.0.11||^6.0||^7.0"
+        "symfony/psr-http-message-bridge": "^1.2||^2.0||^6.4||^7.0"
     },
     "require-dev": {
         "doctrine/dbal": "^2.13||^3.3||^4.0",
@@ -46,6 +44,8 @@
         "symfony/monolog-bundle": "^3.4",
         "symfony/phpunit-bridge": "^5.2.6||^6.0||^7.0",
         "symfony/process": "^4.4.20||^5.0.11||^6.0||^7.0",
+        "symfony/security-core": "^4.4.20||^5.0.11||^6.0||^7.0",
+        "symfony/security-http": "^4.4.20||^5.0.11||^6.0||^7.0",
         "symfony/twig-bundle": "^4.4.20||^5.0.11||^6.0||^7.0",
         "symfony/yaml": "^4.4.20||^5.0.11||^6.0||^7.0",
         "vimeo/psalm": "^4.3||^5.16.0"

--- a/src/DependencyInjection/Compiler/AddLoginListenerTagPass.php
+++ b/src/DependencyInjection/Compiler/AddLoginListenerTagPass.php
@@ -17,9 +17,17 @@ final class AddLoginListenerTagPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container): void
     {
+        if (!$container->hasDefinition(LoginListener::class)) {
+            return;
+        }
         $listenerDefinition = $container->getDefinition(LoginListener::class);
 
-        if (!class_exists(LoginSuccessEvent::class)) {
+        if (class_exists(LoginSuccessEvent::class)) {
+            $listenerDefinition->addTag('kernel.event_listener', [
+                'event' => LoginSuccessEvent::class,
+                'method' => 'handleLoginSuccessEvent',
+            ]);
+        } elseif (class_exists(AuthenticationSuccessEvent::class)) {
             $listenerDefinition->addTag('kernel.event_listener', [
                 'event' => AuthenticationSuccessEvent::class,
                 'method' => 'handleAuthenticationSuccessEvent',

--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -78,7 +78,7 @@ final class SentryExtension extends ConfigurableExtension
         $this->registerCacheTracingConfiguration($container, $mergedConfig['tracing']);
         $this->registerHttpClientTracingConfiguration($container, $mergedConfig['tracing']);
 
-        if (!class_exists(TokenStorageInterface::class)) {
+        if (!interface_exists(TokenStorageInterface::class)) {
             $container->removeDefinition(LoginListener::class);
         }
     }

--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -15,6 +15,7 @@ use Sentry\Integration\RequestIntegration;
 use Sentry\Options;
 use Sentry\SentryBundle\EventListener\ConsoleListener;
 use Sentry\SentryBundle\EventListener\ErrorListener;
+use Sentry\SentryBundle\EventListener\LoginListener;
 use Sentry\SentryBundle\EventListener\MessengerListener;
 use Sentry\SentryBundle\EventListener\TracingConsoleListener;
 use Sentry\SentryBundle\EventListener\TracingRequestListener;
@@ -34,6 +35,7 @@ use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 final class SentryExtension extends ConfigurableExtension
 {
@@ -75,6 +77,10 @@ final class SentryExtension extends ConfigurableExtension
         $this->registerTwigTracingConfiguration($container, $mergedConfig['tracing']);
         $this->registerCacheTracingConfiguration($container, $mergedConfig['tracing']);
         $this->registerHttpClientTracingConfiguration($container, $mergedConfig['tracing']);
+
+        if (!class_exists(TokenStorageInterface::class)) {
+            $container->removeDefinition(LoginListener::class);
+        }
     }
 
     /**

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -83,7 +83,6 @@
             <argument type="service" id="security.token_storage" on-invalid="ignore" />
 
             <tag name="kernel.event_listener" event="kernel.request" method="handleKernelRequestEvent" />
-            <tag name="kernel.event_listener" event="Symfony\Component\Security\Http\Event\LoginSuccessEvent" method="handleLoginSuccessEvent" />
         </service>
 
         <service id="Sentry\SentryBundle\Command\SentryTestCommand" class="Sentry\SentryBundle\Command\SentryTestCommand">

--- a/tests/DependencyInjection/Compiler/AddLoginListenerTagPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddLoginListenerTagPassTest.php
@@ -28,4 +28,20 @@ final class AddLoginListenerTagPassTest extends TestCase
 
         $this->assertSame([['event' => AuthenticationSuccessEvent::class, 'method' => 'handleAuthenticationSuccessEvent']], $listenerDefinition->getTag('kernel.event_listener'));
     }
+
+    public function testProcessLoginSuccess(): void
+    {
+        if (!class_exists(LoginSuccessEvent::class)) {
+            $this->markTestSkipped('Skipping this test because LoginSuccessEvent does not exist.');
+        }
+
+        $container = new ContainerBuilder();
+        $container->register(LoginListener::class)->setPublic(true);
+        $container->addCompilerPass(new AddLoginListenerTagPass());
+        $container->compile();
+
+        $listenerDefinition = $container->getDefinition(LoginListener::class);
+
+        $this->assertSame([['event' => LoginSuccessEvent::class, 'method' => 'handleLoginSuccessEvent']], $listenerDefinition->getTag('kernel.event_listener'));
+    }
 }

--- a/tests/DependencyInjection/SentryExtensionTest.php
+++ b/tests/DependencyInjection/SentryExtensionTest.php
@@ -14,6 +14,7 @@ use Sentry\Options;
 use Sentry\SentryBundle\DependencyInjection\SentryExtension;
 use Sentry\SentryBundle\EventListener\ConsoleListener;
 use Sentry\SentryBundle\EventListener\ErrorListener;
+use Sentry\SentryBundle\EventListener\LoginListener;
 use Sentry\SentryBundle\EventListener\MessengerListener;
 use Sentry\SentryBundle\EventListener\RequestListener;
 use Sentry\SentryBundle\EventListener\SubRequestListener;
@@ -416,6 +417,12 @@ abstract class SentryExtensionTest extends TestCase
         $methodCalls = $factory[0]->getMethodCalls();
 
         $this->assertDefinitionMethodCallAt($methodCalls[3], 'setLogger', [new Reference(NullLogger::class, ContainerBuilder::IGNORE_ON_INVALID_REFERENCE)]);
+    }
+
+    public function testLoginListener(): void
+    {
+        $container = $this->createContainerFromFixture('full');
+        $this->assertTrue($container->hasDefinition(LoginListener::class));
     }
 
     /**


### PR DESCRIPTION
I have a semi small micro service running Symfony. We dont use any security feature (it is a private network). I would love to use this package but I also dont want to install dependencies not needed. 

I saw that the `symfony/security-core` and `symfony/security-http` packages are only used in `LoginListener`. I added check to remove that service if `symfony/security-core` is not installed. I also improved the logic between `src/Resources/config/services.xml` and the compiler pass. 

Merging this will not affect existing users, since they either have `symfony/security-core` required or they are not using it. 

There is one edge case though. Someone installed this package, configure security (without `symfony/security-bundle`) AND did not specify `symfony/security-core` in their composer.json. I find that extremely unlikely but I thought I would mention it. 