### PR TITLE
fix: remove twig extension if TwigBundle is not installed

### DIFF
--- a/src/DependencyInjection/SentryExtension.php
+++ b/src/DependencyInjection/SentryExtension.php
@@ -72,7 +72,7 @@ final class SentryExtension extends ConfigurableExtension
 
         // Remove Twig extension service if Twig is not installed to avoid autoloading failures on Symfony 8
         if (!class_exists(\Twig\Extension\AbstractExtension::class)) {
-            $container->removeDefinition(\Sentry\SentryBundle\Twig\SentryExtension::class);
+            $container->removeDefinition(TwigSentryExtension::class);
         }
 
         $this->registerConfiguration($container, $mergedConfig);


### PR DESCRIPTION
### Description
<!-- What changed and why? -->
When running this without twig I get build errors because we are missing Twigs AbstractExtension

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-symfony/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
