### PR TITLE
fix(logs): use correct option name

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -86,7 +86,7 @@ parameters:
 			path: src/DependencyInjection/SentryExtension.php
 
 		-
-			message: "#^Cannot access offset 'before_send_logs' on mixed\\.$#"
+			message: "#^Cannot access offset 'before_send_log' on mixed\\.$#"
 			count: 1
 			path: src/DependencyInjection/SentryExtension.php
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -113,7 +113,7 @@ final class Configuration implements ConfigurationInterface
                         ->scalarNode('before_send_transaction')->end()
                         ->scalarNode('before_send_check_in')->end()
                         ->scalarNode('before_send_metrics')->end()
-                        ->scalarNode('before_send_logs')->end()
+                        ->scalarNode('before_send_log')->end()
                         ->variableNode('trace_propagation_targets')->end()
                         ->arrayNode('tags')
                             ->useAttributeAsKey('name')

--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -124,8 +124,8 @@ final class SentryExtension extends ConfigurableExtension
             $options['before_send_metrics'] = new Reference($options['before_send_metrics']);
         }
 
-        if (isset($options['before_send_logs'])) {
-            $options['before_send_logs'] = new Reference($options['before_send_logs']);
+        if (isset($options['before_send_log'])) {
+            $options['before_send_log'] = new Reference($options['before_send_log']);
         }
 
         if (isset($options['before_breadcrumb'])) {
@@ -290,7 +290,7 @@ final class SentryExtension extends ConfigurableExtension
     }
 
     /**
-     * @param string[]             $integrations
+     * @param string[] $integrations
      * @param array<string, mixed> $config
      *
      * @return array<Reference|Definition>
@@ -322,12 +322,12 @@ final class SentryExtension extends ConfigurableExtension
 
     /**
      * @param class-string<IntegrationInterface> $integrationClass
-     * @param array<Reference|Definition>        $integrations
+     * @param array<Reference|Definition> $integrations
      */
     private function isIntegrationEnabled(string $integrationClass, array $integrations): bool
     {
         foreach ($integrations as $integration) {
-            if ($integration instanceof Reference && $integrationClass === (string) $integration) {
+            if ($integration instanceof Reference && $integrationClass === (string)$integration) {
                 return true;
             }
 

--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -290,7 +290,7 @@ final class SentryExtension extends ConfigurableExtension
     }
 
     /**
-     * @param string[] $integrations
+     * @param string[]             $integrations
      * @param array<string, mixed> $config
      *
      * @return array<Reference|Definition>
@@ -322,12 +322,12 @@ final class SentryExtension extends ConfigurableExtension
 
     /**
      * @param class-string<IntegrationInterface> $integrationClass
-     * @param array<Reference|Definition> $integrations
+     * @param array<Reference|Definition>        $integrations
      */
     private function isIntegrationEnabled(string $integrationClass, array $integrations): bool
     {
         foreach ($integrations as $integration) {
-            if ($integration instanceof Reference && $integrationClass === (string)$integration) {
+            if ($integration instanceof Reference && $integrationClass === (string) $integration) {
                 return true;
             }
 

--- a/src/Resources/config/schema/sentry-1.0.xsd
+++ b/src/Resources/config/schema/sentry-1.0.xsd
@@ -55,7 +55,7 @@
         <xsd:attribute name="before-send-transaction" type="xsd:string" />
         <xsd:attribute name="before-send-check-in" type="xsd:string" />
         <xsd:attribute name="before-send-metrics" type="xsd:string" />
-        <xsd:attribute name="before-send-logs" type="xsd:string" />
+        <xsd:attribute name="before-send-log" type="xsd:string" />
         <xsd:attribute name="error-types" type="xsd:string" />
         <xsd:attribute name="max-breadcrumbs" type="xsd:integer" />
         <xsd:attribute name="before-breadcrumb" type="xsd:string" />

--- a/tests/DependencyInjection/Fixtures/php/full.php
+++ b/tests/DependencyInjection/Fixtures/php/full.php
@@ -33,7 +33,7 @@ $container->loadFromExtension('sentry', [
         'before_send_transaction' => 'App\\Sentry\\BeforeSendTransactionCallback',
         'before_send_check_in' => 'App\\Sentry\\BeforeSendCheckInCallback',
         'before_send_metrics' => 'App\\Sentry\\BeforeSendMetricsCallback',
-        'before_send_logs' => 'App\\Sentry\\BeforeSendLogsCallback',
+        'before_send_log' => 'App\\Sentry\\BeforeSendLogsCallback',
         'trace_propagation_targets' => ['website.invalid'],
         'tags' => [
             'context' => 'development',

--- a/tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/tests/DependencyInjection/Fixtures/xml/full.xml
@@ -30,7 +30,7 @@
                         before-send-transaction="App\Sentry\BeforeSendTransactionCallback"
                         before-send-check-in="App\Sentry\BeforeSendCheckInCallback"
                         before-send-metrics="App\Sentry\BeforeSendMetricsCallback"
-                        before-send-logs="App\Sentry\BeforeSendLogsCallback"
+                        before-send-log="App\Sentry\BeforeSendLogsCallback"
                         error-types="E_ALL"
                         max-breadcrumbs="1"
                         before-breadcrumb="App\Sentry\BeforeBreadcrumbCallback"

--- a/tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/tests/DependencyInjection/Fixtures/yml/full.yml
@@ -30,7 +30,7 @@ sentry:
         before_send_transaction: App\Sentry\BeforeSendTransactionCallback
         before_send_check_in: App\Sentry\BeforeSendCheckInCallback
         before_send_metrics: App\Sentry\BeforeSendMetricsCallback
-        before_send_logs: App\Sentry\BeforeSendLogsCallback
+        before_send_log: App\Sentry\BeforeSendLogsCallback
         trace_propagation_targets:
           - 'website.invalid'
         tags:

--- a/tests/DependencyInjection/SentryExtensionTest.php
+++ b/tests/DependencyInjection/SentryExtensionTest.php
@@ -491,7 +491,7 @@ abstract class SentryExtensionTest extends TestCase
 
     /**
      * @param array<int, mixed> $methodCall
-     * @param mixed[] $arguments
+     * @param mixed[]           $arguments
      */
     private function assertDefinitionMethodCallAt(array $methodCall, string $method, array $arguments): void
     {

--- a/tests/DependencyInjection/SentryExtensionTest.php
+++ b/tests/DependencyInjection/SentryExtensionTest.php
@@ -229,7 +229,7 @@ abstract class SentryExtensionTest extends TestCase
             'before_send_transaction' => new Reference('App\\Sentry\\BeforeSendTransactionCallback'),
             'before_send_check_in' => new Reference('App\\Sentry\\BeforeSendCheckInCallback'),
             'before_send_metrics' => new Reference('App\\Sentry\\BeforeSendMetricsCallback'),
-            'before_send_logs' => new Reference('App\\Sentry\\BeforeSendLogsCallback'),
+            'before_send_log' => new Reference('App\\Sentry\\BeforeSendLogsCallback'),
             'trace_propagation_targets' => ['website.invalid'],
             'tags' => [
                 'context' => 'development',
@@ -491,7 +491,7 @@ abstract class SentryExtensionTest extends TestCase
 
     /**
      * @param array<int, mixed> $methodCall
-     * @param mixed[]           $arguments
+     * @param mixed[] $arguments
      */
     private function assertDefinitionMethodCallAt(array $methodCall, string $method, array $arguments): void
     {

--- a/tests/End2End/App/Callback/BeforeSendLogCallback.php
+++ b/tests/End2End/App/Callback/BeforeSendLogCallback.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Sentry\SentryBundle\Tests\End2End\App\Callback;
+
+use Sentry\Logs\Log;
+
+class BeforeSendLogCallback
+{
+
+    public function getCallback(): callable
+    {
+        return function (Log $log): ?Log {
+            if ($log->getBody() === "before_send_log") {
+                return null;
+            }
+            return $log;
+        };
+    }
+
+}

--- a/tests/End2End/App/Callback/BeforeSendLogCallback.php
+++ b/tests/End2End/App/Callback/BeforeSendLogCallback.php
@@ -1,20 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sentry\SentryBundle\Tests\End2End\App\Callback;
 
 use Sentry\Logs\Log;
 
 class BeforeSendLogCallback
 {
-
     public function getCallback(): callable
     {
         return function (Log $log): ?Log {
-            if ($log->getBody() === "before_send_log") {
+            if ('before_send_log' === $log->getBody()) {
                 return null;
             }
+
             return $log;
         };
     }
-
 }

--- a/tests/End2End/App/Controller/LoggingController.php
+++ b/tests/End2End/App/Controller/LoggingController.php
@@ -46,9 +46,9 @@ class LoggingController
 
     public function beforeSendLog()
     {
-        $this->logger->warning("warn 1");
-        $this->logger->error("before_send_log");
-        $this->logger->warning("warn 2");
+        $this->logger->warning('warn 1');
+        $this->logger->error('before_send_log');
+        $this->logger->warning('warn 2');
 
         return new Response();
     }

--- a/tests/End2End/App/Controller/LoggingController.php
+++ b/tests/End2End/App/Controller/LoggingController.php
@@ -43,4 +43,13 @@ class LoggingController
         $this->logger->error('About to crash');
         throw new \RuntimeException('Crash');
     }
+
+    public function beforeSendLog()
+    {
+        $this->logger->warning("warn 1");
+        $this->logger->error("before_send_log");
+        $this->logger->warning("warn 2");
+
+        return new Response();
+    }
 }

--- a/tests/End2End/App/logging.yml
+++ b/tests/End2End/App/logging.yml
@@ -1,6 +1,7 @@
 sentry:
   options:
     enable_logs: true
+    before_send_log: "sentry.callback.before_send_log"
 
 monolog:
   handlers:
@@ -12,6 +13,13 @@ services:
   Sentry\SentryBundle\Monolog\LogsHandler:
     arguments:
       - !php/const Monolog\Logger::WARNING
+
+  Sentry\SentryBundle\Tests\End2End\App\Callback\BeforeSendLogCallback:
+    autowire: true
+
+  sentry.callback.before_send_log:
+    class: 'Sentry\SentryBundle\Tests\End2End\App\Callback\BeforeSendLogCallback'
+    factory: ['@Sentry\SentryBundle\Tests\End2End\App\Callback\BeforeSendLogCallback', 'getCallback']
 
   Sentry\SentryBundle\Tests\End2End\App\Controller\LoggingController:
     autowire: true

--- a/tests/End2End/App/routing.yml
+++ b/tests/End2End/App/routing.yml
@@ -50,6 +50,10 @@ logging_With_Error:
   path: /logging-with-error
   defaults: { _controller: 'Sentry\SentryBundle\Tests\End2End\App\Controller\LoggingController::loggingWithError' }
 
+logging_before_send_logs:
+  path: /before-send-log
+  defaults: { _controller: 'Sentry\SentryBundle\Tests\End2End\App\Controller\LoggingController::beforeSendLog' }
+
 buffer_flush:
   path: /buffer-flush
   defaults: { _controller: 'Sentry\SentryBundle\Tests\End2End\App\Controller\BufferFlushController::testBufferFlush' }

--- a/tests/End2End/LoggingEnd2EndTest.php
+++ b/tests/End2End/LoggingEnd2EndTest.php
@@ -57,6 +57,23 @@ class LoggingEnd2EndTest extends WebTestCase
         $this->assertCount(2, $logsEvent->getLogs());
     }
 
+    public function testBeforeSendLogCallback()
+    {
+        $client = static::createClient(['debug' => false]);
+
+        $client->request('GET', '/before-send-log');
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+        $this->assertCount(1, StubTransport::$events);
+        $event = StubTransport::$events[0];
+        $logs = $this->filterFrameworkLogs($event->getLogs());
+
+        // Make sure we just have two warn logs and no error log (since it's filtered by the callback)
+        $this->assertCount(2, $logs);
+        $this->assertEquals('warn 1', $logs[0]->getBody());
+        $this->assertEquals('warn 2', $logs[1]->getBody());
+    }
+
     /**
      * Removes framework logs so that the tests can focus on our expected logs.
      *

--- a/tests/End2End/LoggingEnd2EndTest.php
+++ b/tests/End2End/LoggingEnd2EndTest.php
@@ -57,7 +57,7 @@ class LoggingEnd2EndTest extends WebTestCase
         $this->assertCount(2, $logsEvent->getLogs());
     }
 
-    public function testBeforeSendLogCallback()
+    public function testBeforeSendLogCallback(): void
     {
         $client = static::createClient(['debug' => false]);
 


### PR DESCRIPTION
We used the plural `before_send_logs` while the base SDK expects the singular `before_send_log`.
This PR updates it to also use the singular version and also adds a test to verify that the callback works.