### PR TITLE
feat(ci): add composer audit to CI pipeline

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@728c6c6b8cf02c2e48117716a91ee48313958a19 # v2
         with:
-          php-version: '8.4'
+          php-version: '8.3'
 
       - name: Resolve dependencies
         run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit
@@ -46,7 +46,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@728c6c6b8cf02c2e48117716a91ee48313958a19 # v2
         with:
-          php-version: '8.4'
+          php-version: '8.3'
 
       - name: Resolve dependencies
         run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit
@@ -70,7 +70,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@728c6c6b8cf02c2e48117716a91ee48313958a19 # v2
         with:
-          php-version: '8.4'
+          php-version: '8.3'
 
       - name: Resolve dependencies
         run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@728c6c6b8cf02c2e48117716a91ee48313958a19 # v2
         with:
-          php-version: '8.5'
+          php-version: '8.4'
 
       - name: Resolve dependencies
         run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit
@@ -46,7 +46,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@728c6c6b8cf02c2e48117716a91ee48313958a19 # v2
         with:
-          php-version: '8.5'
+          php-version: '8.4'
 
       - name: Resolve dependencies
         run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit
@@ -70,7 +70,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@728c6c6b8cf02c2e48117716a91ee48313958a19 # v2
         with:
-          php-version: '8.5'
+          php-version: '8.4'
 
       - name: Resolve dependencies
         run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -25,7 +25,7 @@ jobs:
           php-version: '8.5'
 
       - name: Resolve dependencies
-        run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit --no-security-blocking
+        run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit
 
       - name: Audit dependencies
         run: composer audit --locked --no-interaction --format=table
@@ -49,7 +49,7 @@ jobs:
           php-version: '8.5'
 
       - name: Resolve dependencies
-        run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit --no-security-blocking
+        run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit
 
       - name: Audit dependencies
         run: composer audit --locked --no-interaction --format=table
@@ -73,7 +73,7 @@ jobs:
           php-version: '8.5'
 
       - name: Resolve dependencies
-        run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit --no-security-blocking
+        run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit
 
       - name: Audit dependencies
         run: composer audit --locked --no-interaction --format=table

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -28,7 +28,7 @@ jobs:
         run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit
 
       - name: Audit dependencies
-        run: composer audit --locked --no-interaction --format=table
+        run: composer audit --locked --no-interaction --format=table --abandoned=report
 
       - name: Install dependencies
         run: composer install --no-progress --no-interaction --prefer-dist --no-scripts
@@ -52,7 +52,7 @@ jobs:
         run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit
 
       - name: Audit dependencies
-        run: composer audit --locked --no-interaction --format=table
+        run: composer audit --locked --no-interaction --format=table --abandoned=report
 
       - name: Install dependencies
         run: composer install --no-progress --no-interaction --prefer-dist --no-scripts
@@ -76,7 +76,7 @@ jobs:
         run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit
 
       - name: Audit dependencies
-        run: composer audit --locked --no-interaction --format=table
+        run: composer audit --locked --no-interaction --format=table --abandoned=report
 
       - name: Install dependencies
         run: composer install --no-progress --no-interaction --prefer-dist --no-scripts

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -22,12 +22,16 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@728c6c6b8cf02c2e48117716a91ee48313958a19 # v2
         with:
-          php-version: '8.3'
+          php-version: '8.5'
+
+      - name: Resolve dependencies
+        run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit --no-security-blocking
+
+      - name: Audit dependencies
+        run: composer audit --locked --no-interaction --format=table
 
       - name: Install dependencies
-        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # v3
-        with:
-          composer-options: --prefer-dist
+        run: composer install --no-progress --no-interaction --prefer-dist --no-scripts
 
       - name: Run script
         run: vendor/bin/php-cs-fixer fix --verbose --diff --dry-run
@@ -42,12 +46,16 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@728c6c6b8cf02c2e48117716a91ee48313958a19 # v2
         with:
-          php-version: '8.3'
+          php-version: '8.5'
+
+      - name: Resolve dependencies
+        run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit --no-security-blocking
+
+      - name: Audit dependencies
+        run: composer audit --locked --no-interaction --format=table
 
       - name: Install dependencies
-        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # v3
-        with:
-          composer-options: --prefer-dist
+        run: composer install --no-progress --no-interaction --prefer-dist --no-scripts
 
       - name: Run script
         run: vendor/bin/phpstan analyse
@@ -62,12 +70,16 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@728c6c6b8cf02c2e48117716a91ee48313958a19 # v2
         with:
-          php-version: '8.3'
+          php-version: '8.5'
+
+      - name: Resolve dependencies
+        run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit --no-security-blocking
+
+      - name: Audit dependencies
+        run: composer audit --locked --no-interaction --format=table
 
       - name: Install dependencies
