### PR TITLE
Remove support for `traceparent`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": "^7.2||^8.0",
         "guzzlehttp/psr7": "^2.1.1",
         "jean85/pretty-package-versions": "^1.5||^2.0",
-        "sentry/sentry": "^4.11.0",
+        "sentry/sentry": "^4.14.1",
         "symfony/cache-contracts": "^1.1||^2.4||^3.0",
         "symfony/config": "^4.4.20||^5.0.11||^6.0||^7.0",
         "symfony/console": "^4.4.20||^5.0.11||^6.0||^7.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -171,6 +171,21 @@ parameters:
 			path: src/EventListener/LoginListener.php
 
 		-
+			message: "#^Instanceof between Throwable and Symfony\\\\Component\\\\Messenger\\\\Exception\\\\DelayedMessageHandlingException will always evaluate to false\\.$#"
+			count: 1
+			path: src/EventListener/MessengerListener.php
+
+		-
+			message: "#^Instanceof between Throwable and Symfony\\\\Component\\\\Messenger\\\\Exception\\\\HandlerFailedException will always evaluate to false\\.$#"
+			count: 1
+			path: src/EventListener/MessengerListener.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 2
+			path: src/EventListener/MessengerListener.php
+
+		-
 			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpKernel\\\\Event\\\\KernelEvent\\:\\:isMasterRequest\\(\\)\\.$#"
 			count: 1
 			path: src/EventListener/RequestListener.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -171,21 +171,6 @@ parameters:
 			path: src/EventListener/LoginListener.php
 
 		-
-			message: "#^Instanceof between Throwable and Symfony\\\\Component\\\\Messenger\\\\Exception\\\\DelayedMessageHandlingException will always evaluate to false\\.$#"
-			count: 1
-			path: src/EventListener/MessengerListener.php
-
-		-
-			message: "#^Instanceof between Throwable and Symfony\\\\Component\\\\Messenger\\\\Exception\\\\HandlerFailedException will always evaluate to false\\.$#"
-			count: 1
-			path: src/EventListener/MessengerListener.php
-
-		-
-			message: "#^Result of && is always false\\.$#"
-			count: 2
-			path: src/EventListener/MessengerListener.php
-
-		-
 			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpKernel\\\\Event\\\\KernelEvent\\:\\:isMasterRequest\\(\\)\\.$#"
 			count: 1
 			path: src/EventListener/RequestListener.php

--- a/src/Tracing/Doctrine/DBAL/TracingDriverConnectionForV2V3.php
+++ b/src/Tracing/Doctrine/DBAL/TracingDriverConnectionForV2V3.php
@@ -246,9 +246,9 @@ final class TracingDriverConnectionForV2V3 implements TracingDriverConnectionInt
      *
      * @param array<string, mixed> $params The connection params
      *
-     * @return array<string, string>
-     *
      * @phpstan-param ConnectionParams $params
+     *
+     * @return array<string, string>
      *
      * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md
      */

--- a/src/Tracing/Doctrine/DBAL/TracingDriverConnectionForV4.php
+++ b/src/Tracing/Doctrine/DBAL/TracingDriverConnectionForV4.php
@@ -244,9 +244,9 @@ final class TracingDriverConnectionForV4 implements TracingDriverConnectionInter
      *
      * @param array<string, mixed> $params The connection params
      *
-     * @return array<string, string>
-     *
      * @phpstan-param ConnectionParams $params
+     *
+     * @return array<string, string>
      *
      * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md
      */

--- a/src/Tracing/HttpClient/AbstractTraceableHttpClient.php
+++ b/src/Tracing/HttpClient/AbstractTraceableHttpClient.php
@@ -18,7 +18,6 @@ use Symfony\Contracts\Service\ResetInterface;
 
 use function Sentry\getBaggage;
 use function Sentry\getTraceparent;
