### PR TITLE
ref: clean up request in request fetcher

### DIFF
--- a/src/EventListener/TracingRequestListener.php
+++ b/src/EventListener/TracingRequestListener.php
@@ -90,15 +90,15 @@ final class TracingRequestListener extends AbstractTracingRequestListener
     {
         $transaction = $this->hub->getTransaction();
 
-        if (null === $transaction) {
-            return;
-        }
-
-        $transaction->finish();
-        metrics()->flush();
-
-        if ($this->requestFetcher instanceof RequestFetcher) {
-            $this->requestFetcher->setRequest(null);
+        try {
+            if (null !== $transaction) {
+                $transaction->finish();
+                metrics()->flush();
+            }
+        } finally {
+            if ($this->requestFetcher instanceof RequestFetcher) {
+                $this->requestFetcher->setRequest(null);
+            }
         }
     }
 

--- a/tests/EventListener/TracingRequestListenerTest.php
+++ b/tests/EventListener/TracingRequestListenerTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Sentry\ClientInterface;
 use Sentry\Options;
 use Sentry\SentryBundle\EventListener\TracingRequestListener;
+use Sentry\SentryBundle\Integration\RequestFetcher;
 use Sentry\State\HubInterface;
 use Sentry\Tracing\DynamicSamplingContext;
 use Sentry\Tracing\SpanId;
@@ -18,7 +19,9 @@ use Sentry\Tracing\Transaction;
 use Sentry\Tracing\TransactionContext;
 use Sentry\Tracing\TransactionSource;
 use Symfony\Bridge\PhpUnit\ClockMock;
+use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
@@ -512,5 +515,34 @@ final class TracingRequestListenerTest extends TestCase
             new Request(),
             new Response()
         ));
+    }
+
+    public function testHandleKernelTerminateEventClearsRequestFetcherIfNoTransactionIsSetOnHub(): void
+    {
+        $requestStack = $this->createMock(RequestStack::class);
+        $httpMessageFactory = $this->createMock(HttpMessageFactoryInterface::class);
+        $requestFetcher = new RequestFetcher($requestStack, $httpMessageFactory);
+        $listener = new TracingRequestListener($this->hub, $requestFetcher);
+
+        $requestFetcher->setRequest(Request::create('https://www.example.com/manual'));
+
+        $this->hub->expects($this->once())
+            ->method('getTransaction')
+            ->willReturn(null);
+
+        $requestStack->expects($this->once())
+            ->method('getCurrentRequest')
+            ->willReturn(null);
+
+        $httpMessageFactory->expects($this->never())
+            ->method('createRequest');
+
+        $listener->handleKernelTerminateEvent(new TerminateEvent(
+            $this->createMock(HttpKernelInterface::class),
+            new Request(),
+            new Response()
+        ));
+
+        $this->assertNull($requestFetcher->fetchRequest());
     }
 }


### PR DESCRIPTION
Currently we only cleanup the request if there is a `Transaction`. If there is no transaction and the software runs in something like FrankenPHP, we would potentially keep the request until it is overwritten in the new request.

While not being an issue, it's probably best to cleanup after each request to not keep it around for longer than necessary