-        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # v3
-        with:
-          composer-options: --prefer-dist
+        run: composer install --no-progress --no-interaction --prefer-dist --no-scripts
 
       - name: Run script
         run: vendor/bin/psalm --php-version=8.0

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,6 +13,94 @@ permissions:
 env:
   FRANKENPHP_VERSION: v1.11.2
   ROADRUNNER_VERSION: v2025.1.7
+  COMPOSER_ADVISORY_ALLOWLISTS: >-
+    {
+      "symfony-4.4": [
+        "PKSA-z7t6-zt6p-wtng",
+        "PKSA-5r1g-c7b7-y1zg",
+        "PKSA-4k7v-pfvw-nqvp",
+        "PKSA-365x-2zjk-pt47",
+        "PKSA-b35n-565h-rs4q",
+        "PKSA-wtxr-p26d-nn42",
+        "PKSA-2n2k-66v2-bwg3",
+        "PKSA-4wjj-gy1p-ft3r",
+        "PKSA-rkkf-636k-qjb3",
+        "PKSA-wws7-mr54-jsny",
+        "PKSA-bf7t-jnpz-492k",
+        "PKSA-yc7t-91v9-99xs",
+        "PKSA-c28x-6bj5-8spx",
+        "PKSA-tbsf-h7vc-j7hn",
+        "PKSA-v5yj-8nmz-sk2q",
+        "PKSA-ft77-7h5f-p3r6",
+        "PKSA-b14r-zh1d-vdrc"
+      ],
+      "twig": [
+        "PKSA-fbvq-z33h-r2np",
+        "PKSA-g9zw-qxh8-pq8w",
+        "PKSA-yd6k-t2gh-1m43",
+        "PKSA-1tmc-rt7x-12w6",
+        "PKSA-xx6c-6d96-db2w",
+        "PKSA-sjvz-tbbr-vwth",
+        "PKSA-h8hf-ytnd-5t9q",
+        "PKSA-kvv6-36cr-fkzb",
+        "PKSA-n14z-jjjg-g8vd",
+        "PKSA-3mcc-k66d-pydb",
+        "PKSA-dpx1-78wg-1kqs",
+        "PKSA-yhcn-xrg3-68b1",
+        "PKSA-2wrf-1xmk-1pky",
+        "PKSA-6319-ffpf-gx66",
+        "PKSA-n7sg-8f52-pqtf"
+      ],
+      "symfony-6-php-8.0": [
+        "PKSA-z7t6-zt6p-wtng",
+        "PKSA-5r1g-c7b7-y1zg",
+        "PKSA-4k7v-pfvw-nqvp",
+        "PKSA-365x-2zjk-pt47",
+        "PKSA-b35n-565h-rs4q",
+        "PKSA-4wjj-gy1p-ft3r",
+        "PKSA-wws7-mr54-jsny",
+        "PKSA-bf7t-jnpz-492k",
+        "PKSA-yc7t-91v9-99xs",
+        "PKSA-c28x-6bj5-8spx",
+        "PKSA-tbsf-h7vc-j7hn",
+        "PKSA-rqvm-b18n-vg69",
+        "PKSA-5x8m-77gx-t86z",
+        "PKSA-ztgh-x9c8-k66g",
+        "PKSA-v5yj-8nmz-sk2q",
+        "PKSA-ft77-7h5f-p3r6",
+        "PKSA-b14r-zh1d-vdrc",
+        "PKSA-fbvq-z33h-r2np",
+        "PKSA-g9zw-qxh8-pq8w",
+        "PKSA-yd6k-t2gh-1m43",
+        "PKSA-1tmc-rt7x-12w6",
+        "PKSA-xx6c-6d96-db2w",
+        "PKSA-sjvz-tbbr-vwth",
+        "PKSA-h8hf-ytnd-5t9q",
+        "PKSA-kvv6-36cr-fkzb",
+        "PKSA-n14z-jjjg-g8vd",
+        "PKSA-3mcc-k66d-pydb",
+        "PKSA-dpx1-78wg-1kqs",
+        "PKSA-yhcn-xrg3-68b1",
+        "PKSA-2wrf-1xmk-1pky",
+        "PKSA-6319-ffpf-gx66",
+        "PKSA-n7sg-8f52-pqtf"
+      ]
+    }
+  COMPOSER_ADVISORY_ALLOWLIST_KEYS: >-
+    {
+      "4.4.*|7.2": "symfony-4.4",
+      "4.4.*|7.3": "symfony-4.4",
+      "4.4.*|7.4": "symfony-4.4",
+      "4.4.*|8.0": "symfony-4.4",
+      "4.4.*|8.1": "symfony-4.4",
+      "4.4.*|8.2": "symfony-4.4",
+      "4.4.*|8.3": "symfony-4.4",
+      "5.*|7.2": "twig",
+      "5.*|7.3": "twig",
+      "5.*|7.4": "twig",
+      "5.*|8.0": "twig",
+      "6.*|8.0": "symfony-6-php-8.0"
+    }
 
 jobs:
   tests:
