### PR TITLE
Add attribute/tag for command status tracking

### DIFF
--- a/src/Attribute/SentryMonitorCommand.php
+++ b/src/Attribute/SentryMonitorCommand.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Sentry\SentryBundle\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class SentryMonitorCommand
+{
+    /**
+     * @var string
+     */
+    private $slug;
+
+    public function __construct(string $slug)
+    {
+        $this->slug = $slug;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+}

--- a/src/DependencyInjection/Compiler/CronMonitorPass.php
+++ b/src/DependencyInjection/Compiler/CronMonitorPass.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\DependencyInjection\Compiler;
+
+use Sentry\SentryBundle\EventListener\CronMonitorListener;
+use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+class CronMonitorPass implements CompilerPassInterface
+{
+    use PriorityTaggedServiceTrait;
+
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->getParameter('sentry.cron.enabled')) {
+            return;
+        }
+
+        $commands = $this->findAndSortTaggedServices('sentry.monitor_command', $container);
+
+        $commandSlugMapping = [];
+        foreach ($commands as $reference) {
+            $id = $reference->__toString();
+            foreach ($container->getDefinition($id)->getTag('sentry.monitor_command') as $attributes) {
+                $commandSlugMapping[$id] = $attributes['slug'];
+            }
+        }
+
+        $container->getDefinition(CronMonitorListener::class)->setArgument(1, $commandSlugMapping);
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -46,6 +46,7 @@ final class Configuration implements ConfigurationInterface
                 ->end()
                 ->booleanNode('register_error_listener')->defaultTrue()->end()
                 ->booleanNode('register_error_handler')->defaultTrue()->end()
+                ->booleanNode('register_cron_monitor')->defaultTrue()->end()
                 ->scalarNode('logger')
                     ->info('The service ID of the PSR-3 logger used to log messages coming from the SDK client. Be aware that setting the same logger of the application may create a circular loop when an event fails to be sent.')
                     ->defaultNull()

--- a/src/EventListener/CronMonitorListener.php
+++ b/src/EventListener/CronMonitorListener.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\EventListener;
+
+use Sentry\CheckInStatus;
+use Sentry\State\HubInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Event\ConsoleErrorEvent;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+
+class CronMonitorListener
+{
+    /**
+     * @var HubInterface
+     */
+    private $hub;
+
+    /**
+     * @var array<string>
+     */
+    private $registeredCommands;
+
+    /**
+     * @param HubInterface  $hub
+     * @param array<string> $registeredCommands
+     */
+    public function __construct(HubInterface $hub, array $registeredCommands = [])
+    {
+        $this->hub = $hub;
+        $this->registeredCommands = $registeredCommands;
+    }
+
+    public function handleConsoleCommandEvent(ConsoleCommandEvent $event): void
+    {
+        $command = $event->getCommand();
+
+        if (false === $this->isValid($command)) {
+            return;
+        }
+
+        $checkinId = $this->hub->captureCheckIn(
+            $this->registeredCommands[$this->getCommandIndex($command)],
+            CheckInStatus::inProgress()
+        );
+    }
+
+    public function handleConsoleTerminateEvent(ConsoleTerminateEvent $event): void
+    {
+        $command = $event->getCommand();
+
+        if (false === $this->isValid($command)) {
+            return;
+        }
+
+        $this->hub->captureCheckIn(
+            $this->registeredCommands[$this->getCommandIndex($command)],
+            Command::SUCCESS === $event->getExitCode()
+                ? CheckInStatus::ok()
+                : CheckInStatus::error()
+        );
+    }
+
+    public function handleConsoleErrorEvent(ConsoleErrorEvent $event): void
+    {
+        $command = $event->getCommand();
+
+        if (false === $this->isValid($command)) {
+            return;
+        }
+
+        $this->hub->captureCheckIn(
+            $this->registeredCommands[$this->getCommandIndex($command)],
+            CheckInStatus::error()
+        );
+    }
+
+    private function isValid(?Command $command): bool
+    {
+        return $command instanceof Command && isset($this->registeredCommands[$this->getCommandIndex($command)]);
+    }
+
+    private function getCommandIndex(?Command $command): string
+    {
+        if (null === $command) {
+            return '';
+        }
+
+        if (\PHP_VERSION > 8.0) {
+            return $command::class;
+        }
+
+        return \get_class($command);
+    }
+}

--- a/src/EventListener/CronMonitorListener.php
+++ b/src/EventListener/CronMonitorListener.php
@@ -24,6 +24,11 @@ class CronMonitorListener
     private $registeredCommands;
 
     /**
+     * @var string|null
+     */
+    private $checkinId;
+
+    /**
      * @param HubInterface  $hub
      * @param array<string> $registeredCommands
      */
@@ -41,7 +46,7 @@ class CronMonitorListener
             return;
         }
 
