### PR TITLE
Fix tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": "^7.2||^8.0",
         "guzzlehttp/psr7": "^2.1.1",
         "jean85/pretty-package-versions": "^1.5||^2.0",
-        "sentry/sentry": "^4.10.0",
+        "sentry/sentry": "^4.11.0",
         "symfony/cache-contracts": "^1.1||^2.4||^3.0",
         "symfony/config": "^4.4.20||^5.0.11||^6.0||^7.0",
         "symfony/console": "^4.4.20||^5.0.11||^6.0||^7.0",

--- a/tests/EventListener/TracingConsoleListenerTest.php
+++ b/tests/EventListener/TracingConsoleListenerTest.php
@@ -44,6 +44,9 @@ final class TracingConsoleListenerTest extends TestCase
         $this->hub->expects($this->once())
             ->method('startTransaction')
             ->with($this->callback(function (TransactionContext $context) use ($expectedTransactionContext): bool {
+                // This value is random when the metadata is constructed, thus we set it to a fixed expected value since we don't care for the value here
+                $context->getMetadata()->setSampleRand(0.1337);
+
                 $this->assertEquals($expectedTransactionContext, $context);
 
                 return true;
@@ -73,6 +76,7 @@ final class TracingConsoleListenerTest extends TestCase
         $transactionContext->setName('<unnamed command>');
         $transactionContext->setOrigin('auto.console');
         $transactionContext->setSource(TransactionSource::task());
+        $transactionContext->getMetadata()->setSampleRand(0.1337);
 
         yield [
             new Command(),
@@ -84,6 +88,7 @@ final class TracingConsoleListenerTest extends TestCase
         $transactionContext->setName('app:command');
         $transactionContext->setOrigin('auto.console');
         $transactionContext->setSource(TransactionSource::task());
+        $transactionContext->getMetadata()->setSampleRand(0.1337);
 
         yield [
             new Command('app:command'),

--- a/tests/EventListener/TracingRequestListenerTest.php
+++ b/tests/EventListener/TracingRequestListenerTest.php
@@ -65,6 +65,9 @@ final class TracingRequestListenerTest extends TestCase
         $this->hub->expects($this->once())
             ->method('startTransaction')
             ->with($this->callback(function (TransactionContext $context) use ($expectedTransactionContext): bool {
+                // This value is random when the metadata is constructed, thus we set it to a fixed expected value since we don't care for the value here
+                $context->getMetadata()->setSampleRand(0.1337);
+
                 $this->assertEquals($expectedTransactionContext, $context);
 
                 return true;
@@ -108,6 +111,7 @@ final class TracingRequestListenerTest extends TestCase
             'net.host.name' => 'www.example.com',
         ]);
         $transactionContext->getMetadata()->setDynamicSamplingContext($samplingContext);
+        $transactionContext->getMetadata()->setSampleRand(0.1337);
 
         yield 'request.headers.sentry-trace EXISTS' => [
             new Options(),
@@ -146,6 +150,7 @@ final class TracingRequestListenerTest extends TestCase
             'net.host.name' => 'www.example.com',
         ]);
         $transactionContext->getMetadata()->setDynamicSamplingContext($samplingContext);
+        $transactionContext->getMetadata()->setSampleRand(0.1337);
 
         yield 'request.headers.traceparent EXISTS' => [
             new Options(),
@@ -184,6 +189,8 @@ final class TracingRequestListenerTest extends TestCase
             'net.host.name' => 'www.example.com',
         ]);
         $transactionContext->getMetadata()->setDynamicSamplingContext($samplingContext);
+        $transactionContext->getMetadata()->setParentSamplingRate(1.0);
+        $transactionContext->getMetadata()->setSampleRand(0.1337);
 
         yield 'request.headers.sentry-trace and headers.baggage EXISTS' => [
             new Options(),
@@ -216,6 +223,7 @@ final class TracingRequestListenerTest extends TestCase
             'route' => '<unknown>',
             'net.host.name' => 'www.example.com',
         ]);
+        $transactionContext->getMetadata()->setSampleRand(0.1337);
 
         $request = Request::create('http://www.example.com');
         $request->server->remove('REQUEST_TIME_FLOAT');
@@ -240,6 +248,7 @@ final class TracingRequestListenerTest extends TestCase
             'route' => '<unknown>',
             'net.host.ip' => '127.0.0.1',
         ]);
+        $transactionContext->getMetadata()->setSampleRand(0.1337);
 
         yield 'request.server.HOST IS IPV4' => [
             new Options(),
@@ -272,6 +281,7 @@ final class TracingRequestListenerTest extends TestCase
             'route' => 'app_homepage',
             'net.host.name' => 'www.example.com',
         ]);