@@ -121,21 +209,22 @@ jobs:
         if: ${{ matrix.dependencies == 'lowest' && matrix.php != '7.2' }}
         run: composer require phpunit/phpunit:^9.6.34 --dev --no-interaction --no-update
 
-      - name: Resolve highest dependencies
-        run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit --no-security-blocking
+      - name: Configure advisory allowlist
+        if: ${{ fromJSON(env.COMPOSER_ADVISORY_ALLOWLIST_KEYS)[format('{0}|{1}', matrix.symfony-version, matrix.php)] != null }}
+        env:
+          COMPOSER_ADVISORY_ALLOWLIST: ${{ toJSON(fromJSON(env.COMPOSER_ADVISORY_ALLOWLISTS)[fromJSON(env.COMPOSER_ADVISORY_ALLOWLIST_KEYS)[format('{0}|{1}', matrix.symfony-version, matrix.php)]]) }}
+        run: composer config --json policy.advisories.ignore-id "$COMPOSER_ADVISORY_ALLOWLIST"
+
+      - name: Resolve dependencies
+        run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit
         if: ${{ matrix.dependencies == 'highest' }}
 
-      - name: Resolve lowest dependencies
-        run: composer update --no-progress --no-interaction --prefer-dist --prefer-lowest --no-install --no-scripts --no-audit --no-security-blocking
+      - name: Resolve dependencies
+        run: composer update --no-progress --no-interaction --prefer-dist --prefer-lowest --no-install --no-scripts --no-audit
         if: ${{ matrix.dependencies == 'lowest' }}
 
-      - name: Audit highest dependencies
-        run: composer audit --locked --no-interaction --format=table
-        if: ${{ matrix.dependencies == 'highest' }}
-
-      - name: Audit lowest dependencies
+      - name: Audit dependencies
         run: composer audit --locked --no-interaction --format=table --abandoned=report
-        if: ${{ matrix.dependencies == 'lowest' }}
 
       - name: Install dependencies
         run: composer install --no-progress --no-interaction --prefer-dist --no-scripts
@@ -199,21 +288,22 @@ jobs:
         if: ${{ matrix.dependencies == 'lowest' && matrix.php != '7.2' }}
         run: composer require phpunit/phpunit:^9.6.34 --dev --no-interaction --no-update
 
-      - name: Resolve highest dependencies
-        run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit --no-security-blocking
+      - name: Configure advisory allowlist
+        if: ${{ fromJSON(env.COMPOSER_ADVISORY_ALLOWLIST_KEYS)[format('{0}|{1}', matrix.symfony-version, matrix.php)] != null }}
+        env:
+          COMPOSER_ADVISORY_ALLOWLIST: ${{ toJSON(fromJSON(env.COMPOSER_ADVISORY_ALLOWLISTS)[fromJSON(env.COMPOSER_ADVISORY_ALLOWLIST_KEYS)[format('{0}|{1}', matrix.symfony-version, matrix.php)]]) }}
+        run: composer config --json policy.advisories.ignore-id "$COMPOSER_ADVISORY_ALLOWLIST"
+
+      - name: Resolve dependencies
+        run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit
         if: ${{ matrix.dependencies == 'highest' }}
 
-      - name: Resolve lowest dependencies
-        run: composer update --no-progress --no-interaction --prefer-dist --prefer-lowest --no-install --no-scripts --no-audit --no-security-blocking
+      - name: Resolve dependencies
+        run: composer update --no-progress --no-interaction --prefer-dist --prefer-lowest --no-install --no-scripts --no-audit
         if: ${{ matrix.dependencies == 'lowest' }}
 
-      - name: Audit highest dependencies
-        run: composer audit --locked --no-interaction --format=table
-        if: ${{ matrix.dependencies == 'highest' }}
-
-      - name: Audit lowest dependencies
+      - name: Audit dependencies
         run: composer audit --locked --no-interaction --format=table --abandoned=report
-        if: ${{ matrix.dependencies == 'lowest' }}
 
       - name: Install dependencies
         run: composer install --no-progress --no-interaction --prefer-dist --no-scripts
@@ -256,7 +346,7 @@ jobs:
           restore-keys: ${{ runner.os }}-runtime-frankenphp-composer-
 
       - name: Resolve dependencies
