### PR TITLE
feat(cache): enable auto-instrumentation for symfony cache

### DIFF
--- a/src/Tracing/Cache/TraceableCacheAdapterForV2.php
+++ b/src/Tracing/Cache/TraceableCacheAdapterForV2.php
@@ -40,14 +40,8 @@ final class TraceableCacheAdapterForV2 implements AdapterInterface, CacheInterfa
      *
      * @return mixed
      */
-    public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null)
+    public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null): mixed
     {
-        return $this->traceFunction('cache.get_item', function () use ($key, $callback, $beta, &$metadata) {
-            if (!$this->decoratedAdapter instanceof CacheInterface) {
-                throw new \BadMethodCallException(\sprintf('The %s::get() method is not supported because the decorated adapter does not implement the "%s" interface.', self::class, CacheInterface::class));
-            }
-
-            return $this->decoratedAdapter->get($key, $callback, $beta, $metadata);
-        }, $key);
+        return $this->traceGet($key, $callback, $beta, $metadata);
     }
 }

--- a/src/Tracing/Cache/TraceableCacheAdapterForV3.php
+++ b/src/Tracing/Cache/TraceableCacheAdapterForV3.php
@@ -40,12 +40,6 @@ final class TraceableCacheAdapterForV3 implements AdapterInterface, CacheInterfa
      */
     public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null): mixed
     {
-        return $this->traceFunction('cache.get_item', function () use ($key, $callback, $beta, &$metadata) {
-            if (!$this->decoratedAdapter instanceof CacheInterface) {
-                throw new \BadMethodCallException(\sprintf('The %s::get() method is not supported because the decorated adapter does not implement the "%s" interface.', self::class, CacheInterface::class));
-            }
-
-            return $this->decoratedAdapter->get($key, $callback, $beta, $metadata);
-        }, $key);
+        return $this->traceGet($key, $callback, $beta, $metadata);
     }
 }

--- a/src/Tracing/Cache/TraceableCacheAdapterForV3WithNamespace.php
+++ b/src/Tracing/Cache/TraceableCacheAdapterForV3WithNamespace.php
@@ -41,13 +41,7 @@ final class TraceableCacheAdapterForV3WithNamespace implements AdapterInterface,
      */
     public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null): mixed
     {
-        return $this->traceFunction('cache.get_item', function () use ($key, $callback, $beta, &$metadata) {
-            if (!$this->decoratedAdapter instanceof CacheInterface) {
-                throw new \BadMethodCallException(\sprintf('The %s::get() method is not supported because the decorated adapter does not implement the "%s" interface.', self::class, CacheInterface::class));
-            }
-
-            return $this->decoratedAdapter->get($key, $callback, $beta, $metadata);
-        }, $key);
+        return $this->traceGet($key, $callback, $beta, $metadata);
     }
 
     public function withSubNamespace(string $namespace): static

--- a/src/Tracing/Cache/TraceableCacheAdapterTrait.php
+++ b/src/Tracing/Cache/TraceableCacheAdapterTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sentry\SentryBundle\Tracing\Cache;
 
 use Psr\Cache\CacheItemInterface;
+use Psr\Cache\InvalidArgumentException;
 use Sentry\State\HubInterface;
 use Sentry\Tracing\SpanContext;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
