### PR TITLE
ref: add hardening to twig meta rendering

### DIFF
--- a/src/EventListener/LogRequestListener.php
+++ b/src/EventListener/LogRequestListener.php
@@ -19,7 +19,7 @@ class LogRequestListener
      *
      * @return void
      */
-    public function handleKernelTerminateEvent(TerminateEvent $event)
+    public function handleKernelTerminateEvent(TerminateEvent $event): void
     {
         Logs::getInstance()->flush();
     }

--- a/src/EventListener/MetricsRequestListener.php
+++ b/src/EventListener/MetricsRequestListener.php
@@ -19,7 +19,7 @@ class MetricsRequestListener
      *
      * @return void
      */
-    public function handleKernelTerminateEvent(TerminateEvent $event)
+    public function handleKernelTerminateEvent(TerminateEvent $event): void
     {
         TraceMetrics::getInstance()->flush();
     }

--- a/src/Tracing/HttpClient/AbstractTraceableResponse.php
+++ b/src/Tracing/HttpClient/AbstractTraceableResponse.php
@@ -53,7 +53,7 @@ abstract class AbstractTraceableResponse implements ResponseInterface
         throw new \BadMethodCallException('Serializing instances of this class is forbidden.');
     }
 
-    public function __wakeup()
+    public function __wakeup(): void
     {
         throw new \BadMethodCallException('Unserializing instances of this class is forbidden.');
     }

--- a/src/Twig/SentryExtension.php
+++ b/src/Twig/SentryExtension.php
@@ -37,7 +37,7 @@ final class SentryExtension extends AbstractExtension
      */
     public function getTraceMeta(): string
     {
-        return \sprintf('<meta name="sentry-trace" content="%s" />', getTraceparent());
+        return \sprintf('<meta name="sentry-trace" content="%s" />', self::escapeAttributeValue(getTraceparent()));
     }
 
     /**
@@ -55,6 +55,11 @@ final class SentryExtension extends AbstractExtension
      */
     public function getBaggageMeta(): string
     {
-        return \sprintf('<meta name="baggage" content="%s" />', getBaggage());
+        return \sprintf('<meta name="baggage" content="%s" />', self::escapeAttributeValue(getBaggage()));
+    }
+
+    private static function escapeAttributeValue(string $value): string
+    {
+        return htmlspecialchars($value, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
     }
 }

--- a/tests/DependencyInjection/Compiler/BufferFlushPassTest.php
+++ b/tests/DependencyInjection/Compiler/BufferFlushPassTest.php
@@ -46,7 +46,7 @@ class BufferFlushPassTest extends TestCase
      *
      * @return void
      */