-        run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit --no-security-blocking
+        run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit
 
       - name: Audit dependencies
         run: composer audit --locked --no-interaction --format=table
@@ -327,7 +417,7 @@ jobs:
           restore-keys: ${{ runner.os }}-runtime-roadrunner-composer-
 
       - name: Resolve dependencies
-        run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit --no-security-blocking
+        run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit
 
       - name: Audit dependencies
         run: composer audit --locked --no-interaction --format=table

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -121,11 +121,24 @@ jobs:
         if: ${{ matrix.dependencies == 'lowest' && matrix.php != '7.2' }}
         run: composer require phpunit/phpunit:^9.6.34 --dev --no-interaction --no-update
 
+      - name: Resolve highest dependencies
+        run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit --no-security-blocking
+        if: ${{ matrix.dependencies == 'highest' }}
+
+      - name: Resolve lowest dependencies
+        run: composer update --no-progress --no-interaction --prefer-dist --prefer-lowest --no-install --no-scripts --no-audit --no-security-blocking
+        if: ${{ matrix.dependencies == 'lowest' }}
+
+      - name: Audit highest dependencies
+        run: composer audit --locked --no-interaction --format=table
+        if: ${{ matrix.dependencies == 'highest' }}
+
+      - name: Audit lowest dependencies
+        run: composer audit --locked --no-interaction --format=table --abandoned=report
+        if: ${{ matrix.dependencies == 'lowest' }}
+
       - name: Install dependencies
-        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # v3
-        with:
-          dependency-versions: ${{ matrix.dependencies }}
-          composer-options: --prefer-dist --no-security-blocking
+        run: composer install --no-progress --no-interaction --prefer-dist --no-scripts
 
       - name: Run tests
         run: vendor/bin/phpunit --coverage-clover=build/coverage-report.xml
@@ -186,11 +199,24 @@ jobs:
         if: ${{ matrix.dependencies == 'lowest' && matrix.php != '7.2' }}
         run: composer require phpunit/phpunit:^9.6.34 --dev --no-interaction --no-update
 
+      - name: Resolve highest dependencies
+        run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit --no-security-blocking
+        if: ${{ matrix.dependencies == 'highest' }}
+
+      - name: Resolve lowest dependencies
+        run: composer update --no-progress --no-interaction --prefer-dist --prefer-lowest --no-install --no-scripts --no-audit --no-security-blocking
+        if: ${{ matrix.dependencies == 'lowest' }}
+
+      - name: Audit highest dependencies
+        run: composer audit --locked --no-interaction --format=table
+        if: ${{ matrix.dependencies == 'highest' }}
+
+      - name: Audit lowest dependencies
+        run: composer audit --locked --no-interaction --format=table --abandoned=report
+        if: ${{ matrix.dependencies == 'lowest' }}
+
       - name: Install dependencies
-        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # v3
-        with:
-          dependency-versions: ${{ matrix.dependencies }}
-          composer-options: --prefer-dist --no-security-blocking
+        run: composer install --no-progress --no-interaction --prefer-dist --no-scripts
 
       - name: Run tests
         run: vendor/bin/phpunit --coverage-clover=build/coverage-report.xml
@@ -229,8 +255,14 @@ jobs:
           key: ${{ runner.os }}-runtime-frankenphp-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-runtime-frankenphp-composer-
 
+      - name: Resolve dependencies
+        run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit --no-security-blocking
+
+      - name: Audit dependencies
+        run: composer audit --locked --no-interaction --format=table
+
       - name: Install dependencies
-        run: composer install --no-progress --no-interaction --prefer-dist
+        run: composer install --no-progress --no-interaction --prefer-dist --no-scripts
 
       - name: Install FrankenPHP
         env:
@@ -294,8 +326,14 @@ jobs:
           key: ${{ runner.os }}-runtime-roadrunner-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-runtime-roadrunner-composer-
 
+      - name: Resolve dependencies
+        run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit --no-security-blocking
+
+      - name: Audit dependencies
+        run: composer audit --locked --no-interaction --format=table
+
       - name: Install dependencies
-        run: composer install --no-progress --no-interaction --prefer-dist
+        run: composer install --no-progress --no-interaction --prefer-dist --no-scripts
 
       - name: Install RoadRunner
         env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -176,6 +176,12 @@ jobs:
         if: ${{ matrix.dependencies == 'lowest' && matrix.php != '7.2' }}
         run: composer require phpunit/phpunit:^9.6.34 --dev --no-interaction --no-update
 