+        $transactionContext->getMetadata()->setSampleRand(0.1337);
 
         yield 'request.attributes.route IS STRING' => [
             new Options(),
@@ -297,6 +307,7 @@ final class TracingRequestListenerTest extends TestCase
             'route' => '/path',
             'net.host.name' => 'www.example.com',
         ]);
+        $transactionContext->getMetadata()->setSampleRand(0.1337);
 
         yield 'request.attributes.route IS INSTANCEOF Symfony\Component\Routing\Route' => [
             new Options(),
@@ -322,6 +333,7 @@ final class TracingRequestListenerTest extends TestCase
             'route' => 'App\\Controller::indexAction',
             'net.host.name' => 'www.example.com',
         ]);
+        $transactionContext->getMetadata()->setSampleRand(0.1337);
 
         yield 'request.attributes._controller IS STRING' => [
             new Options(),
@@ -347,6 +359,7 @@ final class TracingRequestListenerTest extends TestCase
             'route' => 'App\\Controller::indexAction',
             'net.host.name' => 'www.example.com',
         ]);
+        $transactionContext->getMetadata()->setSampleRand(0.1337);
 
         yield 'request.attributes._controller IS CALLABLE (1)' => [
             new Options(),
@@ -372,6 +385,7 @@ final class TracingRequestListenerTest extends TestCase
             'route' => 'class@anonymous::indexAction',
             'net.host.name' => 'www.example.com',
         ]);
+        $transactionContext->getMetadata()->setSampleRand(0.1337);
 
         yield 'request.attributes._controller IS CALLABLE (2)' => [
             new Options(),
@@ -397,6 +411,7 @@ final class TracingRequestListenerTest extends TestCase
             'route' => '<unknown>',
             'net.host.name' => 'www.example.com',
         ]);
+        $transactionContext->getMetadata()->setSampleRand(0.1337);
 
         yield 'request.attributes._controller IS ARRAY and NOT VALID CALLABLE' => [
             new Options(),
@@ -423,6 +438,7 @@ final class TracingRequestListenerTest extends TestCase
             'net.host.name' => 'www.example.com',
             'net.peer.ip' => '127.0.0.1',
         ]);
+        $transactionContext->getMetadata()->setSampleRand(0.1337);
 
         yield 'request.server.REMOTE_ADDR EXISTS and client.options.send_default_pii = TRUE' => [
             new Options(['send_default_pii' => true]),
@@ -446,6 +462,7 @@ final class TracingRequestListenerTest extends TestCase
             'route' => '<unknown>',
             'net.host.name' => '',
         ]);
