### PR TITLE
fix(command): fix breadcrumbs and tag propagation for console commands

### DIFF
--- a/src/Command/SentryBreadcrumbTestCommand.php
+++ b/src/Command/SentryBreadcrumbTestCommand.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Command;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SentryBreadcrumbTestCommand extends Command
+{
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(LoggerInterface $logger)
+    {
+        parent::__construct('sentry:breadcrumb:test');
+        $this->logger = $logger;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->logger->error('Breadcrumb error');
+
+        throw new \RuntimeException('Breadcrumb error');
+    }
+}

--- a/src/Command/SentryDummyTestCommand.php
+++ b/src/Command/SentryDummyTestCommand.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Command;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SentryDummyTestCommand extends Command
+{
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(LoggerInterface $logger)
+    {
+        parent::__construct('sentry:dummy:test');
+        $this->logger = $logger;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->logger->error('This is a dummy message');
+
+        return 0;
+    }
+}

--- a/src/Command/SentrySubcommandTestCommand.php
+++ b/src/Command/SentrySubcommandTestCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Command;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SentrySubcommandTestCommand extends Command
+{
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var Command
+     */
+    private $subcommand;
+
+    public function __construct(LoggerInterface $logger, Command $subcommand)
+    {
+        parent::__construct('sentry:subcommand:test');
+        $this->logger = $logger;
+        $this->subcommand = $subcommand;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->logger->error('Subcommand will run now');
+
+        $this->getApplication()->doRun(new ArrayInput(['command' => $this->subcommand->getName()]), new NullOutput());
+
+        $this->logger->error('Breadcrumb after subcommand');
+
+        return 0;
+    }
+}