+        # The following tasks add security advisories to the allowlist to allow proper composer resolution
+        # They are as strict as possible and bound to particular versions so that we only ignore a well known set.
+        # If new ones appear, they will fail CI and will require investigation
+        # The rationale behind that is that we don't want to ignore them for all versions and instead only
+        # ignore them if absolutely necessary for resolution so that composer can select versions without security
+        # concerns if available
       - name: Configure common Symfony advisory allowlist
         if: ${{ matrix.symfony-version == '4.4.*' || (matrix.symfony-version == '5.*' && matrix.php == '7.2' && matrix.dependencies == 'lowest') || (matrix.symfony-version == '6.*' && matrix.php == '8.0') }}
         run: composer config --merge --json policy.advisories.ignore-id "$COMPOSER_ADVISORY_SYMFONY_COMMON"
@@ -199,6 +205,8 @@ jobs:
       - name: Configure Twig advisory allowlist
         if: ${{ contains(fromJSON('["4.4.*","5.*","6.*"]'), matrix.symfony-version) && contains(fromJSON('["7.2","7.3","7.4","8.0"]'), matrix.php) }}
         run: composer config --merge --json policy.advisories.ignore-id "$COMPOSER_ADVISORY_TWIG"
+
+      # End of security advisory tasks
 
       - name: Resolve dependencies
         run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,94 +13,61 @@ permissions:
 env:
   FRANKENPHP_VERSION: v1.11.2
   ROADRUNNER_VERSION: v2025.1.7
