### PR TITLE
test: update test matrix to include 8.5

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,6 +32,7 @@ jobs:
           - '8.2'
           - '8.3'
           - '8.4'
+          - '8.5'
         symfony-version:
           - 4.4.*
           - 5.*
@@ -59,6 +60,8 @@ jobs:
             symfony-version: 7.*
           - php: '8.4'
             symfony-version: 4.4.*
+          - php: '8.5'
+            symfony-version: 4.4.*
           - php: '7.2'
             symfony-version: 8.*
           - php: '7.3'
@@ -85,6 +88,9 @@ jobs:
             dependencies: lowest
           - php: '8.2'
             symfony-version: 7.*
+            dependencies: lowest
+          - php: '8.4'
+            symfony-version: 8.*
             dependencies: lowest
 
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -117,6 +117,10 @@ jobs:
         if: ${{ runner.os == 'Windows' || matrix.php == '7.2' || matrix.php == '7.3' || matrix.php == '7.4' || matrix.php == '8.0' }}
         run: composer remove spiral/roadrunner-http spiral/roadrunner-worker --dev --no-interaction --no-update
 
+      - name: Use PHPUnit 9 for lowest dependencies on newer PHP versions
+        if: ${{ matrix.dependencies == 'lowest' && matrix.php != '7.2' }}
+        run: composer require phpunit/phpunit:^9.6.34 --dev --no-interaction --no-update
+
       - name: Install dependencies
         uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # v3
         with:
@@ -177,6 +181,10 @@ jobs:
 
       - name: Remove optional packages
         run: composer remove doctrine/dbal doctrine/doctrine-bundle symfony/messenger symfony/twig-bundle symfony/cache symfony/http-client --dev --no-update
+
+      - name: Use PHPUnit 9 for lowest dependencies on newer PHP versions
+        if: ${{ matrix.dependencies == 'lowest' && matrix.php != '7.2' }}
+        run: composer require phpunit/phpunit:^9.6.34 --dev --no-interaction --no-update
 
       - name: Install dependencies
         uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # v3

