### PR TITLE
fix: support named arguments in BufferFlushPass

### DIFF
--- a/src/DependencyInjection/Compiler/BufferFlushPass.php
+++ b/src/DependencyInjection/Compiler/BufferFlushPass.php
@@ -45,8 +45,8 @@ class BufferFlushPass implements CompilerPassInterface
                 $arguments = $definition->getArguments();
                 if (!empty($arguments)) {
                     // The first argument of BufferHandler is the HandlerInterface, which
-                    // can be a SentryHandler.
-                    $firstArgument = $arguments[0];
+                    // can be a SentryHandler. Missing argument will be ignored.
+                    $firstArgument = $arguments[0] ?? $arguments['$handler'] ?? null;
 
                     if ($firstArgument instanceof Reference) {
                         $referencedServiceId = (string) $firstArgument;

--- a/tests/DependencyInjection/Compiler/BufferFlushPassTest.php
+++ b/tests/DependencyInjection/Compiler/BufferFlushPassTest.php
@@ -116,4 +116,21 @@ class BufferFlushPassTest extends TestCase
         $serviceIds = $this->argumentToName($definition);
         $this->assertEquals(['sentry.test.handler'], $serviceIds);
     }
+
+    /**
+     * Test that the flusher will work with named arguments.
+     *
+     * @return void
+     */
+    public function testProcessWithNamedArguments()
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition('sentry.handler', new Definition(SentryHandler::class));
+        $container->setDefinition('sentry.test.handler', new Definition(BufferHandler::class, ['$handler' => new Reference('sentry.handler')]));
+
+        (new BufferFlushPass())->process($container);
+        $definition = $container->getDefinition('sentry.buffer_flusher');
+        $serviceIds = $this->argumentToName($definition);
+        $this->assertEquals(['sentry.test.handler'], $serviceIds);
+    }
 }


### PR DESCRIPTION
This PR fixes "Undefined array key 0" on BufferFlushPass when using named arguments