-  COMPOSER_ADVISORY_ALLOWLISTS: >-
-    {
-      "symfony-4.4": [
-        "PKSA-z7t6-zt6p-wtng",
-        "PKSA-5r1g-c7b7-y1zg",
-        "PKSA-4k7v-pfvw-nqvp",
-        "PKSA-365x-2zjk-pt47",
-        "PKSA-b35n-565h-rs4q",
-        "PKSA-wtxr-p26d-nn42",
-        "PKSA-2n2k-66v2-bwg3",
-        "PKSA-4wjj-gy1p-ft3r",
-        "PKSA-rkkf-636k-qjb3",
-        "PKSA-wws7-mr54-jsny",
-        "PKSA-bf7t-jnpz-492k",
-        "PKSA-yc7t-91v9-99xs",
-        "PKSA-c28x-6bj5-8spx",
-        "PKSA-tbsf-h7vc-j7hn",
-        "PKSA-v5yj-8nmz-sk2q",
-        "PKSA-ft77-7h5f-p3r6",
-        "PKSA-b14r-zh1d-vdrc"
-      ],
-      "twig": [
-        "PKSA-fbvq-z33h-r2np",
-        "PKSA-g9zw-qxh8-pq8w",
-        "PKSA-yd6k-t2gh-1m43",
-        "PKSA-1tmc-rt7x-12w6",
-        "PKSA-xx6c-6d96-db2w",
-        "PKSA-sjvz-tbbr-vwth",
-        "PKSA-h8hf-ytnd-5t9q",
-        "PKSA-kvv6-36cr-fkzb",
-        "PKSA-n14z-jjjg-g8vd",
-        "PKSA-3mcc-k66d-pydb",
-        "PKSA-dpx1-78wg-1kqs",
-        "PKSA-yhcn-xrg3-68b1",
-        "PKSA-2wrf-1xmk-1pky",
-        "PKSA-6319-ffpf-gx66",
-        "PKSA-n7sg-8f52-pqtf"
-      ],
-      "symfony-6-php-8.0": [
-        "PKSA-z7t6-zt6p-wtng",
-        "PKSA-5r1g-c7b7-y1zg",
-        "PKSA-4k7v-pfvw-nqvp",
-        "PKSA-365x-2zjk-pt47",
-        "PKSA-b35n-565h-rs4q",
-        "PKSA-4wjj-gy1p-ft3r",
-        "PKSA-wws7-mr54-jsny",
-        "PKSA-bf7t-jnpz-492k",
-        "PKSA-yc7t-91v9-99xs",
-        "PKSA-c28x-6bj5-8spx",
-        "PKSA-tbsf-h7vc-j7hn",
-        "PKSA-rqvm-b18n-vg69",
-        "PKSA-5x8m-77gx-t86z",
-        "PKSA-ztgh-x9c8-k66g",
-        "PKSA-v5yj-8nmz-sk2q",
-        "PKSA-ft77-7h5f-p3r6",
-        "PKSA-b14r-zh1d-vdrc",
-        "PKSA-fbvq-z33h-r2np",
-        "PKSA-g9zw-qxh8-pq8w",
-        "PKSA-yd6k-t2gh-1m43",
-        "PKSA-1tmc-rt7x-12w6",
-        "PKSA-xx6c-6d96-db2w",
-        "PKSA-sjvz-tbbr-vwth",
-        "PKSA-h8hf-ytnd-5t9q",
-        "PKSA-kvv6-36cr-fkzb",
-        "PKSA-n14z-jjjg-g8vd",
-        "PKSA-3mcc-k66d-pydb",
-        "PKSA-dpx1-78wg-1kqs",
-        "PKSA-yhcn-xrg3-68b1",
-        "PKSA-2wrf-1xmk-1pky",
-        "PKSA-6319-ffpf-gx66",
-        "PKSA-n7sg-8f52-pqtf"
-      ]
-    }
-  COMPOSER_ADVISORY_ALLOWLIST_KEYS: >-
-    {
-      "4.4.*|7.2": "symfony-4.4",
-      "4.4.*|7.3": "symfony-4.4",
-      "4.4.*|7.4": "symfony-4.4",
-      "4.4.*|8.0": "symfony-4.4",
-      "4.4.*|8.1": "symfony-4.4",
-      "4.4.*|8.2": "symfony-4.4",
-      "4.4.*|8.3": "symfony-4.4",
-      "5.*|7.2": "twig",
-      "5.*|7.3": "twig",
-      "5.*|7.4": "twig",
-      "5.*|8.0": "twig",
-      "6.*|8.0": "symfony-6-php-8.0"
-    }
+  COMPOSER_ADVISORY_SYMFONY_COMMON: >-
+    [
+      "PKSA-z7t6-zt6p-wtng",
+      "PKSA-5r1g-c7b7-y1zg",
+      "PKSA-4k7v-pfvw-nqvp",
+      "PKSA-365x-2zjk-pt47",
+      "PKSA-b35n-565h-rs4q",
+      "PKSA-4wjj-gy1p-ft3r",
+      "PKSA-wws7-mr54-jsny",
+      "PKSA-bf7t-jnpz-492k",
+      "PKSA-yc7t-91v9-99xs",
+      "PKSA-c28x-6bj5-8spx",
+      "PKSA-tbsf-h7vc-j7hn",
+      "PKSA-v5yj-8nmz-sk2q",
+      "PKSA-ft77-7h5f-p3r6",
+      "PKSA-b14r-zh1d-vdrc"
+    ]
+  COMPOSER_ADVISORY_SYMFONY_4_4_AND_5_LOWEST: >-
+    [
+      "PKSA-wtxr-p26d-nn42",
+      "PKSA-2n2k-66v2-bwg3",
+      "PKSA-rkkf-636k-qjb3"
+    ]
+  COMPOSER_ADVISORY_SYMFONY_5_LOWEST_AND_6: >-
+    [
+      "PKSA-ztgh-x9c8-k66g"
+    ]
+  COMPOSER_ADVISORY_SYMFONY_5_LOWEST_ONLY: >-
+    [
+      "PKSA-hr4y-jwk2-1yb9",
+      "PKSA-8knv-7jsn-12w8"
+    ]
+  COMPOSER_ADVISORY_SYMFONY_6_PHP_8_0_ONLY: >-
+    [
+      "PKSA-rqvm-b18n-vg69",
+      "PKSA-5x8m-77gx-t86z"
+    ]
+  COMPOSER_ADVISORY_TWIG: >-
+    [
+      "PKSA-fbvq-z33h-r2np",
+      "PKSA-g9zw-qxh8-pq8w",
+      "PKSA-yd6k-t2gh-1m43",
+      "PKSA-1tmc-rt7x-12w6",
+      "PKSA-xx6c-6d96-db2w",
+      "PKSA-sjvz-tbbr-vwth",
+      "PKSA-h8hf-ytnd-5t9q",
+      "PKSA-kvv6-36cr-fkzb",
+      "PKSA-n14z-jjjg-g8vd",
+      "PKSA-3mcc-k66d-pydb",
+      "PKSA-dpx1-78wg-1kqs",
+      "PKSA-yhcn-xrg3-68b1",
+      "PKSA-2wrf-1xmk-1pky",
+      "PKSA-6319-ffpf-gx66",
+      "PKSA-n7sg-8f52-pqtf"
+    ]
 
 jobs:
   tests:
@@ -209,11 +176,29 @@ jobs:
         if: ${{ matrix.dependencies == 'lowest' && matrix.php != '7.2' }}
         run: composer require phpunit/phpunit:^9.6.34 --dev --no-interaction --no-update
 
