### PR TITLE
Capture invalid IP address exceptions

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -332,7 +332,7 @@ parameters:
 
 		-
 			message: "#^Access to undefined constant Symfony\\\\Component\\\\HttpKernel\\\\HttpKernelInterface\\:\\:MASTER_REQUEST\\.$#"
-			count: 6
+			count: 7
 			path: tests/EventListener/RequestListenerTest.php
 
 		-

--- a/src/EventListener/RequestListener.php
+++ b/src/EventListener/RequestListener.php
@@ -56,7 +56,11 @@ final class RequestListener
             $user = $scope->getUser() ?? new UserDataBag();
 
             if (null === $user->getIpAddress()) {
-                $user->setIpAddress($event->getRequest()->getClientIp());
+                try {
+                    $user->setIpAddress($event->getRequest()->getClientIp());
+                } catch (\InvalidArgumentException $e) {
+                    // If the IP is in an invalid format, we ignore it
+                }
             }
 
             $scope->setUser($user);

--- a/tests/EventListener/RequestListenerTest.php
+++ b/tests/EventListener/RequestListenerTest.php
@@ -121,6 +121,17 @@ final class RequestListenerTest extends TestCase
             new UserDataBag('foo_user', null, '::1'),
             new UserDataBag('foo_user', null, '::1'),
         ];
+
+        yield 'remote address empty' => [
+            new RequestEvent(
+                $this->createMock(HttpKernelInterface::class),
+                new Request([], [], [], [], [], ['REMOTE_ADDR' => '']),
+                \defined(HttpKernelInterface::class . '::MAIN_REQUEST') ? HttpKernelInterface::MAIN_REQUEST : HttpKernelInterface::MASTER_REQUEST
+            ),
+            $this->getMockedClientWithOptions(new Options(['send_default_pii' => true])),
+            new UserDataBag(),
+            new UserDataBag(),
+        ];
     }
 
     /**


### PR DESCRIPTION
We could throw an exception if a IP address is invalid or an empty string. Capture and ignore the exception since we can just continue without it.

As reported: https://github.com/getsentry/sentry-php/issues/1750#issuecomment-3117928735