-        $checkinId = $this->hub->captureCheckIn(
+        $this->checkinId = $this->hub->captureCheckIn(
             $this->registeredCommands[$this->getCommandIndex($command)],
             CheckInStatus::inProgress()
         );
@@ -59,7 +64,10 @@ class CronMonitorListener
             $this->registeredCommands[$this->getCommandIndex($command)],
             Command::SUCCESS === $event->getExitCode()
                 ? CheckInStatus::ok()
-                : CheckInStatus::error()
+                : CheckInStatus::error(),
+            null,
+            null,
+            $this->checkinId
         );
     }
 
@@ -73,7 +81,10 @@ class CronMonitorListener
 
         $this->hub->captureCheckIn(
             $this->registeredCommands[$this->getCommandIndex($command)],
-            CheckInStatus::error()
+            CheckInStatus::error(),
+            null,
+            null,
+            $this->checkinId
         );
     }
 

--- a/src/Resources/config/schema/sentry-1.0.xsd
+++ b/src/Resources/config/schema/sentry-1.0.xsd
@@ -16,6 +16,7 @@
 
         <xsd:attribute name="register-error-listener" type="xsd:boolean" />
         <xsd:attribute name="register-error-handler" type="xsd:boolean" />
+        <xsd:attribute name="register-cron-monitor" type="xsd:boolean" />
         <xsd:attribute name="transport-factory" type="xsd:string" />
         <xsd:attribute name="dsn" type="xsd:string" />
         <xsd:attribute name="logger" type="xsd:string" />

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -26,6 +26,14 @@
             <tag name="kernel.event_listener" event="console.error" method="handleConsoleErrorEvent" priority="-64" />
         </service>
 
+        <service id="Sentry\SentryBundle\EventListener\CronMonitorListener" class="Sentry\SentryBundle\EventListener\CronMonitorListener">
+            <argument type="service" id="Sentry\State\HubInterface" />
+
+            <tag name="kernel.event_listener" event="console.command" method="handleConsoleCommandEvent" priority="128" />
+            <tag name="kernel.event_listener" event="console.terminate" method="handleConsoleTerminateEvent" priority="-64" />
+            <tag name="kernel.event_listener" event="console.error" method="handleConsoleErrorEvent" priority="-64" />
+        </service>
+
         <service id="Sentry\SentryBundle\EventListener\ErrorListener" class="Sentry\SentryBundle\EventListener\ErrorListener">
             <argument type="service" id="Sentry\State\HubInterface" />
 

--- a/src/SentryBundle.php
+++ b/src/SentryBundle.php
@@ -6,6 +6,7 @@ namespace Sentry\SentryBundle;
 
 use Sentry\SentryBundle\DependencyInjection\Compiler\AddLoginListenerTagPass;
 use Sentry\SentryBundle\DependencyInjection\Compiler\CacheTracingPass;
+use Sentry\SentryBundle\DependencyInjection\Compiler\CronMonitorPass;
 use Sentry\SentryBundle\DependencyInjection\Compiler\DbalTracingPass;
 use Sentry\SentryBundle\DependencyInjection\Compiler\HttpClientTracingPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
@@ -26,5 +27,6 @@ final class SentryBundle extends Bundle
         $container->addCompilerPass(new CacheTracingPass());
         $container->addCompilerPass(new HttpClientTracingPass());
         $container->addCompilerPass(new AddLoginListenerTagPass());
+        $container->addCompilerPass(new CronMonitorPass());
     }
 }