-      - name: Configure advisory allowlist
-        if: ${{ fromJSON(env.COMPOSER_ADVISORY_ALLOWLIST_KEYS)[format('{0}|{1}', matrix.symfony-version, matrix.php)] != null }}
-        env:
-          COMPOSER_ADVISORY_ALLOWLIST: ${{ toJSON(fromJSON(env.COMPOSER_ADVISORY_ALLOWLISTS)[fromJSON(env.COMPOSER_ADVISORY_ALLOWLIST_KEYS)[format('{0}|{1}', matrix.symfony-version, matrix.php)]]) }}
-        run: composer config --json policy.advisories.ignore-id "$COMPOSER_ADVISORY_ALLOWLIST"
+      - name: Configure common Symfony advisory allowlist
+        if: ${{ matrix.symfony-version == '4.4.*' || (matrix.symfony-version == '5.*' && matrix.php == '7.2' && matrix.dependencies == 'lowest') || (matrix.symfony-version == '6.*' && matrix.php == '8.0') }}
+        run: composer config --merge --json policy.advisories.ignore-id "$COMPOSER_ADVISORY_SYMFONY_COMMON"
+
+      - name: Configure Symfony 4.4/5 lowest advisory allowlist
+        if: ${{ matrix.symfony-version == '4.4.*' || (matrix.symfony-version == '5.*' && matrix.php == '7.2' && matrix.dependencies == 'lowest') }}
+        run: composer config --merge --json policy.advisories.ignore-id "$COMPOSER_ADVISORY_SYMFONY_4_4_AND_5_LOWEST"
+
+      - name: Configure Symfony 5 lowest/6 advisory allowlist
+        if: ${{ (matrix.symfony-version == '5.*' && matrix.php == '7.2' && matrix.dependencies == 'lowest') || (matrix.symfony-version == '6.*' && matrix.php == '8.0') }}
+        run: composer config --merge --json policy.advisories.ignore-id "$COMPOSER_ADVISORY_SYMFONY_5_LOWEST_AND_6"
+
+      - name: Configure Symfony 5 lowest advisory allowlist
+        if: ${{ matrix.symfony-version == '5.*' && matrix.php == '7.2' && matrix.dependencies == 'lowest' }}
+        run: composer config --merge --json policy.advisories.ignore-id "$COMPOSER_ADVISORY_SYMFONY_5_LOWEST_ONLY"
+
+      - name: Configure Symfony 6 advisory allowlist
+        if: ${{ matrix.symfony-version == '6.*' && matrix.php == '8.0' }}
+        run: composer config --merge --json policy.advisories.ignore-id "$COMPOSER_ADVISORY_SYMFONY_6_PHP_8_0_ONLY"
+
+      - name: Configure Twig advisory allowlist
+        if: ${{ contains(fromJSON('["4.4.*","5.*","6.*"]'), matrix.symfony-version) && contains(fromJSON('["7.2","7.3","7.4","8.0"]'), matrix.php) }}
+        run: composer config --merge --json policy.advisories.ignore-id "$COMPOSER_ADVISORY_TWIG"
 
       - name: Resolve dependencies
         run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit
@@ -288,11 +273,29 @@ jobs:
         if: ${{ matrix.dependencies == 'lowest' && matrix.php != '7.2' }}
         run: composer require phpunit/phpunit:^9.6.34 --dev --no-interaction --no-update
 
-      - name: Configure advisory allowlist
-        if: ${{ fromJSON(env.COMPOSER_ADVISORY_ALLOWLIST_KEYS)[format('{0}|{1}', matrix.symfony-version, matrix.php)] != null }}
-        env:
-          COMPOSER_ADVISORY_ALLOWLIST: ${{ toJSON(fromJSON(env.COMPOSER_ADVISORY_ALLOWLISTS)[fromJSON(env.COMPOSER_ADVISORY_ALLOWLIST_KEYS)[format('{0}|{1}', matrix.symfony-version, matrix.php)]]) }}
-        run: composer config --json policy.advisories.ignore-id "$COMPOSER_ADVISORY_ALLOWLIST"
+      - name: Configure common Symfony advisory allowlist
+        if: ${{ matrix.symfony-version == '4.4.*' || (matrix.symfony-version == '5.*' && matrix.php == '7.2' && matrix.dependencies == 'lowest') || (matrix.symfony-version == '6.*' && matrix.php == '8.0') }}
+        run: composer config --merge --json policy.advisories.ignore-id "$COMPOSER_ADVISORY_SYMFONY_COMMON"
+
+      - name: Configure Symfony 4.4/5 lowest advisory allowlist
+        if: ${{ matrix.symfony-version == '4.4.*' || (matrix.symfony-version == '5.*' && matrix.php == '7.2' && matrix.dependencies == 'lowest') }}
+        run: composer config --merge --json policy.advisories.ignore-id "$COMPOSER_ADVISORY_SYMFONY_4_4_AND_5_LOWEST"
+
+      - name: Configure Symfony 5 lowest/6 advisory allowlist
+        if: ${{ (matrix.symfony-version == '5.*' && matrix.php == '7.2' && matrix.dependencies == 'lowest') || (matrix.symfony-version == '6.*' && matrix.php == '8.0') }}
+        run: composer config --merge --json policy.advisories.ignore-id "$COMPOSER_ADVISORY_SYMFONY_5_LOWEST_AND_6"
+
+      - name: Configure Symfony 5 lowest advisory allowlist
+        if: ${{ matrix.symfony-version == '5.*' && matrix.php == '7.2' && matrix.dependencies == 'lowest' }}
+        run: composer config --merge --json policy.advisories.ignore-id "$COMPOSER_ADVISORY_SYMFONY_5_LOWEST_ONLY"
+
+      - name: Configure Symfony 6 advisory allowlist
+        if: ${{ matrix.symfony-version == '6.*' && matrix.php == '8.0' }}
+        run: composer config --merge --json policy.advisories.ignore-id "$COMPOSER_ADVISORY_SYMFONY_6_PHP_8_0_ONLY"
+
+      - name: Configure Twig advisory allowlist
+        if: ${{ contains(fromJSON('["4.4.*","5.*","6.*"]'), matrix.symfony-version) && contains(fromJSON('["7.2","7.3","7.4","8.0"]'), matrix.php) }}
+        run: composer config --merge --json policy.advisories.ignore-id "$COMPOSER_ADVISORY_TWIG"
 
       - name: Resolve dependencies
         run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit
