### PR TITLE
fix(logs): Allow passing string and enum Monolog level

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -18,6 +18,20 @@
       <code><![CDATA[isMasterRequest]]></code>
     </UndefinedMethod>
   </file>
+  <file src="src/Monolog/LogsHandler.php">
+    <InvalidParamDefault>
+      <code><![CDATA[value-of<MonologLevel::VALUES>|value-of<MonologLevel::NAMES>|MonologLevel|PsrLogLevel::*]]></code>
+    </InvalidParamDefault>
+    <UndefinedClass>
+      <code><![CDATA[value-of<MonologLevel::VALUES>|value-of<MonologLevel::NAMES>|MonologLevel|PsrLogLevel::*]]></code>
+    </UndefinedClass>
+    <UndefinedDocblockClass>
+      <code><![CDATA[value-of<MonologLevel::VALUES>|value-of<MonologLevel::NAMES>|MonologLevel|PsrLogLevel::*]]></code>
+    </UndefinedDocblockClass>
+    <UnresolvableConstant>
+      <code><![CDATA[value-of<MonologLevel::VALUES>|value-of<MonologLevel::NAMES>|MonologLevel|PsrLogLevel::*]]></code>
+    </UnresolvableConstant>
+  </file>
   <file src="src/Tracing/Cache/TraceableCacheAdapterTrait.php">
     <LessSpecificImplementedReturnType>
       <code><![CDATA[iterable]]></code>

--- a/src/Monolog/LogsHandler.php
+++ b/src/Monolog/LogsHandler.php
@@ -7,6 +7,7 @@ namespace Sentry\SentryBundle\Monolog;
 use Monolog\Level as MonologLevel;
 use Monolog\Logger as MonologLogger;
 use Monolog\LogRecord;
+use Psr\Log\InvalidArgumentException;
 use Psr\Log\LogLevel as PsrLogLevel;
 use Sentry\Monolog\CompatibilityLogLevelTrait;
 use Sentry\Monolog\LogsHandler as BaseLogsHandler;
@@ -27,7 +28,11 @@ class LogsHandler extends BaseLogsHandler
      */
     public function __construct($level = MonologLogger::DEBUG, bool $bubble = true)
     {
-        $level = MonologLogger::toMonologLevel($level);
+        try {
+            $level = MonologLogger::toMonologLevel($level);
+        } catch (InvalidArgumentException $e) {
+            $level = MonologLogger::INFO;
+        }
         if ($level instanceof MonologLevel) { // Monolog >= 3
             $level = $level->value;
         }

--- a/src/Monolog/LogsHandler.php
+++ b/src/Monolog/LogsHandler.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Sentry\SentryBundle\Monolog;
 
+use Monolog\Level as MonologLevel;
 use Monolog\Logger as MonologLogger;
 use Monolog\LogRecord;
+use Psr\Log\LogLevel as PsrLogLevel;
 use Sentry\Monolog\CompatibilityLogLevelTrait;
 use Sentry\Monolog\LogsHandler as BaseLogsHandler;
 
@@ -18,8 +20,17 @@ class LogsHandler extends BaseLogsHandler
 {
     use CompatibilityLogLevelTrait;
 
-    public function __construct(int $level = MonologLogger::DEBUG, bool $bubble = true)
+    /**
+     * @param int|string|MonologLevel|PsrLogLevel::* $level
+     *
+     * @phpstan-param value-of<MonologLevel::VALUES>|value-of<MonologLevel::NAMES>|MonologLevel|PsrLogLevel::* $level
+     */
+    public function __construct($level = MonologLogger::DEBUG, bool $bubble = true)
     {
+        $level = MonologLogger::toMonologLevel($level);
+        if ($level instanceof MonologLevel) { // Monolog >= 3
+            $level = $level->value;
+        }
         $logLevel = self::getSentryLogLevelFromMonologLevel($level);
         parent::__construct($logLevel, $bubble);
     }

--- a/tests/Monolog/LogsHandlerTest.php
+++ b/tests/Monolog/LogsHandlerTest.php
@@ -84,4 +84,18 @@ final class LogsHandlerTest extends TestCase
             yield [MonologLevel::Debug];
         }
     }
+
+    public function testHandlerFallbacksToInfoOnInvalidLevel(): void
+    {
+        /** @phpstan-ignore-next-line */
+        $handler = new LogsHandler(123124213, false);
+        $record = [
+            'message' => 'msg',
+            'context' => [],
+            'extra' => [],
+        ];
+
+        $this->assertFalse($handler->handle($record + ['level' => MonologLogger::DEBUG]));
+        $this->assertTrue($handler->handle($record + ['level' => MonologLogger::WARNING]));
+    }
 }

--- a/tests/Monolog/LogsHandlerTest.php
+++ b/tests/Monolog/LogsHandlerTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Sentry\SentryBundle\Tests\Monolog;
 
+use Monolog\Level as MonologLevel;
 use Monolog\Logger as MonologLogger;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LogLevel as PsrLogLevel;
 use Sentry\SentryBundle\Monolog\LogsHandler;
 
 final class LogsHandlerTest extends TestCase
@@ -47,5 +49,39 @@ final class LogsHandlerTest extends TestCase
         ];
 
         $this->assertTrue($handler->handle($record));
+    }
+
+    /**
+     * @dataProvider levelProvider
+     *
+     * @param int|string|MonologLevel $level
+     *
+     * @phpstan-param value-of<MonologLevel::VALUES>|value-of<MonologLevel::NAMES>|MonologLevel|PsrLogLevel::* $level
+     */
+    public function testHandlerAcceptsVariousTypesAsLevel($level): void
+    {
+        $handler = new LogsHandler($level, false);
+        $record = [
+            'level' => MonologLogger::WARNING,
+            'message' => 'msg',
+            'context' => [],
+            'extra' => [],
+        ];
+
+        $this->assertTrue($handler->handle($record));
+    }
+
+    /**
+     * @return iterable<array{0: int|string|MonologLevel}>
+     */
+    public static function levelProvider(): iterable
+    {
+        yield [MonologLogger::DEBUG];
+        yield ['DEBUG'];
+        yield [PsrLogLevel::DEBUG];
+
+        if (class_exists(MonologLevel::class)) {
+            yield [MonologLevel::Debug];
+        }
     }
 }


### PR DESCRIPTION
### Description

Currently, the constructor only accepts integers as the log level, e.g. by using the `Monolog\Logger` constants:

```yaml
services:
  Sentry\SentryBundle\Monolog\LogsHandler:
    arguments:
      - !php/const Monolog\Logger::INFO
```

This, however, isn't very flexible, especially since the Monolog constants are deprecated.
This PR expands the accepted types to also allow strings or the Monolog `Level` enum, like other handlers:

```yaml
services:
  Sentry\SentryBundle\Monolog\LogsHandler:
    arguments:
      - 'info'
```

```yaml
# or using PSR constants
services:
  Sentry\SentryBundle\Monolog\LogsHandler:
    arguments:
      - !php/const Psr\Log\LogLevel::INFO
```

```php
// or via PHP config
$container->services()
    ->set(\Sentry\SentryBundle\Monolog\LogsHandler::class)
    ->args([\Monolog\Level::Info]);
```