### PR TITLE
Add support for guzzlehttp/psr7 3.x (Guzzle 8 compatibility)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^7.2||^8.0",
-        "guzzlehttp/psr7": "^2.1.1",
+        "guzzlehttp/psr7": "^2.1.1|^3.0",
         "jean85/pretty-package-versions": "^1.5||^2.0",
         "sentry/sentry": "^4.23.0",
         "symfony/cache-contracts": "^1.1||^2.4||^3.0",


### PR DESCRIPTION
## Summary
- Widen the `guzzlehttp/psr7` Composer constraint from `^2.1.1` to `^2.1.1|^3.0`.
- Allow `sentry/sentry-symfony` to be installed alongside Guzzle 8, which depends on `guzzlehttp/psr7` 3.x.
- Keep backward compatibility with existing `guzzlehttp/psr7` 2.x installations.

## Motivation
Projects upgrading to Guzzle 8 cannot currently install this bundle because of the hard `guzzlehttp/psr7` `^2.1.1` requirement. Expanding the constraint unblocks that upgrade path without changing runtime behavior for existing consumers.

## Test plan
- [ ] Confirm `composer update` succeeds with `guzzlehttp/psr7` 2.x.
- [ ] Confirm `composer update` succeeds with `guzzlehttp/psr7` 3.x / Guzzle 8.
- [ ] Run the existing test suite / CI matrix against this branch.


Made with [Cursor](https://cursor.com)