@@ -349,7 +352,7 @@ jobs:
         run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit
 
       - name: Audit dependencies
-        run: composer audit --locked --no-interaction --format=table
+        run: composer audit --locked --no-interaction --format=table --abandoned=report
 
       - name: Install dependencies
         run: composer install --no-progress --no-interaction --prefer-dist --no-scripts
@@ -420,7 +423,7 @@ jobs:
         run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit
 
       - name: Audit dependencies
-        run: composer audit --locked --no-interaction --format=table
+        run: composer audit --locked --no-interaction --format=table --abandoned=report
 
       - name: Install dependencies
         run: composer install --no-progress --no-interaction --prefer-dist --no-scripts

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -273,6 +273,12 @@ jobs:
         if: ${{ matrix.dependencies == 'lowest' && matrix.php != '7.2' }}
         run: composer require phpunit/phpunit:^9.6.34 --dev --no-interaction --no-update
 
+      # The following tasks add security advisories to the allowlist to allow proper composer resolution
+      # They are as strict as possible and bound to particular versions so that we only ignore a well known set.
+      # If new ones appear, they will fail CI and will require investigation
+      # The rationale behind that is that we don't want to ignore them for all versions and instead only
+      # ignore them if absolutely necessary for resolution so that composer can select versions without security
+      # concerns if available
       - name: Configure common Symfony advisory allowlist
         if: ${{ matrix.symfony-version == '4.4.*' || (matrix.symfony-version == '5.*' && matrix.php == '7.2' && matrix.dependencies == 'lowest') || (matrix.symfony-version == '6.*' && matrix.php == '8.0') }}
         run: composer config --merge --json policy.advisories.ignore-id "$COMPOSER_ADVISORY_SYMFONY_COMMON"
@@ -296,6 +302,8 @@ jobs:
       - name: Configure Twig advisory allowlist
         if: ${{ contains(fromJSON('["4.4.*","5.*","6.*"]'), matrix.symfony-version) && contains(fromJSON('["7.2","7.3","7.4","8.0"]'), matrix.php) }}
         run: composer config --merge --json policy.advisories.ignore-id "$COMPOSER_ADVISORY_TWIG"
+
+    # End of security advisory tasks
 
       - name: Resolve dependencies
         run: composer update --no-progress --no-interaction --prefer-dist --no-install --no-scripts --no-audit

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "phpstan/phpstan": "1.12.5",
         "phpstan/phpstan-phpunit": "1.4.0",
         "phpstan/phpstan-symfony": "1.4.10",
-        "phpunit/phpunit": "^8.5.40||^9.6.21",
+        "phpunit/phpunit": "^8.5.52||^9.6.34",
         "symfony/browser-kit": "^4.4.20||^5.0.11||^6.0||^7.0||^8.0",
         "symfony/cache": "^4.4.20||^5.0.11||^6.0||^7.0||^8.0",
         "symfony/dom-crawler": "^4.4.20||^5.0.11||^6.0||^7.0||^8.0",


### PR DESCRIPTION
Adds a `composer audit` step to the CI pipeline. 

It adds a list of ignored security advisories to allow composer resolve dependencies properly. The list is as minimal as possible and scoped to Symfony + PHP. 

The reason for this is that we don't want to disable audit in general, but instead disable it only for relevant combinations so that we can still get warnings for new issues that arrive.

Also updates the CI to be more consistent with the other SDKs