### PR TITLE
fix: `symfony/yaml` is a required dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "symfony/event-dispatcher": "^4.4.20||^5.0.11||^6.0||^7.0||^8.0",
         "symfony/http-kernel": "^4.4.20||^5.0.11||^6.0||^7.0||^8.0",
         "symfony/polyfill-php80": "^1.22",
-        "symfony/psr-http-message-bridge": "^1.2||^2.0||^6.4||^7.0||^8.0"
+        "symfony/psr-http-message-bridge": "^1.2||^2.0||^6.4||^7.0||^8.0",
+        "symfony/yaml": "^4.4.20||^5.0.11||^6.0||^7.0||^8.0"
     },
     "require-dev": {
         "doctrine/dbal": "^2.13||^3.3||^4.0",
@@ -47,7 +48,6 @@
         "symfony/security-core": "^4.4.20||^5.0.11||^6.0||^7.0||^8.0",
         "symfony/security-http": "^4.4.20||^5.0.11||^6.0||^7.0||^8.0",
         "symfony/twig-bundle": "^4.4.20||^5.0.11||^6.0||^7.0||^8.0",
-        "symfony/yaml": "^4.4.20||^5.0.11||^6.0||^7.0||^8.0",
         "vimeo/psalm": "^4.3||^5.16.0"
     },
     "suggest": {


### PR DESCRIPTION
### Description
#968 migrated the service definitions from XML to YAML, however, the bundle only declares the YAML component as a development dependency.  This causes the bundle's services to not be loaded if an application does not have the component installed, therefore, the YAML component is now a production dependency of the bundle.

#### Issues
Follow-up to #968

#### Reminders
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-symfony/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
