### PR TITLE
fix: PHP8.4 deprecation warning

### DIFF
--- a/src/Tracing/HttpClient/TraceableResponseForV4.php
+++ b/src/Tracing/HttpClient/TraceableResponseForV4.php
@@ -12,7 +12,7 @@ final class TraceableResponseForV4 extends AbstractTraceableResponse
     /**
      * {@inheritdoc}
      */
-    public function getInfo(string $type = null)
+    public function getInfo(?string $type = null)
     {
         return $this->response->getInfo($type);
     }


### PR DESCRIPTION
### Description
Resolve PHP8.4 deprecation

```
FILE: /vendor/sentry/sentry-symfony/src/Tracing/HttpClient/TraceableResponseForV4.php
------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
------------------------------------------------------------------------------------------------------------------------
 15 | WARNING | Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be
    |         | explicitly nullable instead. Found implicitly nullable parameter: $type.
    |         | (PHPCompatibility.FunctionDeclarations.RemovedImplicitlyNullableParam.Deprecated)
```