### PR TITLE
fix: Implicitly marking parameter as nullable is deprecated (#894). Backport to 4.x branch

### DIFF
--- a/src/Tracing/Cache/TraceableCacheAdapterForV2.php
+++ b/src/Tracing/Cache/TraceableCacheAdapterForV2.php
@@ -40,7 +40,7 @@ final class TraceableCacheAdapterForV2 implements AdapterInterface, CacheInterfa
      *
      * @return mixed
      */
-    public function get(string $key, callable $callback, float $beta = null, array &$metadata = null)
+    public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null)
     {
         return $this->traceFunction('cache.get_item', function () use ($key, $callback, $beta, &$metadata) {
             if (!$this->decoratedAdapter instanceof CacheInterface) {

--- a/src/Tracing/Cache/TraceableCacheAdapterForV3.php
+++ b/src/Tracing/Cache/TraceableCacheAdapterForV3.php
@@ -38,7 +38,7 @@ final class TraceableCacheAdapterForV3 implements AdapterInterface, CacheInterfa
      *
      * @param mixed[] $metadata
      */
-    public function get(string $key, callable $callback, float $beta = null, array &$metadata = null): mixed
+    public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null): mixed
     {
         return $this->traceFunction('cache.get_item', function () use ($key, $callback, $beta, &$metadata) {
             if (!$this->decoratedAdapter instanceof CacheInterface) {

--- a/src/Tracing/Cache/TraceableCacheAdapterTrait.php
+++ b/src/Tracing/Cache/TraceableCacheAdapterTrait.php
@@ -168,7 +168,7 @@ trait TraceableCacheAdapterTrait
      *
      * @phpstan-return TResult
      */
-    private function traceFunction(string $spanOperation, \Closure $callback, string $spanDescription = null)
+    private function traceFunction(string $spanOperation, \Closure $callback, ?string $spanDescription = null)
     {
         $span = $this->hub->getSpan();
 

--- a/src/Tracing/Cache/TraceableTagAwareCacheAdapterForV2.php
+++ b/src/Tracing/Cache/TraceableTagAwareCacheAdapterForV2.php
@@ -41,7 +41,7 @@ final class TraceableTagAwareCacheAdapterForV2 implements TagAwareAdapterInterfa
      *
      * @return mixed
      */
-    public function get(string $key, callable $callback, float $beta = null, array &$metadata = null)
+    public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null)
     {
         return $this->traceFunction('cache.get_item', function () use ($key, $callback, $beta, &$metadata) {
             if (!$this->decoratedAdapter instanceof CacheInterface) {

--- a/src/Tracing/Cache/TraceableTagAwareCacheAdapterForV3.php
+++ b/src/Tracing/Cache/TraceableTagAwareCacheAdapterForV3.php
@@ -39,7 +39,7 @@ final class TraceableTagAwareCacheAdapterForV3 implements TagAwareAdapterInterfa
      *
      * @param mixed[] $metadata
      */
-    public function get(string $key, callable $callback, float $beta = null, array &$metadata = null): mixed
+    public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null): mixed
     {
         return $this->traceFunction('cache.get_item', function () use ($key, $callback, $beta, &$metadata) {
             if (!$this->decoratedAdapter instanceof CacheInterface) {

--- a/src/Tracing/HttpClient/AbstractTraceableHttpClient.php
+++ b/src/Tracing/HttpClient/AbstractTraceableHttpClient.php
@@ -103,7 +103,7 @@ abstract class AbstractTraceableHttpClient implements HttpClientInterface, Reset
     /**
      * {@inheritdoc}
      */
-    public function stream($responses, float $timeout = null): ResponseStreamInterface
+    public function stream($responses, ?float $timeout = null): ResponseStreamInterface
     {
         if ($responses instanceof AbstractTraceableResponse) {
             $responses = [$responses];

--- a/src/Tracing/HttpClient/TraceableResponseForV6.php
+++ b/src/Tracing/HttpClient/TraceableResponseForV6.php
@@ -14,7 +14,7 @@ final class TraceableResponseForV6 extends AbstractTraceableResponse implements 
     /**
      * {@inheritdoc}
      */
-    public function getInfo(string $type = null): mixed
+    public function getInfo(?string $type = null): mixed
     {
         return $this->response->getInfo($type);
     }

--- a/src/Twig/SentryExtension.php
+++ b/src/Twig/SentryExtension.php
@@ -16,7 +16,7 @@ final class SentryExtension extends AbstractExtension
     /**
      * @param HubInterface $hub The current hub
      */
-    public function __construct(HubInterface $hub = null)
+    public function __construct(?HubInterface $hub = null)
     {
     }
 


### PR DESCRIPTION
(cherry picked from commit 78205167e1ce7abd79fb317171b21524f49deb7f)

Better PHP 8.4 support without breaking BC.