-use function Sentry\getW3CTraceparent;
 
 /**
  * This is an implementation of the {@see HttpClientInterface} that decorates
@@ -59,7 +58,6 @@ abstract class AbstractTraceableHttpClient implements HttpClientInterface, Reset
             if (self::shouldAttachTracingHeaders($client, $uri)) {
                 $headers['baggage'] = getBaggage();
                 $headers['sentry-trace'] = getTraceparent();
-                $headers['traceparent'] = getW3CTraceparent();
             }
 
             $options['headers'] = $headers;

--- a/src/Twig/SentryExtension.php
+++ b/src/Twig/SentryExtension.php
@@ -10,7 +10,6 @@ use Twig\TwigFunction;
 
 use function Sentry\getBaggage;
 use function Sentry\getTraceparent;
-use function Sentry\getW3CTraceparent;
 
 final class SentryExtension extends AbstractExtension
 {
@@ -43,10 +42,12 @@ final class SentryExtension extends AbstractExtension
 
     /**
      * Returns an HTML meta tag named `traceparent`.
+     *
+     * @deprecated since version 5.3. To be removed in version 6.0.
      */
     public function getW3CTraceMeta(): string
     {
-        return \sprintf('<meta name="traceparent" content="%s" />', getW3CTraceparent());
+        return '';
     }
 
     /**

--- a/tests/EventListener/TracingRequestListenerTest.php
+++ b/tests/EventListener/TracingRequestListenerTest.php
@@ -129,45 +129,6 @@ final class TracingRequestListenerTest extends TestCase
             $transactionContext,
         ];
 
-        $samplingContext = DynamicSamplingContext::fromHeader('');
-        $samplingContext->freeze();
-
-        $transactionContext = new TransactionContext();
-        $transactionContext->setTraceId(new TraceId('566e3688a61d4bc888951642d6f14a19'));
-        $transactionContext->setParentSpanId(new SpanId('566e3688a61d4bc8'));
-        $transactionContext->setParentSampled(true);
-        $transactionContext->setName('GET http://www.example.com/');
-        $transactionContext->setSource(TransactionSource::url());
-        $transactionContext->setOp('http.server');
-        $transactionContext->setOrigin('auto.http.server');
-        $transactionContext->setStartTimestamp(1613493597.010275);
-        $transactionContext->setData([
-            'net.host.port' => '80',
-            'http.request.method' => 'GET',
-            'http.url' => 'http://www.example.com/',
-            'http.flavor' => '1.1',
-            'route' => '<unknown>',
-            'net.host.name' => 'www.example.com',
-        ]);
-        $transactionContext->getMetadata()->setDynamicSamplingContext($samplingContext);
-        $transactionContext->getMetadata()->setSampleRand(0.1337);
-
-        yield 'request.headers.traceparent EXISTS' => [
-            new Options(),
-            Request::create(
-                'http://www.example.com',
-                'GET',
-                [],
-                [],
-                [],
-                [
-                    'REQUEST_TIME_FLOAT' => 1613493597.010275,
-                    'HTTP_traceparent' => '00-566e3688a61d4bc888951642d6f14a19-566e3688a61d4bc8-01',
-                ]
-            ),
-            $transactionContext,
-        ];
-
         $samplingContext = DynamicSamplingContext::fromHeader('sentry-trace_id=566e3688a61d4bc888951642d6f14a19,sentry-public_key=public,sentry-sample_rate=1');
         $samplingContext->freeze();
 

--- a/tests/Tracing/HttpClient/TraceableHttpClientTest.php
+++ b/tests/Tracing/HttpClient/TraceableHttpClientTest.php
@@ -176,7 +176,7 @@ final class TraceableHttpClientTest extends TestCase
             'trace_propagation_targets' => ['www.example.com'],
         ]);
         $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->exactly(5))
+        $client->expects($this->exactly(4))
             ->method('getOptions')
             ->willReturn($options);
 
@@ -200,7 +200,6 @@ final class TraceableHttpClientTest extends TestCase
         $this->assertSame('POST', $response->getInfo('http_method'));
         $this->assertSame('https://www.example.com/test-page', $response->getInfo('url'));
         $this->assertSame([\sprintf('sentry-trace: %s', $propagationContext->toTraceparent())], $mockResponse->getRequestOptions()['normalized_headers']['sentry-trace']);
-        $this->assertSame([\sprintf('traceparent: %s', $propagationContext->toW3CTraceparent())], $mockResponse->getRequestOptions()['normalized_headers']['traceparent']);
         $this->assertSame([\sprintf('baggage: %s', $propagationContext->toBaggage())], $mockResponse->getRequestOptions()['normalized_headers']['baggage']);
     }
 

--- a/tests/Twig/SentryExtensionTest.php
+++ b/tests/Twig/SentryExtensionTest.php
@@ -73,50 +73,6 @@ final class SentryExtensionTest extends TestCase
         $this->assertSame('<meta name="sentry-trace" content="a3c01c41d7b94b90aee23edac90f4319-e69c2aef0ec34f2a-1" />', $environment->render('foo.twig'));
     }
 
-    public function testW3CTraceMetaFunctionWithNoActiveSpan(): void
-    {
-        $environment = new Environment(new ArrayLoader(['foo.twig' => '{{ sentry_w3c_trace_meta() }}']));
-        $environment->addExtension(new SentryExtension());
-
-        $propagationContext = PropagationContext::fromDefaults();
-        $propagationContext->setTraceId(new TraceId('566e3688a61d4bc888951642d6f14a19'));
-        $propagationContext->setSpanId(new SpanId('566e3688a61d4bc8'));
-
-        $hub = new Hub(null, new Scope($propagationContext));
-
-        SentrySdk::setCurrentHub($hub);
-
-        $this->assertSame('<meta name="traceparent" content="00-566e3688a61d4bc888951642d6f14a19-566e3688a61d4bc8-00" />', $environment->render('foo.twig'));
-    }
-
-    public function testW3CTraceMetaFunctionWithActiveSpan(): void
-    {
-        $environment = new Environment(new ArrayLoader(['foo.twig' => '{{ sentry_w3c_trace_meta() }}']));
-        $environment->addExtension(new SentryExtension());
-
-        $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->atLeastOnce())
-            ->method('getOptions')
-            ->willReturn(new Options([
-                'traces_sample_rate' => 1.0,
-                'release' => '1.0.0',
-                'environment' => 'development',
-            ]));
-
-        $hub = new Hub($client);
-
-        SentrySdk::setCurrentHub($hub);
-
-        $transaction = new Transaction(new TransactionContext());
-        $transaction->setTraceId(new TraceId('a3c01c41d7b94b90aee23edac90f4319'));
-        $transaction->setSpanId(new SpanId('e69c2aef0ec34f2a'));
-        $transaction->setSampled(true);
-
-        $hub->setSpan($transaction);
-
-        $this->assertSame('<meta name="traceparent" content="00-a3c01c41d7b94b90aee23edac90f4319-e69c2aef0ec34f2a-01" />', $environment->render('foo.twig'));
-    }
-
     public function testBaggageMetaFunctionWithNoActiveSpan(): void
     {
         $environment = new Environment(new ArrayLoader(['foo.twig' => '{{ sentry_baggage_meta() }}']));


### PR DESCRIPTION
Adding support for W3C's `traceparent` header was a mistake on our end. This mainly causes surprises for users, that get spammed by 3rd parties sending this header.
We made the decision to remove support from the SDK.

Some changes in dependencies were also made causing phpstan to not like the code anymore. I believe it's right but not for older Symfony versions so I opted to ignore the errors for now. Codepaths are protected against failures so it's not an issue.

See also getsentry/sentry-laravel#994