-    public function testProcessWithMultipleHandlers()
+    public function testProcessWithMultipleHandlers(): void
     {
         $container = new ContainerBuilder();
         $container->setDefinition('sentry.handler', new Definition(SentryHandler::class));
@@ -65,7 +65,7 @@ class BufferFlushPassTest extends TestCase
      *
      * @return void
      */
-    public function testProcessWithoutSentryHandler()
+    public function testProcessWithoutSentryHandler(): void
     {
         $container = new ContainerBuilder();
         $container->setDefinition('null.handler', new Definition(NullHandler::class));
@@ -81,7 +81,7 @@ class BufferFlushPassTest extends TestCase
      *
      * @return void
      */
-    public function testProcessWithMultipleSentryHandlers()
+    public function testProcessWithMultipleSentryHandlers(): void
     {
         $container = new ContainerBuilder();
         $container->setDefinition('sentry.handler', new Definition(SentryHandler::class));
@@ -103,7 +103,7 @@ class BufferFlushPassTest extends TestCase
      *
      * @return void
      */
-    public function testProcessWithFakeSentryHandlers()
+    public function testProcessWithFakeSentryHandlers(): void
     {
         $container = new ContainerBuilder();
         $container->setDefinition('sentry.handler', new Definition(SentryHandler::class));
@@ -122,7 +122,7 @@ class BufferFlushPassTest extends TestCase
      *
      * @return void
      */
-    public function testProcessWithNamedArguments()
+    public function testProcessWithNamedArguments(): void
     {
         $container = new ContainerBuilder();
         $container->setDefinition('sentry.handler', new Definition(SentryHandler::class));

--- a/tests/End2End/App/Controller/LoggingController.php
+++ b/tests/End2End/App/Controller/LoggingController.php
@@ -37,7 +37,7 @@ class LoggingController
         return new Response();
     }
 
-    public function loggingWithError()
+    public function loggingWithError(): void
     {
         $this->logger->emergency('Something is not right');
         $this->logger->error('About to crash');

--- a/tests/End2End/BreadcrumbTestCommandTest.php
+++ b/tests/End2End/BreadcrumbTestCommandTest.php
@@ -42,7 +42,7 @@ class BreadcrumbTestCommandTest extends WebTestCase
      *
      * @return void
      */
-    public function testBreadcrumbWithConsoleListener()
+    public function testBreadcrumbWithConsoleListener(): void
     {
         try {
             // We need to run this by the application directly because the CommandTester doesn't produce proper events.
@@ -81,7 +81,7 @@ class BreadcrumbTestCommandTest extends WebTestCase
      *
      * @throws \Throwable
      */
-    public function testSubCommandBreadcrumbs()
+    public function testSubCommandBreadcrumbs(): void
     {
         // We need to run this by the application directly because the CommandTester doesn't produce proper events.
         $this->application->doRun(new ArgvInput(['bin/console', 'sentry:subcommand:test']), new NullOutput());
@@ -118,7 +118,7 @@ class BreadcrumbTestCommandTest extends WebTestCase
      *
      * @return void
      */
-    public function testCrashingSubcommand()
+    public function testCrashingSubcommand(): void
     {
         try {
             $this->application->doRun(new ArgvInput(['bin/console', 'sentry:subcommand:crash']), new NullOutput());
@@ -194,7 +194,7 @@ class BreadcrumbTestCommandTest extends WebTestCase
      *
      * @throws \Throwable
      */
-    public function testRunSecondCommandAfterCrashingCommand()
+    public function testRunSecondCommandAfterCrashingCommand(): void
     {
         try {
             // Run first command which crashes but is handled
@@ -227,7 +227,7 @@ class BreadcrumbTestCommandTest extends WebTestCase
      *
      * @throws \Throwable
      */
-    public function testBreadcrumbsAreAvailableAfterCommandTermination()
+    public function testBreadcrumbsAreAvailableAfterCommandTermination(): void
     {
         $this->application->doRun(new ArgvInput(['bin/console', 'sentry:dummy:test']), new NullOutput());
 

--- a/tests/Twig/SentryExtensionTest.php
+++ b/tests/Twig/SentryExtensionTest.php
@@ -20,6 +20,8 @@ use Symfony\Bundle\TwigBundle\TwigBundle;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
 
+use function Sentry\continueTrace;
+
 final class SentryExtensionTest extends TestCase
 {
     public static function setUpBeforeClass(): void
@@ -121,6 +123,70 @@ final class SentryExtensionTest extends TestCase
         $hub->setSpan($transaction);
 
         $this->assertSame(\sprintf('<meta name="baggage" content="%s" />', $transaction->toBaggage()), $environment->render('foo.twig'));
+    }
+
+    public function testMetaFunctionsPreserveRegularPropagatedSdkValues(): void
+    {
+        $environment = new Environment(new ArrayLoader([
+            'foo.twig' => '{{ sentry_trace_meta() }}{{ sentry_baggage_meta() }}',
+        ]));
+        $environment->addExtension(new SentryExtension());
+
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->atLeastOnce())
+            ->method('getOptions')
+            ->willReturn(new Options([
+                'traces_sample_rate' => 1.0,
+                'release' => '1.0.0',
+                'environment' => 'development',
+            ]));
+
+        $hub = new Hub($client);
+
+        SentrySdk::setCurrentHub($hub);
+
+        $context = continueTrace(
+            'a3c01c41d7b94b90aee23edac90f4319-e69c2aef0ec34f2a-1',
+            'sentry-trace_id=a3c01c41d7b94b90aee23edac90f4319,sentry-public_key=public,sentry-sample_rate=1,sentry-release=1.0.0,sentry-environment=development'
+        );
+
+        $transaction = $hub->startTransaction($context);
+        $hub->setSpan($transaction);
+
+        $this->assertSame(
+            \sprintf('<meta name="sentry-trace" content="%s" />', $transaction->toTraceparent()) .
+            \sprintf('<meta name="baggage" content="%s" />', $transaction->toBaggage()),
+            $environment->render('foo.twig')
+        );
+    }
+
+    public function testBaggageMetaFunctionWithPropagatedBaggage(): void
+    {
+        $environment = new Environment(new ArrayLoader(['foo.twig' => '{{ sentry_baggage_meta() }}']));
+        $environment->addExtension(new SentryExtension());
+
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->atLeastOnce())
+            ->method('getOptions')
+            ->willReturn(new Options([
+                'traces_sample_rate' => 1.0,
+            ]));
+
+        $hub = new Hub($client);
+
+        SentrySdk::setCurrentHub($hub);
+
+        $context = continueTrace(
+            '566e3688a61d4bc888951642d6f14a19-566e3688a61d4bc8-1',
+            'sentry-environment=x"><script>alert(1)</script>&foo=\'bar\''
+        );
+
+        $hub->setSpan($hub->startTransaction($context));
+
+        $this->assertSame(
+            '<meta name="baggage" content="sentry-environment=x%22%3E%3Cscript%3Ealert%281%29%3C%2Fscript%3E%26foo%3D%27bar%27,sentry-sample_rate=1" />',
+            $environment->render('foo.twig')
+        );
     }
 
     private static function isTwigBundlePackageInstalled(): bool


### PR DESCRIPTION
This PR adds hardening for twig rendering and adds responsibility to the Symfony SDK. While the PHP SDK did escape all values properly, there was no explicit safety measure here.

The reason for this change is that it's very small and can protect from changes in the PHP SDK