--- a/tests/DependencyInjection/Compiler/CronMonitorPassTest.php
+++ b/tests/DependencyInjection/Compiler/CronMonitorPassTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Sentry\SentryBundle\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\SentryBundle\Command\SentryTestCommand;
+use Sentry\SentryBundle\DependencyInjection\Compiler\CronMonitorPass;
+use Sentry\SentryBundle\EventListener\CronMonitorListener;
+use Sentry\State\HubInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class CronMonitorPassTest extends TestCase
+{
+    public function testProcess(): void
+    {
+        $container = $this->createContainerBuilder(true);
+
+        $container->setDefinition(
+            SentryTestCommand::class,
+            (new Definition(SentryTestCommand::class))
+                ->setPublic(false)
+                ->addTag('console.command')
+                ->addTag('sentry.monitor_command', ['slug' => 'test-command'])
+        );
+
+        $container->compile();
+
+        $insertedCronMonitorListenerArgument = $container->getDefinition(CronMonitorListener::class)->getArgument(1);
+
+        $this->assertIsArray($insertedCronMonitorListenerArgument);
+        $this->assertArrayHasKey(SentryTestCommand::class, $insertedCronMonitorListenerArgument);
+        $this->assertEquals('test-command', $insertedCronMonitorListenerArgument[SentryTestCommand::class]);
+    }
+
+    public function testProcessDoesNothingIfConditionsForEnablingCronIsFalse(): void
+    {
+        $container = $this->createContainerBuilder(false);
+        $container->compile();
+
+        $this->assertFalse($container->getDefinition(CronMonitorListener::class)->getArgument(1));
+    }
+
+    private function createContainerBuilder(bool $isCronActive): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $container->addCompilerPass(new CronMonitorPass());
+        $container->setParameter('sentry.cron.enabled', $isCronActive);
+
+        $cronMonitorListenerMock = $this->createMock(CronMonitorListener::class);
+
+        $container->setDefinition(CronMonitorListener::class, (new Definition(\get_class($cronMonitorListenerMock)))
+            ->setPublic(true))
+            ->setArgument(0, HubInterface::class)
+            ->setArgument(1, false);
+
+        return $container;
+    }
+}

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -22,6 +22,7 @@ final class ConfigurationTest extends TestCase
         $expectedBundleDefaultConfig = [
             'register_error_listener' => true,
             'register_error_handler' => true,
+            'register_cron_monitor' => true,
             'logger' => null,
             'options' => [
                 'integrations' => [],

--- a/tests/DependencyInjection/Fixtures/php/cron_monitor_disabled.php
+++ b/tests/DependencyInjection/Fixtures/php/cron_monitor_disabled.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/** @var ContainerBuilder $container */
+$container->loadFromExtension('sentry', [
+    'register_cron_monitor' => false,
+]);

--- a/tests/DependencyInjection/Fixtures/php/cron_monitor_enabled.php
+++ b/tests/DependencyInjection/Fixtures/php/cron_monitor_enabled.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/** @var ContainerBuilder $container */
+$container->loadFromExtension('sentry', [
+    'register_cron_monitor' => true,
+]);

--- a/tests/DependencyInjection/Fixtures/xml/cron_monitor_disabled.xml
+++ b/tests/DependencyInjection/Fixtures/xml/cron_monitor_disabled.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:sentry="https://sentry.io/schema/dic/sentry-symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                               https://sentry.io/schema/dic/sentry-symfony https://sentry.io/schema/dic/sentry-symfony/sentry-1.0.xsd">
+
+    <sentry:config register-cron-monitor="false" />
+</container>

--- a/tests/DependencyInjection/Fixtures/xml/cron_monitor_enabled.xml
+++ b/tests/DependencyInjection/Fixtures/xml/cron_monitor_enabled.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:sentry="https://sentry.io/schema/dic/sentry-symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                               https://sentry.io/schema/dic/sentry-symfony https://sentry.io/schema/dic/sentry-symfony/sentry-1.0.xsd">
+
+    <sentry:config register-cron-monitor="true" />
+</container>

--- a/tests/DependencyInjection/Fixtures/yml/cron_monitor_disabled.yml
+++ b/tests/DependencyInjection/Fixtures/yml/cron_monitor_disabled.yml
@@ -1,0 +1,2 @@
+sentry:
+    register_cron_monitor: false

--- a/tests/DependencyInjection/Fixtures/yml/cron_monitor_enabled.yml
+++ b/tests/DependencyInjection/Fixtures/yml/cron_monitor_enabled.yml
@@ -1,0 +1,2 @@
+sentry:
+    register_cron_monitor: true

--- a/tests/DependencyInjection/SentryExtensionTest.php
+++ b/tests/DependencyInjection/SentryExtensionTest.php
@@ -13,6 +13,7 @@ use Sentry\Logger\DebugStdOutLogger;
 use Sentry\Options;
 use Sentry\SentryBundle\DependencyInjection\SentryExtension;
 use Sentry\SentryBundle\EventListener\ConsoleListener;
+use Sentry\SentryBundle\EventListener\CronMonitorListener;
 use Sentry\SentryBundle\EventListener\ErrorListener;
 use Sentry\SentryBundle\EventListener\LoginListener;
 use Sentry\SentryBundle\EventListener\MessengerListener;
@@ -458,6 +459,22 @@ abstract class SentryExtensionTest extends TestCase
             'release_option_fallback_to_composer_version',
             PrettyVersions::getRootPackageVersion()->getPrettyVersion(),
         ];
+    }
+
+    public function testRegisterCronMonitoringConfigurationDisabled(): void
+    {
+        $container = $this->createContainerFromFixture('cron_monitor_disabled');
+
+        $this->assertFalse($container->getParameter('sentry.cron.enabled'));
+        $this->assertFalse($container->hasDefinition(CronMonitorListener::class));
+    }
+
+    public function testRegisterCronMonitoringConfiguration(): void
+    {
+        $container = $this->createContainerFromFixture('cron_monitor_enabled');
+
+        $this->assertTrue($container->getParameter('sentry.cron.enabled'));
+        $this->assertTrue($container->hasDefinition(CronMonitorListener::class));
     }
 
     private function createContainerFromFixture(string $fixtureFile): ContainerBuilder

