### PR TITLE
Do not call Reflection*::setAccessible() in PHP >= 8.1

### DIFF
--- a/src/Tracing/Doctrine/DBAL/ConnectionConfigurator.php
+++ b/src/Tracing/Doctrine/DBAL/ConnectionConfigurator.php
@@ -39,8 +39,12 @@ final class ConnectionConfigurator
     public function configure(Connection $connection): void
     {
         $reflectionProperty = new \ReflectionProperty($connection, '_driver');
-        $reflectionProperty->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
         $reflectionProperty->setValue($connection, $this->tracingDriverMiddleware->wrap($reflectionProperty->getValue($connection)));
-        $reflectionProperty->setAccessible(false);
+        if (\PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(false);
+        }
     }
 }


### PR DESCRIPTION
> As of PHP 8.1.0, calling this method has no effect; all methods are invokable by default.

(https://www.php.net/manual/en/reflectionmethod.setaccessible.php and https://www.php.net/manual/en/reflectionproperty.setaccessible.php).

There're even plans to deprecate the method in PHP 8.5: https://wiki.php.net/rfc/deprecations_php_8_5#extreflection_deprecations