@@ -38,7 +39,7 @@ trait TraceableCacheAdapterTrait
      */
     public function getItem($key): CacheItem
     {
-        return $this->traceFunction('cache.get_item', function () use ($key): CacheItem {
+        return $this->traceFunction('cache.get', function () use ($key): CacheItem {
             return $this->decoratedAdapter->getItem($key);
         }, $key);
     }
@@ -48,7 +49,7 @@ trait TraceableCacheAdapterTrait
      */
     public function getItems(array $keys = []): iterable
     {
-        return $this->traceFunction('cache.get_items', function () use ($keys): iterable {
+        return $this->traceFunction('cache.get', function () use ($keys): iterable {
             return $this->decoratedAdapter->getItems($keys);
         });
     }
@@ -58,7 +59,7 @@ trait TraceableCacheAdapterTrait
      */
     public function clear(string $prefix = ''): bool
     {
-        return $this->traceFunction('cache.clear', function () use ($prefix): bool {
+        return $this->traceFunction('cache.flush', function () use ($prefix): bool {
             return $this->decoratedAdapter->clear($prefix);
         }, $prefix);
     }
@@ -68,7 +69,7 @@ trait TraceableCacheAdapterTrait
      */
     public function delete(string $key): bool
     {
-        return $this->traceFunction('cache.delete_item', function () use ($key): bool {
+        return $this->traceFunction('cache.remove', function () use ($key): bool {
             if (!$this->decoratedAdapter instanceof CacheInterface) {
                 throw new \BadMethodCallException(\sprintf('The %s::delete() method is not supported because the decorated adapter does not implement the "%s" interface.', self::class, CacheInterface::class));
             }
@@ -92,7 +93,7 @@ trait TraceableCacheAdapterTrait
      */
     public function deleteItem($key): bool
     {
-        return $this->traceFunction('cache.delete_item', function () use ($key): bool {
+        return $this->traceFunction('cache.remove', function () use ($key): bool {
             return $this->decoratedAdapter->deleteItem($key);
         }, $key);
     }
@@ -102,7 +103,7 @@ trait TraceableCacheAdapterTrait
      */
     public function deleteItems(array $keys): bool
     {
-        return $this->traceFunction('cache.delete_items', function () use ($keys): bool {
+        return $this->traceFunction('cache.remove', function () use ($keys): bool {
             return $this->decoratedAdapter->deleteItems($keys);
         });
     }
@@ -112,7 +113,7 @@ trait TraceableCacheAdapterTrait
      */
     public function save(CacheItemInterface $item): bool
     {
-        return $this->traceFunction('cache.save', function () use ($item): bool {
+        return $this->traceFunction('cache.put', function () use ($item): bool {
             return $this->decoratedAdapter->save($item);
         });
     }
@@ -122,7 +123,7 @@ trait TraceableCacheAdapterTrait
      */
     public function saveDeferred(CacheItemInterface $item): bool
     {
-        return $this->traceFunction('cache.save_deferred', function () use ($item): bool {
+        return $this->traceFunction('cache.put', function () use ($item): bool {
             return $this->decoratedAdapter->saveDeferred($item);
         });
     }
@@ -162,6 +163,10 @@ trait TraceableCacheAdapterTrait
     }
 
     /**
+     * Traces a symfony operation and creating one span in the process.
+     *
+     * If you want to trace a get operation with callback, use {@see self::traceGet()} instead.
+     *
      * @phpstan-template TResult
      *
      * @phpstan-param \Closure(): TResult $callback
@@ -172,25 +177,143 @@ trait TraceableCacheAdapterTrait
     {
         $span = $this->hub->getSpan();
 
-        if (null !== $span) {
-            $spanContext = SpanContext::make()
-                ->setOp($spanOperation)
-                ->setOrigin('auto.cache');
+        // Exit early if we have no span.
+        if (null === $span) {
+            return $callback();
+        }
 
-            if (null !== $spanDescription) {
-                $spanContext->setDescription(urldecode($spanDescription));
+        $spanContext = SpanContext::make()
+            ->setOp($spanOperation)
+            ->setOrigin('auto.cache');
+
+        if (null !== $spanDescription) {
+            $spanContext->setDescription(urldecode($spanDescription));
+        }
+
+        $span = $span->startChild($spanContext);
+
+        try {
+            $result = $callback();
+
+            // Necessary for static analysis. Otherwise, the TResult type is assumed to be CacheItemInterface.
+            if (!$result instanceof CacheItemInterface) {
+                return $result;
             }
 
-            $span = $span->startChild($spanContext);
+            $data = ['cache.hit' => $result->isHit()];
+            if ($result->isHit()) {
+                $data['cache.item_size'] = static::getCacheItemSize($result->get());
+            }
+            $span->setData($data);
+
+            return $result;
+        } finally {
+            $span->finish();
+        }
+    }
+
+    /**
+     * Traces a Symfony Cache get() call with a get and optional put span.
+     *
+     * Produces 2 spans in case of a cache miss:
+     * 1. 'cache.get' span
+     * 2. 'cache.put' span
+     *
+     * If the callback uses code with sentry traces, those traces will be available in the trace explorer.
+     *
+     * Use this method if you want to instrument {@see CacheInterface::get()}.
+     *
+     * @param string                       $key
+     * @param callable                     $callback
+     * @param float|null                   $beta
+     * @param array<int|string,mixed>|null $metadata
+     *
+     * @return mixed
+     *
+     * @throws InvalidArgumentException
+     */
+    private function traceGet(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null)
+    {
+        if (!$this->decoratedAdapter instanceof CacheInterface) {
+            throw new \BadMethodCallException(\sprintf('The %s::get() method is not supported because the decorated adapter does not implement the "%s" interface.', self::class, CacheInterface::class));
+        }
+        $parentSpan = $this->hub->getSpan();
+
+        // If we don't have a parent span we can just forward it.
+        if (null === $parentSpan) {
+            return $this->decoratedAdapter->get($key, $callback, $beta, $metadata);
         }
 
         try {
-            return $callback();
-        } finally {
-            if (null !== $span) {
-                $span->finish();
+            $spanContext = SpanContext::make()
+                ->setOp('cache.get')
+                ->setOrigin('auto.cache');
+
+            $spanContext->setDescription(urldecode($key));
+
+            $getSpan = $parentSpan->startChild($spanContext);
+            $this->hub->setSpan($getSpan);
+
+            $wasMiss = false;
+            $saveStartTimestamp = null;
+
+            $value = $this->decoratedAdapter->get($key, function (CacheItemInterface $item, &$save) use ($callback, &$wasMiss, &$saveStartTimestamp) {
+                $wasMiss = true;
+
+                $result = $callback($item, $save);
+
+                if ($save) {
+                    $saveStartTimestamp = microtime(true);
+                }
+
+                return $result;
+            }, $beta, $metadata);
+
+            $now = microtime(true);
+
+            $getSpan->setData([
+                'cache.hit' => !$wasMiss,
+                'cache.item_size' => self::getCacheItemSize($value),
+            ]);
+
+            // If we got a timestamp here we know that we missed
+            if (null !== $saveStartTimestamp) {
+                $getSpan->finish($saveStartTimestamp);
+                $saveContext = SpanContext::make()
+                    ->setOp('cache.put')
+                    ->setOrigin('auto.cache')
+                    ->setDescription(urldecode($key));
+                $saveSpan = $parentSpan->startChild($saveContext);
+                $saveSpan->setStartTimestamp($saveStartTimestamp);
+                $saveSpan->setData([
+                    'cache.item_size' => self::getCacheItemSize($value),
+                ]);
+                $saveSpan->finish($now);
+            } else {
+                $getSpan->finish();
             }
+        } finally {
+            // We always want to restore the previous parent span.
+            $this->hub->setSpan($parentSpan);
         }
+
+        return $value;
+    }
+
+    /**
+     * Calculates the size of the cached item.
+     *
+     * @param mixed $value
+     *
+     * @return int|null
+     */
+    public static function getCacheItemSize($value): ?int
+    {
+        if (\is_string($value)) {
+            return \strlen($value);
+        }
+
+        return null;
     }
 
     /**

--- a/src/Tracing/Cache/TraceableTagAwareCacheAdapterForV2.php
+++ b/src/Tracing/Cache/TraceableTagAwareCacheAdapterForV2.php
@@ -8,7 +8,6 @@ use Sentry\State\HubInterface;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Component\Cache\ResettableInterface;
-use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\TagAwareCacheInterface;
 
 /**
@@ -43,13 +42,7 @@ final class TraceableTagAwareCacheAdapterForV2 implements TagAwareAdapterInterfa
      */
     public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null)
     {
-        return $this->traceFunction('cache.get_item', function () use ($key, $callback, $beta, &$metadata) {
-            if (!$this->decoratedAdapter instanceof CacheInterface) {
-                throw new \BadMethodCallException(\sprintf('The %s::get() method is not supported because the decorated adapter does not implement the "%s" interface.', self::class, CacheInterface::class));
-            }
-
-            return $this->decoratedAdapter->get($key, $callback, $beta, $metadata);
-        }, $key);
+        return $this->traceGet($key, $callback, $beta, $metadata);
     }
 
     /**

--- a/src/Tracing/Cache/TraceableTagAwareCacheAdapterForV3.php
+++ b/src/Tracing/Cache/TraceableTagAwareCacheAdapterForV3.php
@@ -8,7 +8,6 @@ use Sentry\State\HubInterface;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Component\Cache\ResettableInterface;
-use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\TagAwareCacheInterface;
 
 /**
@@ -25,7 +24,7 @@ final class TraceableTagAwareCacheAdapterForV3 implements TagAwareAdapterInterfa
     use TraceableCacheAdapterTrait;
 
     /**
-     * @param HubInterface             $hub              The current hub
+     * @param HubInterface $hub The current hub
      * @param TagAwareAdapterInterface $decoratedAdapter The decorated cache adapter
      */
     public function __construct(HubInterface $hub, TagAwareAdapterInterface $decoratedAdapter)
@@ -41,13 +40,7 @@ final class TraceableTagAwareCacheAdapterForV3 implements TagAwareAdapterInterfa
      */
     public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null): mixed
     {
-        return $this->traceFunction('cache.get_item', function () use ($key, $callback, $beta, &$metadata) {
-            if (!$this->decoratedAdapter instanceof CacheInterface) {
-                throw new \BadMethodCallException(\sprintf('The %s::get() method is not supported because the decorated adapter does not implement the "%s" interface.', self::class, CacheInterface::class));
-            }
-
-            return $this->decoratedAdapter->get($key, $callback, $beta, $metadata);
-        }, $key);
+        return $this->traceGet($key, $callback, $beta, $metadata);
     }
 
     /**

--- a/tests/End2End/App/Controller/PsrTracingCacheController.php
+++ b/tests/End2End/App/Controller/PsrTracingCacheController.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\End2End\App\Controller;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+class PsrTracingCacheController
+{
+    /**
+     * @var AdapterInterface
+     */
+    private $adapter;
+
+    public function __construct(CacheItemPoolInterface $adapter)
+    {
+        $this->adapter = $adapter;
+    }
+
+    public function testPopulateString()
+    {
+        $item = $this->adapter->getItem('foo');
+        if (!$item->isHit()) {
+            $item->set('example');
+            $this->adapter->save($item);
+        }
+
+        return new Response();
+    }
+
+    public function testDelete()
+    {
+        $this->adapter->deleteItem('foo');
+
+        return new Response();
+    }
+}

--- a/tests/End2End/App/Controller/TracingCacheController.php
+++ b/tests/End2End/App/Controller/TracingCacheController.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\End2End\App\Controller;
+
+use Doctrine\DBAL\Connection;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\Cache\CacheInterface;
+
+class TracingCacheController
+{
+    /**
+     * @var CacheInterface
+     */
+    private $cache;
+
+    /**
+     * @var Connection|null
+     */
+    private $connection;
+
+    public function __construct(CacheInterface $cache, ?Connection $connection = null)
+    {
+        $this->cache = $cache;
+        $this->connection = $connection;
+    }
+
+    public function populateCacheWithString()
+    {
+        $this->cache->get('example', function () {
+            return 'example-string';
+        });
+
+        return new Response();
+    }
+
+    public function populateCacheWithInteger()
+    {
+        $this->cache->get('numeric', function () {
+            if ($this->connection) {
+                $this->connection->executeQuery('SELECT 1');
+            }
+
+            return 1234;
+        });
+
+        return new Response();
+    }
+
+    public function deleteCache()
+    {
+        $this->cache->delete('example');
+
+        return new Response();
+    }
+
+    public function getWithDbTrace()
+    {
+        $this->cache->get('fetched-value', function () {
+            $this->connection->executeQuery('SELECT 1');
+
+            return 'value';
+        });
+
+        return new Response();
+    }
+}

--- a/tests/End2End/App/config.yml
+++ b/tests/End2End/App/config.yml
@@ -20,6 +20,9 @@ framework:
   annotations: false
   php_errors:
     log: true
+  # Use FS cache for testing
+  cache:
+    app: cache.adapter.filesystem
 
 services:
   test.hub:

--- a/tests/End2End/App/routing.yml
+++ b/tests/End2End/App/routing.yml
@@ -42,6 +42,30 @@ tracing_ignored_transaction:
   path: /tracing/ignored-transaction
   defaults: { _controller: 'Sentry\SentryBundle\Tests\End2End\App\Controller\TracingController::ignoredTransaction' }
 
+tracing_cache_populate_string:
+  path: /tracing/cache/populate-string
+  defaults: { _controller: 'Sentry\SentryBundle\Tests\End2End\App\Controller\TracingCacheController::populateCacheWithString' }
+
+tracing_cache_populate_integer:
+  path: /tracing/cache/populate-integer
+  defaults: { _controller: 'Sentry\SentryBundle\Tests\End2End\App\Controller\TracingCacheController::populateCacheWithInteger' }
+
+tracing_cache_delete:
+  path: /tracing/cache/delete
+  defaults: { _controller: 'Sentry\SentryBundle\Tests\End2End\App\Controller\TracingCacheController::deleteCache' }
+
+tracing_cache_populate_string_with_db:
+  path: /tracing/cache/populate-string-with-db
+  defaults: { _controller: 'Sentry\SentryBundle\Tests\End2End\App\Controller\TracingCacheController::getWithDbTrace' }
+
+psr_tracing_cache_populate_string:
+  path: /tracing/cache/psr/populate-string
+  defaults: { _controller: 'Sentry\SentryBundle\Tests\End2End\App\Controller\PsrTracingCacheController::testPopulateString' }
+
+psr_tracing_cache_delete:
+  path: /tracing/cache/psr/delete
+  defaults: { _controller: 'Sentry\SentryBundle\Tests\End2End\App\Controller\PsrTracingCacheController::testDelete' }
+
 just_logging:
   path: /just-logging
   defaults: { _controller: 'Sentry\SentryBundle\Tests\End2End\App\Controller\LoggingController::justLogging' }

--- a/tests/End2End/App/tracing.yml
+++ b/tests/End2End/App/tracing.yml
@@ -10,4 +10,16 @@ services:
       $hub: '@Sentry\State\HubInterface'
       $connection: '@?doctrine.dbal.default_connection'
     tags:
-      - controller.service_arguments
+      - { name: controller.service_arguments }
+
+  Sentry\SentryBundle\Tests\End2End\App\Controller\TracingCacheController:
+    arguments:
+      $cache: '@cache.app'
+      $connection: '@?doctrine.dbal.default_connection'
+    tags:
+      - { name: controller.service_arguments }
+
+  Sentry\SentryBundle\Tests\End2End\App\Controller\PsrTracingCacheController:
+    autowire: true
+    tags:
+      - { name: controller.service_arguments }

--- a/tests/End2End/TracingCacheEnd2EndTest.php
+++ b/tests/End2End/TracingCacheEnd2EndTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\End2End;
+
+use Sentry\SentryBundle\Tests\End2End\App\KernelWithTracing;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * @runTestsInSeparateProcesses
+ */
+class TracingCacheEnd2EndTest extends WebTestCase
+{
+    protected static function getKernelClass(): string
+    {
+        return KernelWithTracing::class;
+    }
+
+    protected function setUp(): void
+    {
+        StubTransport::$events = [];
+    }
+
+    public function testPopulateStringCache()
+    {
+        $client = static::createClient(['debug' => false]);
+
+        $client->request('GET', '/tracing/cache/populate-string');
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+        $this->assertCount(1, StubTransport::$events);
+        $event = StubTransport::$events[0];
+        $this->assertCount(2, $event->getSpans());
+
+        $getSpan = $event->getSpans()[0];
+        $this->assertEquals('cache.get', $getSpan->getOp());
+        $this->assertEquals(14, $getSpan->getData('cache.item_size'));
+        $this->assertFalse($getSpan->getData('cache.hit'));
+
+        $putSpan = $event->getSpans()[1];
+        $this->assertEquals('cache.put', $putSpan->getOp());
+        $this->assertEquals(14, $getSpan->getData('cache.item_size'));
+        $this->assertNull($putSpan->getData('cache.hit'));
+
+        // assert that put is a sibling span to get
+        $this->assertNotEquals($getSpan->getSpanId(), $putSpan->getParentSpanId());
+        $this->assertEquals($getSpan->getParentSpanId(), $putSpan->getParentSpanId());
+    }
+
+    public function testCacheHit()
+    {
+        $client = static::createClient(['debug' => false]);
+
+        // Populate the cache by having a cache miss
+        $client->request('GET', '/tracing/cache/populate-string');
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+        // Reset transport so we only get events for cache HITs
+        StubTransport::$events = [];
+
+        $client->request('GET', '/tracing/cache/populate-string');
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+        $this->assertCount(1, StubTransport::$events);
+
+        $event = StubTransport::$events[0];
+        $this->assertCount(1, $event->getSpans());
+
+        $span = $event->getSpans()[0];
+        $this->assertEquals('cache.get', $span->getOp());
+        $this->assertEquals(14, $span->getData('cache.item_size'));
+        $this->assertTrue($span->getData('cache.hit'));
+    }
+
+    public function testNonStringItemSize()
+    {
+        $client = static::createClient(['debug' => false]);
+
+        $client->request('GET', '/tracing/cache/populate-integer');
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertCount(1, StubTransport::$events);
+
+        $event = StubTransport::$events[0];
+        $this->assertCount(2, $event->getSpans());
+
+        $span = $event->getSpans()[0];
+        $this->assertEquals('cache.get', $span->getOp());
+        $this->assertNull($span->getData('cache.item_size'));
+    }
+
+    public function testDeleteCacheSpan()
+    {
+        $client = static::createClient(['debug' => false]);
+
+        $client->request('GET', '/tracing/cache/delete');
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+        $this->assertCount(1, StubTransport::$events);
+        $event = StubTransport::$events[0];
+
+        $this->assertCount(1, $event->getSpans());
+
+        $span = $event->getSpans()[0];
+        $this->assertEquals('cache.remove', $span->getOp());
+        $this->assertNull($span->getData('cache.item_size'));
+    }
+
+    public function testGetWithDbSpan()
+    {
+        $client = static::createClient(['debug' => false]);
+
+        $client->request('GET', '/tracing/cache/populate-string-with-db');
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+        $this->assertCount(1, StubTransport::$events);
+        $event = StubTransport::$events[0];
+
+        $this->assertCount(3, $event->getSpans());
+        $getSpan = $event->getSpans()[0];
+        $this->assertEquals('cache.get', $getSpan->getOp());
+
+        $dbSpan = $event->getSpans()[1];
+        $this->assertEquals('db.sql.query', $dbSpan->getOp());
+
+        $putSpan = $event->getSpans()[2];
+        $this->assertEquals('cache.put', $putSpan->getOp());
+
+        // assert that the DB call is a child span of the get operation
+        $this->assertEquals($getSpan->getSpanId(), $dbSpan->getParentSpanId());
+
+        // assert that get and put are siblings
+        $this->assertEquals($getSpan->getParentSpanId(), $putSpan->getParentSpanId());
+    }
+
+    public function testPsrCachePopulateString()
+    {
+        $client = static::createClient(['debug' => false]);
+
+        $client->request('GET', '/tracing/cache/psr/populate-string');
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+        $this->assertCount(1, StubTransport::$events);
+        $event = StubTransport::$events[0];
+
+        // PSR caches will only have two spans, one for the get and one for put
+        $this->assertCount(2, $event->getSpans());
+
+        $getSpan = $event->getSpans()[0];
+        $this->assertEquals('cache.get', $getSpan->getOp());
+
+        $putSpan = $event->getSpans()[1];
+        $this->assertEquals('cache.put', $putSpan->getOp());
+    }
+
+    public function testPsrCacheHit()
+    {
+        $client = static::createClient(['debug' => false]);
+
+        $client->request('GET', '/tracing/cache/psr/populate-string');
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+        // This populates the cache and is tested in a different test
+        $this->assertCount(1, StubTransport::$events);
+        $this->assertCount(2, StubTransport::$events[0]->getSpans());
+        StubTransport::$events = [];
+
+        $client->request('PUT', '/tracing/cache/psr/populate-string');
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+        $this->assertCount(1, StubTransport::$events);
+        $event = StubTransport::$events[0];
+
+        $this->assertCount(1, $event->getSpans());
+        $span = $event->getSpans()[0];
+        $this->assertEquals('cache.get', $span->getOp());
+        $this->assertTrue($span->getData('cache.hit'));
+    }
+
+    public function testPsrCacheDelete()
+    {
+        $client = static::createClient(['debug' => false]);
+
+        $client->request('GET', '/tracing/cache/psr/delete');
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+        $this->assertCount(1, StubTransport::$events);
+        $event = StubTransport::$events[0];
+
+        $this->assertCount(1, $event->getSpans());
+        $span = $event->getSpans()[0];
+        $this->assertEquals('cache.remove', $span->getOp());
+        $this->assertNull($span->getData('cache.item_size'));
+    }
+}

--- a/tests/Tracing/Cache/AbstractTraceableCacheAdapterTest.php
+++ b/tests/Tracing/Cache/AbstractTraceableCacheAdapterTest.php
@@ -126,7 +126,8 @@ abstract class AbstractTraceableCacheAdapterTest extends TestCase
 
     public function testGet(): void
     {
-        $callback = static function () {};
+        $callback = static function () {
+        };
         $metadata = [];
         $transaction = new Transaction(new TransactionContext(), $this->hub);
         $transaction->initSpanRecorder();
@@ -149,7 +150,7 @@ abstract class AbstractTraceableCacheAdapterTest extends TestCase
         $spans = $transaction->getSpanRecorder()->getSpans();
 
         $this->assertCount(2, $spans);
-        $this->assertSame('cache.get_item', $spans[1]->getOp());
+        $this->assertSame('cache.get', $spans[1]->getOp());
         $this->assertSame('foo', $spans[1]->getDescription());
         $this->assertNotNull($spans[1]->getEndTimestamp());
     }
@@ -161,7 +162,8 @@ abstract class AbstractTraceableCacheAdapterTest extends TestCase
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage(\sprintf('The %s::get() method is not supported because the decorated adapter does not implement the "Symfony\\Contracts\\Cache\\CacheInterface" interface.', \get_class($adapter)));
 
-        $adapter->get('foo', static function () {});
+        $adapter->get('foo', static function () {
+        });
     }
 
     public function testDelete(): void
@@ -187,7 +189,7 @@ abstract class AbstractTraceableCacheAdapterTest extends TestCase
         $spans = $transaction->getSpanRecorder()->getSpans();
 
         $this->assertCount(2, $spans);
-        $this->assertSame('cache.delete_item', $spans[1]->getOp());
+        $this->assertSame('cache.delete', $spans[1]->getOp());
         $this->assertSame('foo', $spans[1]->getDescription());
         $this->assertNotNull($spans[1]->getEndTimestamp());
     }


### PR DESCRIPTION
Introduces auto-instrumentation for Symfony cache.

Symfony cache works slightly different than PSR-6 Cache. Instead of having an explicit put or save method, it provides a callback which is invoked on a cache miss.

Sentry will now auto instrument those and will provide proper spans. If the callback produces spans, those spans will be visible in the trace explorer to give further insights to the cache operation.

This PR also updates the `span.op`. Previously, it just used the PSR-6 method names as span op, which would not work with the [Cache Module](https://develop.sentry.dev/sdk/telemetry/traces/modules/caches/).