--- a/tests/EventListener/CronMonitorListenerTest.php
+++ b/tests/EventListener/CronMonitorListenerTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\EventListener;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sentry\CheckInStatus;
+use Sentry\SentryBundle\EventListener\CronMonitorListener;
+use Sentry\State\HubInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Event\ConsoleErrorEvent;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class CronMonitorListenerTest extends TestCase
+{
+    /**
+     * @var MockObject&HubInterface
+     */
+    private $hub;
+
+    protected function setUp(): void
+    {
+        $this->hub = $this->createMock(HubInterface::class);
+    }
+
+    public function testHandleConsoleCommandEvent(): void
+    {
+        $listener = new CronMonitorListener($this->hub, [Command::class => 'bar']);
+
+        $this->hub->expects($this->once())
+            ->method('captureCheckIn')
+            ->with('bar', CheckInStatus::inProgress())
+        ;
+
+        $consoleEvent = new ConsoleCommandEvent(new Command('foo:bar'), new ArrayInput([]), new NullOutput());
+        $listener->handleConsoleCommandEvent($consoleEvent);
+    }
+
+    public function testHandleConsoleCommandEventSkipped(): void
+    {
+        $listener = new CronMonitorListener($this->hub, []);
+
+        $this->hub->expects($this->never())
+            ->method('captureCheckIn');
+
+        $consoleEvent = new ConsoleCommandEvent(new Command('foo:bar'), new ArrayInput([]), new NullOutput());
+        $listener->handleConsoleCommandEvent($consoleEvent);
+    }
+
+    public function testHandleConsoleCommandEventSkippedWithEmptyCommand(): void
+    {
+        $listener = new CronMonitorListener($this->hub, [Command::class => 'bar']);
+
+        $this->hub->expects($this->never())
+            ->method('captureCheckIn');
+
+        $consoleEvent = new ConsoleCommandEvent(null, new ArrayInput([]), new NullOutput());
+        $listener->handleConsoleCommandEvent($consoleEvent);
+    }
+
+    /**
+     * @dataProvider provideTerminateEvents
+     */
+    public function testHandleConsoleTerminateEvent(ConsoleTerminateEvent $consoleEvent, CheckInStatus $expectedState): void
+    {
+        $listener = new CronMonitorListener($this->hub, [Command::class => 'bar']);
+
+        $this->hub->expects($this->once())
+            ->method('captureCheckIn')
+            ->with('bar', $expectedState)
+        ;
+
+        $listener->handleConsoleTerminateEvent($consoleEvent);
+    }
+
+    /**
+     * @return \Generator<mixed>
+     */
+    public function provideTerminateEvents(): \Generator
+    {
+        yield [
+            new ConsoleTerminateEvent(new Command('foo:bar'), new ArrayInput([]), new NullOutput(), Command::SUCCESS),
+            CheckInStatus::ok(),
+        ];
+
+        yield [
+            new ConsoleTerminateEvent(new Command('foo:bar'), new ArrayInput([]), new NullOutput(), Command::FAILURE),
+            CheckInStatus::error(),
+        ];
+    }
+
+    public function testHandleConsoleErrorEvent(): void
+    {
+        $listener = new CronMonitorListener($this->hub, [Command::class => 'bar']);
+
+        $this->hub->expects($this->once())
+            ->method('captureCheckIn')
+            ->with('bar', CheckInStatus::error())
+        ;
+
+        $consoleEvent = new ConsoleErrorEvent(
+            new ArrayInput([]),
+            new NullOutput(),
+            new \Exception(),
+            new Command('foo:bar')
+        );
+
+        $listener->handleConsoleErrorEvent($consoleEvent);
+    }
+}


### PR DESCRIPTION
Added attribute/tag to track command status.

This feature helps to track status without adding check in tracking on every possible return.

In newer PHP versions you can add an attribute

```php
#[SentryMonitorCommand(slug: 'test-command')]
class TestCommand extends Command
```

in older versions you can use a tag

```yml
App\Command\TestCommand:
    tags:
        - {name: 'sentry.monitor_command', slug: 'test-command'}
```