--- a/src/Tracing/Doctrine/DBAL/TracingDriverConnectionFactoryForV2V3.php
+++ b/src/Tracing/Doctrine/DBAL/TracingDriverConnectionFactoryForV2V3.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\DB2Platform;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
@@ -67,6 +68,7 @@ final class TracingDriverConnectionFactoryForV2V3 implements TracingDriverConnec
         // https://github.com/open-telemetry/opentelemetry-specification/blob/33113489fb5a1b6da563abb4ffa541447b87f515/specification/trace/semantic_conventions/database.md#connection-level-attributes
         switch (true) {
             case $databasePlatform instanceof AbstractMySQLPlatform:
+            case $databasePlatform instanceof MySqlPlatform:
                 return 'mysql';
 
             case $databasePlatform instanceof DB2Platform:

--- a/tests/End2End/App/Callback/IgnoreSilencedDeprecationBeforeSendCallback.php
+++ b/tests/End2End/App/Callback/IgnoreSilencedDeprecationBeforeSendCallback.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\End2End\App\Callback;
+
+use Sentry\Event;
+use Sentry\EventHint;
+use Sentry\Exception\SilencedErrorException;
+
+class IgnoreSilencedDeprecationBeforeSendCallback
+{
+    public function getCallback(): callable
+    {
+        return static function (Event $event, ?EventHint $hint): ?Event {
+            $exception = null !== $hint ? $hint->exception : null;
+
+            if ($exception instanceof SilencedErrorException && \in_array($exception->getSeverity(), [\E_DEPRECATED, \E_USER_DEPRECATED], true)) {
+                return null;
+            }
+
+            return $event;
+        };
+    }
+}

--- a/tests/End2End/App/config.yml
+++ b/tests/End2End/App/config.yml
@@ -3,8 +3,9 @@ sentry:
   tracing:
     enabled: true
   options:
+    before_send: 'sentry.callback.before_send'
     capture_silenced_errors: true
-    error_types: E_ALL & ~E_USER_DEPRECATED
+    error_types: E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED
     traces_sample_rate: 0
     ignore_exceptions:
       - 'Symfony\Component\HttpKernel\Exception\BadRequestHttpException'
@@ -29,6 +30,13 @@ services:
     public: true
 
   Sentry\SentryBundle\Tests\End2End\StubTransport: ~
+
+  Sentry\SentryBundle\Tests\End2End\App\Callback\IgnoreSilencedDeprecationBeforeSendCallback:
+    autowire: true
+
+  sentry.callback.before_send:
+    class: 'Sentry\SentryBundle\Tests\End2End\App\Callback\IgnoreSilencedDeprecationBeforeSendCallback'
+    factory: ['@Sentry\SentryBundle\Tests\End2End\App\Callback\IgnoreSilencedDeprecationBeforeSendCallback', 'getCallback']
 
   Sentry\SentryBundle\Tests\End2End\App\Controller\MainController:
     autowire: true

--- a/tests/End2End/End2EndTest.php
+++ b/tests/End2End/End2EndTest.php
@@ -166,10 +166,15 @@ class End2EndTest extends WebTestCase
             $this->assertSame(500, $response->getStatusCode());
             $this->assertStringNotContainsString('not happen', $response->getContent() ?: '');
         } catch (\RuntimeException $exception) {
-            $this->assertStringContainsStringIgnoringCase('error', $exception->getMessage());
-            $this->assertStringContainsStringIgnoringCase('contains 1 abstract method', $exception->getMessage());
-            $this->assertStringContainsStringIgnoringCase('MainController.php', $exception->getMessage());
-            $this->assertStringContainsStringIgnoringCase('eval()\'d code on line', $exception->getMessage());
+            $message = $exception->getMessage();
+
+            $this->assertStringContainsStringIgnoringCase('error', $message);
+            $this->assertTrue(
+                false !== stripos($message, 'contains 1 abstract method') || false !== stripos($message, 'must implement 1 abstract method'),
+                \sprintf('Failed asserting that the exception message contains an abstract method error. Message: %s', $message)
+            );
+            $this->assertStringContainsStringIgnoringCase('MainController.php', $message);
+            $this->assertStringContainsStringIgnoringCase('eval()\'d code on line', $message);
         }
 
         $this->assertEventCount(1);

--- a/tests/Tracing/Cache/TraceableTagAwareCacheAdapterTest.php
+++ b/tests/Tracing/Cache/TraceableTagAwareCacheAdapterTest.php
@@ -81,7 +81,9 @@ final class TraceableTagAwareCacheAdapterTest extends AbstractTraceableCacheAdap
         $this->assertNotSame($adapter, $result);
 
         $ref = new \ReflectionProperty($result, 'decoratedAdapter');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
 
         $this->assertEquals($namespacedAdapter, $ref->getValue($result));
     }

--- a/tests/Tracing/Doctrine/DBAL/TracingDriverConnectionFactoryV2Test.php
+++ b/tests/Tracing/Doctrine/DBAL/TracingDriverConnectionFactoryV2Test.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\DB2Platform;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
@@ -78,7 +79,7 @@ final class TracingDriverConnectionFactoryV2Test extends DoctrineTestCase
     public static function createDataProvider(): \Generator
     {
         yield [
-            AbstractMySQLPlatform::class,
+            class_exists(AbstractMySQLPlatform::class) ? AbstractMySQLPlatform::class : MySqlPlatform::class,
             'mysql',
         ];
 
@@ -93,7 +94,7 @@ final class TracingDriverConnectionFactoryV2Test extends DoctrineTestCase
         ];
 
         yield [
-            PostgreSQLPlatform::class,
+            class_exists(PostgreSQLPlatform::class) ? PostgreSQLPlatform::class : 'Doctrine\\DBAL\\Platforms\\PostgreSqlPlatform',
             'postgresql',
         ];
 


### PR DESCRIPTION
Adds PHP 8.5 to the test matrix and adds a lowest target for PHP 8.4/Symfony 8.*