+        $transactionContext->getMetadata()->setSampleRand(0.1337);
 
         yield 'request.server.SERVER_PROTOCOL NOT EXISTS' => [
             new Options(),

--- a/tests/Tracing/HttpClient/TraceableHttpClientTest.php
+++ b/tests/Tracing/HttpClient/TraceableHttpClientTest.php
@@ -92,9 +92,9 @@ final class TraceableHttpClientTest extends TestCase
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('GET', $response->getInfo('http_method'));
         $this->assertSame('https://username:password@www.example.com/test-page?foo=bar#baz', $response->getInfo('url'));
-        $this->assertSame(['sentry-trace: ' . $spans[1]->toTraceparent()], $mockResponse->getRequestOptions()['normalized_headers']['sentry-trace']);
-        $this->assertSame(['traceparent: ' . $spans[1]->toW3CTraceparent()], $mockResponse->getRequestOptions()['normalized_headers']['traceparent']);
-        $this->assertSame(['baggage: ' . $transaction->toBaggage()], $mockResponse->getRequestOptions()['normalized_headers']['baggage']);
+        $this->assertSame([\sprintf('sentry-trace: %s', $spans[1]->toTraceparent())], $mockResponse->getRequestOptions()['normalized_headers']['sentry-trace']);
+        $this->assertSame([\sprintf('traceparent: %s', $spans[1]->toW3CTraceparent())], $mockResponse->getRequestOptions()['normalized_headers']['traceparent']);
+        $this->assertSame([\sprintf('baggage: %s', $transaction->toBaggage())], $mockResponse->getRequestOptions()['normalized_headers']['baggage']);
         $this->assertNotNull($transaction->getSpanRecorder());
 
         $spans = $transaction->getSpanRecorder()->getSpans();
@@ -199,9 +199,9 @@ final class TraceableHttpClientTest extends TestCase
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('POST', $response->getInfo('http_method'));
         $this->assertSame('https://www.example.com/test-page', $response->getInfo('url'));
-        $this->assertSame(['sentry-trace: 566e3688a61d4bc888951642d6f14a19-566e3688a61d4bc8'], $mockResponse->getRequestOptions()['normalized_headers']['sentry-trace']);
-        $this->assertSame(['traceparent: 00-566e3688a61d4bc888951642d6f14a19-566e3688a61d4bc8-00'], $mockResponse->getRequestOptions()['normalized_headers']['traceparent']);
-        $this->assertSame(['baggage: sentry-trace_id=566e3688a61d4bc888951642d6f14a19,sentry-public_key=public,sentry-release=1.0.0,sentry-environment=test'], $mockResponse->getRequestOptions()['normalized_headers']['baggage']);
+        $this->assertSame([\sprintf('sentry-trace: %s', $propagationContext->toTraceparent())], $mockResponse->getRequestOptions()['normalized_headers']['sentry-trace']);
+        $this->assertSame([\sprintf('traceparent: %s', $propagationContext->toW3CTraceparent())], $mockResponse->getRequestOptions()['normalized_headers']['traceparent']);
+        $this->assertSame([\sprintf('baggage: %s', $propagationContext->toBaggage())], $mockResponse->getRequestOptions()['normalized_headers']['baggage']);
     }
 
     public function testRequestSetsUnknownErrorAsSpanStatusIfResponseStatusCodeIsUnavailable(): void

--- a/tests/Twig/SentryExtensionTest.php
+++ b/tests/Twig/SentryExtensionTest.php
@@ -138,7 +138,7 @@ final class SentryExtensionTest extends TestCase
 
         SentrySdk::setCurrentHub($hub);
 
-        $this->assertSame('<meta name="baggage" content="sentry-trace_id=566e3688a61d4bc888951642d6f14a19,sentry-sample_rate=1,sentry-release=1.0.0,sentry-environment=development" />', $environment->render('foo.twig'));
+        $this->assertSame(\sprintf('<meta name="baggage" content="%s" />', $propagationContext->toBaggage()), $environment->render('foo.twig'));
     }
 
     public function testBaggageMetaFunctionWithActiveSpan(): void
@@ -164,7 +164,7 @@ final class SentryExtensionTest extends TestCase
 
         $hub->setSpan($transaction);
 
-        $this->assertSame('<meta name="baggage" content="sentry-trace_id=a3c01c41d7b94b90aee23edac90f4319,sentry-transaction=%3Cunlabeled%20transaction%3E,sentry-release=1.0.0,sentry-environment=development" />', $environment->render('foo.twig'));
+        $this->assertSame(\sprintf('<meta name="baggage" content="%s" />', $transaction->toBaggage()), $environment->render('foo.twig'));
     }
 
     private static function isTwigBundlePackageInstalled(): bool


### PR DESCRIPTION
In some places we are basically testing the base PHP SDK instead of the Symfony integration. This PR fixes this which should fix the test suite erroring when the PHP SDK 4.11 is used.

The second commit fixes tests relying on random values (introduced in 4.11 of the base SDK), this is unfortunate and should be tested differently in the future probably but for now a workaround is implemented.