### PR TITLE
Fix console tracing

### DIFF
--- a/src/EventListener/TracingConsoleListener.php
+++ b/src/EventListener/TracingConsoleListener.php
@@ -91,11 +91,12 @@ final class TracingConsoleListener
             return;
         }
 
-        $span = $this->hub->getSpan();
+        $transaction = $this->hub->getTransaction();
 
-        if (null !== $span) {
-            $span->setStatus(0 === $event->getExitCode() ? SpanStatus::ok() : SpanStatus::internalError());
-            $span->finish();
+        if (null !== $transaction) {
+            $transaction->setStatus(0 === $event->getExitCode() ? SpanStatus::ok() : SpanStatus::internalError());
+            $transaction->finish();
+            metrics()->flush();
         }
     }
 


### PR DESCRIPTION
I noticed that our project lacks spans when executing console commands. I found that upon completion of a console command, only one specific span is finalized, rather than the entire transaction, unlike the behavior in TracingRequestListener. After locally modifying it to complete the transaction and running console sentry:test, I observed the other spans that were previously missing. Therefore, I believe this fix should resolve the issue.