--- a/src/Command/SentrySubcommandTestCommand.php
+++ b/src/Command/SentrySubcommandTestCommand.php
@@ -34,7 +34,7 @@ class SentrySubcommandTestCommand extends Command
     {
         $this->logger->error('Subcommand will run now');
 
-        if ($this->getApplication() !== null) {
+        if (null !== $this->getApplication()) {
             $this->getApplication()->doRun(new ArrayInput(['command' => $this->subcommand->getName()]), new NullOutput());
         }
 

--- a/src/Command/SentrySubcommandTestCommand.php
+++ b/src/Command/SentrySubcommandTestCommand.php
@@ -34,7 +34,9 @@ class SentrySubcommandTestCommand extends Command
     {
         $this->logger->error('Subcommand will run now');
 
-        $this->getApplication()->doRun(new ArrayInput(['command' => $this->subcommand->getName()]), new NullOutput());
+        if ($this->getApplication() !== null) {
+            $this->getApplication()->doRun(new ArrayInput(['command' => $this->subcommand->getName()]), new NullOutput());
+        }
 
         $this->logger->error('Breadcrumb after subcommand');
 

--- a/src/EventListener/ConsoleListener.php
+++ b/src/EventListener/ConsoleListener.php
@@ -53,6 +53,7 @@ class ConsoleListener
         $this->hub = $hub;
         $this->captureErrors = $captureErrors;
         $this->commandHasErrors = false;
+        $this->commandDepth = 0;
     }
 
     /**
@@ -65,6 +66,10 @@ class ConsoleListener
         $scope = $this->hub->pushScope();
         $command = $event->getCommand();
         $input = $event->getInput();
+        // Reset hasErrors flag if this is a new command and not a sub-command.
+        if (0 === $this->commandDepth) {
+            $this->commandHasErrors = false;
+        }
         ++$this->commandDepth;
 
         if (null !== $command && null !== $command->getName()) {

--- a/tests/Command/BreadcrumbTestCommandTest.php
+++ b/tests/Command/BreadcrumbTestCommandTest.php
@@ -202,6 +202,7 @@ class BreadcrumbTestCommandTest extends TestCase
      * Tests that even if no errors occur, breadcrumb information is available.
      *
      * @return void
+     *
      * @throws \Throwable
      */
     public function testBreadcrumbsAreAvailableAfterCommandTermination()

--- a/tests/Command/BreadcrumbTestCommandTest.php
+++ b/tests/Command/BreadcrumbTestCommandTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Command;
+
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Sentry\Client;
+use Sentry\Event;
+use Sentry\Monolog\BreadcrumbHandler;
+use Sentry\Options;
+use Sentry\SentryBundle\Command\SentryBreadcrumbTestCommand;
+use Sentry\SentryBundle\Command\SentryDummyTestCommand;
+use Sentry\SentryBundle\Command\SentrySubcommandTestCommand;
+use Sentry\SentryBundle\EventListener\ConsoleListener;
+use Sentry\SentryBundle\Tests\End2End\StubTransport;
+use Sentry\State\Hub;
+use Sentry\State\HubInterface;
+use Sentry\State\Scope;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+class BreadcrumbTestCommandTest extends TestCase
+{
+    /**
+     * @var HubInterface
+     */
+    private $hub;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var Application
+     */
+    private $application;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $client = new Client(new Options(), new StubTransport());
+        $hub = new Hub($client);
+
+        $consoleListener = new ConsoleListener($hub);
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(ConsoleEvents::COMMAND, [$consoleListener, 'handleConsoleCommandEvent']);
+        $dispatcher->addListener(ConsoleEvents::TERMINATE, [$consoleListener, 'handleConsoleTerminateEvent']);
+        $dispatcher->addListener(ConsoleEvents::ERROR, [$consoleListener, 'handleConsoleErrorEvent']);
+
+        $this->application = new Application();
+        $this->application->setDispatcher($dispatcher);
+
+        $breadcrumbHandler = new BreadcrumbHandler($hub);
+        $this->hub = $hub;
+        $this->logger = new Logger('test', [$breadcrumbHandler]);
+    }
+
+    /**
+     * Tests that breadcrumbs are properly captured within a console command and not lost
+     * on command termination.
+     *
+     * @return void
+     */
+    public function testBreadcrumbWithConsoleListener()
+    {
+        $command = new SentryBreadcrumbTestCommand($this->logger);
+        $this->application->add($command);
+
+        try {
+            // We need to run this by the application directly because the CommandTester doesn't produce proper events.
+            $this->application->doRun(new ArgvInput(['bin/console', 'sentry:breadcrumb:test']), new NullOutput());
+            $this->fail();
+        } catch (\Throwable $e) {
+            $this->assertSame($e->getMessage(), 'Breadcrumb error');
+        }
+
+        $event = Event::createEvent();
+        $modifiedEvent = null;
+
+        $this->hub->configureScope(function (Scope $scope) use ($event, &$modifiedEvent) {
+            $modifiedEvent = $scope->applyToEvent($event);
+        });
+
+        $this->assertNotNull($modifiedEvent);
+        $this->assertCount(1, $modifiedEvent->getBreadcrumbs());
+    }
+
+    /**
+     * Tests that the scope is reset after the command finished without any errors.
+     *
+     * @return void
+     *
+     * @throws \Throwable
+     */
+    public function testSubCommandBreadcrumbs()
+    {
+        $subcommand = new SentryDummyTestCommand($this->logger);
+        $this->application->add($subcommand);
+
+        $command = new SentrySubcommandTestCommand($this->logger, $subcommand);
+        $this->application->add($command);
+
+        // We need to run this by the application directly because the CommandTester doesn't produce proper events.
+        $this->application->doRun(new ArgvInput(['bin/console', 'sentry:subcommand:test']), new NullOutput());
+
+        $event = Event::createEvent();
+        $modifiedEvent = null;
+
+        $this->hub->configureScope(function (Scope $scope) use ($event, &$modifiedEvent) {
+            $modifiedEvent = $scope->applyToEvent($event);
+        });
+
+        $this->assertNotNull($modifiedEvent);
+        // We do not have breadcrumbs here because no error happened and the scope was popped.
+        $this->assertCount(0, $modifiedEvent->getBreadcrumbs());
+    }
+
+    /**
+     * Tests that the command that caused the crash is reported as `console.command` tag.
+     *
+     * @return void
+     */
+    public function testCrashingSubcommand()
+    {
+        $subcommand = new SentryBreadcrumbTestCommand($this->logger);
+        $this->application->add($subcommand);
+
+        $command = new SentrySubcommandTestCommand($this->logger, $subcommand);
+        $this->application->add($command);
+
+        try {
+            $this->application->doRun(new ArgvInput(['bin/console', 'sentry:subcommand:test']), new NullOutput());
+            $this->fail();
+        } catch (\Throwable $e) {
+            $this->assertSame($e->getMessage(), 'Breadcrumb error');
+        }
+
+        $event = Event::createEvent();
+        $modifiedEvent = null;
+
+        $this->hub->configureScope(function (Scope $scope) use ($event, &$modifiedEvent) {
+            $modifiedEvent = $scope->applyToEvent($event);
+        });
+
+        $this->assertNotNull($modifiedEvent);
+        $this->assertCount(2, $modifiedEvent->getBreadcrumbs());
+        $this->assertSame($modifiedEvent->getTags()['console.command'], 'sentry:breadcrumb:test');
+    }
+
+    /**
+     * Tests that we have the correct `console.command` tag if one command throws an unhandled exception
+     * even if we had commands that threw exceptions but were handled.
+     *
+     * @return void
+     *
+     * @throws \Throwable
+     */
+    public function testRunSecondCommandAfterCrashingCommand()
+    {
+        $subcommand = new SentryBreadcrumbTestCommand($this->logger);
+        $this->application->add($subcommand);
+
+        $command = new SentrySubcommandTestCommand($this->logger, $subcommand);
+        $this->application->add($command);
+
+        try {
+            // Run first command which crashes but is handled
+            $this->application->doRun(new ArgvInput(['bin/console', 'sentry:subcommand:test']), new NullOutput());
+            $this->fail();
+        } catch (\Throwable $e) {
+            $this->assertSame($e->getMessage(), 'Breadcrumb error');
+        }
+
+        $command = new SentryDummyTestCommand($this->logger);
+        $this->application->add($command);
+
+        // Run the second command which crashes unhandled.
+        $this->application->doRun(new ArgvInput(['bin/console', 'sentry:dummy:test']), new NullOutput());
+
+        $event = Event::createEvent();
+        $modifiedEvent = null;
+        $this->hub->configureScope(function (Scope $scope) use ($event, &$modifiedEvent) {
+            $modifiedEvent = $scope->applyToEvent($event);
+        });
+
+        $this->assertNotNull($modifiedEvent);
+        // Breadcrumbs contain all log entries until the sentry:dummy:test command crash.
+        $this->assertCount(3, $modifiedEvent->getBreadcrumbs());
+        // console.command tag is properly set to the last command
+        $this->assertSame($modifiedEvent->getTags()['console.command'], 'sentry:dummy:test');
+    }
+}

--- a/tests/EventListener/AbstractConsoleListenerTest.php
+++ b/tests/EventListener/AbstractConsoleListenerTest.php
@@ -91,7 +91,7 @@ abstract class AbstractConsoleListenerTest extends TestCase
         $listenerClass = static::getListenerClass();
         $listener = new $listenerClass($this->hub);
 
-        $this->hub->expects($this->once())
+        $this->hub->expects($this->never())
             ->method('popScope');
 
         $listener->handleConsoleTerminateEvent(new ConsoleTerminateEvent(new Command(), new ArrayInput([]), new NullOutput(), 0));


### PR DESCRIPTION
This PR improves scope handling for symfony commands. Prior to this change, the scope was always reset on command termination, which would happen before sentry captures an exception that happens within the ConsoleCommand.

The console listener will now keep track if errors occurred during a command and will not reset the scope, which will add more context like breadcrumbs to the event.

It will also not reset the scope if the root command terminates to allow breadcrumbs to be added to an event.