### PR TITLE
feat(pii): add data collection for HTTP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": "^7.2||^8.0",
         "guzzlehttp/psr7": "^2.1.1|^3.0",
         "jean85/pretty-package-versions": "^1.5||^2.0",
-        "sentry/sentry": "^4.31.0",
+        "sentry/sentry": "dev-shared-data-collectors-rework",
         "symfony/cache-contracts": "^1.1||^2.4||^3.0",
         "symfony/config": "^4.4.20||^5.0.11||^6.0||^7.0||^8.0",
         "symfony/console": "^4.4.20||^5.0.11||^6.0||^7.0||^8.0",

--- a/src/DependencyInjection/Compiler/HttpClientTracingPass.php
+++ b/src/DependencyInjection/Compiler/HttpClientTracingPass.php
@@ -9,6 +9,7 @@ use Sentry\State\HubInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpClient\HttpClient;
 
 final class HttpClientTracingPass implements CompilerPassInterface
 {
@@ -38,9 +39,17 @@ final class HttpClientTracingPass implements CompilerPassInterface
             return;
         }
 
+        $definition = $container->getDefinition($decoratedService[0]);
+        // The framework's mock replaces the transport without inheriting its defaults.
+        $hasMockTransport = 'http_client.transport' === $decoratedService[0] && $container->hasDefinition('http_client.mock_client');
+        $defaultOptions = !$hasMockTransport && [HttpClient::class, 'create'] === $definition->getFactory()
+            ? ($definition->getArguments()[0] ?? [])
+            : [];
+
         $container->register(TraceableHttpClient::class, TraceableHttpClient::class)
             ->setArgument(0, new Reference(TraceableHttpClient::class . '.inner'))
             ->setArgument(1, new Reference(HubInterface::class))
+            ->setArgument(2, $defaultOptions)
             ->setDecoratedService($decoratedService[0], null, $decoratedService[1]);
     }
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sentry\SentryBundle\DependencyInjection;
 
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use Sentry\DataCollection\DataCollectionOptions;
 use Sentry\SentryBundle\ErrorTypesParser;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Cache\CacheItem;
@@ -54,6 +55,15 @@ final class Configuration implements ConfigurationInterface
                     ->defaultNull()
                 ->end()
                 ->arrayNode('options')
+                    ->beforeNormalization()
+                        ->always(static function ($value) {
+                            if (\is_array($value) && \array_key_exists('data_collection', $value) && null === $value['data_collection']) {
+                                unset($value['data_collection']);
+                            }
+
+                            return $value;
+                        })
+                    ->end()
                     ->addDefaultsIfNotSet()
                     ->fixXmlConfig('integration')
                     ->fixXmlConfig('trace_propagation_target')
@@ -145,6 +155,86 @@ final class Configuration implements ConfigurationInterface
                             ->beforeNormalization()->castToArray()->end()
                         ->end()
                         ->booleanNode('send_default_pii')->end()
+                        ->arrayNode('data_collection')
+                            ->fixXmlConfig('http_body', 'http_bodies')
+                            ->children()
+                                ->booleanNode('user_info')->end()
+                                ->arrayNode('cookies')
+                                    ->fixXmlConfig('term')
+                                    ->children()
+                                        ->enumNode('mode')->values(['off', 'denyList', 'allowList'])->end()
+                                        ->arrayNode('terms')->performNoDeepMerging()->scalarPrototype()->end()->end()
+                                    ->end()
+                                ->end()
+                                ->arrayNode('http_headers')
+                                    ->fixXmlConfig('term')
+                                    ->children()
+                                        ->enumNode('mode')->values(['off', 'denyList', 'allowList'])->end()
+                                        ->arrayNode('terms')->performNoDeepMerging()->scalarPrototype()->end()->end()
+                                        ->arrayNode('request')
+                                            ->fixXmlConfig('term')
+                                            ->children()
+                                                ->enumNode('mode')->values(['off', 'denyList', 'allowList'])->end()
+                                                ->arrayNode('terms')->performNoDeepMerging()->scalarPrototype()->end()->end()
+                                            ->end()
+                                        ->end()
+                                        ->arrayNode('response')
+                                            ->fixXmlConfig('term')
+                                            ->children()
+                                                ->enumNode('mode')->values(['off', 'denyList', 'allowList'])->end()
+                                                ->arrayNode('terms')->performNoDeepMerging()->scalarPrototype()->end()->end()
+                                            ->end()
+                                        ->end()
+                                    ->end()
+                                    ->validate()
+                                        ->always(static function (array $value): array {
+                                            if (!\array_key_exists('mode', $value) && (\array_key_exists('request', $value) || \array_key_exists('response', $value))) {
+                                                unset($value['terms']);
+                                            }
+
+                                            return $value;
+                                        })
+                                    ->end()
+                                ->end()
+                                ->arrayNode('http_bodies')
+                                    ->performNoDeepMerging()
+                                    ->treatNullLike([])
+                                    ->defaultValue(DataCollectionOptions::HTTP_BODY_TYPES)
+                                    ->enumPrototype()->values(DataCollectionOptions::HTTP_BODY_TYPES)->end()
+                                ->end()
+                                ->arrayNode('url_query_params')
+                                    ->fixXmlConfig('term')
+                                    ->children()
+                                        ->enumNode('mode')->values(['off', 'denyList', 'allowList'])->end()
+                                        ->arrayNode('terms')->performNoDeepMerging()->scalarPrototype()->end()->end()
+                                    ->end()
+                                ->end()
+                                ->arrayNode('gen_ai')
+                                    ->children()
+                                        ->booleanNode('inputs')->end()
+                                        ->booleanNode('outputs')->end()
+                                    ->end()
+                                ->end()
+                                ->booleanNode('database_query_data')->end()
+                                ->booleanNode('queues')->end()
+                                ->arrayNode('stack_frame_variables')
+                                    ->beforeNormalization()
+                                        ->ifTrue(static function ($value): bool {
+                                            return \is_bool($value);
+                                        })
+                                        ->then(static function (bool $value): array {
+                                            return ['mode' => $value ? 'denyList' : 'off'];
+                                        })
+                                    ->end()
+                                    ->fixXmlConfig('term')
+                                    ->children()
+                                        ->enumNode('mode')->values(['off', 'denyList', 'allowList'])->end()
+                                        ->arrayNode('terms')->performNoDeepMerging()->scalarPrototype()->end()->end()
+                                    ->end()
+                                ->end()
+                                ->integerNode('frame_context_lines')->min(0)->end()
+                            ->end()
+                        ->end()
                         ->integerNode('max_value_length')->min(0)->end()
                         ->scalarNode('transport')->end()
                         ->scalarNode('http_client')->end()

--- a/src/EventListener/AbstractTracingRequestListener.php
+++ b/src/EventListener/AbstractTracingRequestListener.php
@@ -4,9 +4,17 @@ declare(strict_types=1);
 
 namespace Sentry\SentryBundle\EventListener;
 
+use Sentry\DataCollection\DataCollectionOptions;
+use Sentry\DataCollection\DataCollectionPolicy;
+use Sentry\DataCollection\HttpBodyCollector;
+use Sentry\DataCollection\HttpDataCollector;
+use Sentry\DataCollection\HttpHeaderNormalizer;
 use Sentry\State\HubInterface;
+use Sentry\Tracing\Span;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\Routing\Route;
 
@@ -47,6 +55,122 @@ abstract class AbstractTracingRequestListener
         }
 
         $span->setHttpStatus($response->getStatusCode());
+    }
+
+    /**
+     * Collects prepared response data for both main requests and subrequests.
+     *
+     * @internal
+     */
+    public function collectKernelResponseEvent(ResponseEvent $event): void
+    {
+        $span = $this->hub->getSpan();
+
+        if (null === $span || !$span->getSampled()) {
+            return;
+        }
+
+        $policy = DataCollectionPolicy::fromHub($this->hub);
+        if ($policy->isLegacyMode()) {
+            return;
+        }
+
+        $response = $event->getResponse();
+        $headers = HttpHeaderNormalizer::normalize($response->headers->getIterator()->getArrayCopy());
+        $cookies = [];
+        foreach ($response->headers->getCookies() as $cookie) {
+            $cookies[] = [$cookie->getName(), $cookie->getValue()];
+        }
+
+        $data = HttpDataCollector::collectResponseData($policy, $headers, $cookies);
+        $data += $this->collectResponseBodyData($span, $response, $policy, $headers);
+
+        $span->setData(array_diff_key($data, $span->getData()));
+    }
+
+    /**
+     * @param array<array-key, string[]> $headers
+     *
+     * @return array<string, mixed>
+     */
+    private function collectResponseBodyData(Span $span, Response $response, DataCollectionPolicy $policy, array $headers): array
+    {
+        if (\array_key_exists('http.response.body.data', $span->getData())) {
+            return [];
+        }
+
+        if ($response instanceof StreamedResponse || $response instanceof BinaryFileResponse) {
+            return [];
+        }
+
+        if (0 === HttpBodyCollector::getMaxBodyLength($policy, DataCollectionOptions::HTTP_BODY_OUTGOING_RESPONSE)) {
+            return [];
+        }
+
+        $body = $response->getContent();
+        if (false === $body) {
+            return [];
+        }
+
+        return HttpDataCollector::collectBodyData($policy, DataCollectionOptions::HTTP_BODY_OUTGOING_RESPONSE, $body, $headers['content-type'][0] ?? '');
+    }
+
+    protected function collectRequestData(Span $span, Request $request, DataCollectionPolicy $policy): void
+    {
+        if (!$span->getSampled()) {
+            return;
+        }
+
+        if ($policy->isLegacyMode()) {
+            return;
+        }
+
+        $headers = HttpHeaderNormalizer::normalize($request->headers->getIterator()->getArrayCopy());
+        $data = HttpDataCollector::collectRequestData($policy, $headers, $request->cookies->all());
+        $data += $this->collectRequestBodyData($span, $request, $policy, $headers);
+
+        $span->setData(array_diff_key($data, $span->getData()));
+    }
+
+    /**
+     * @param array<array-key, string[]> $headers
+     *
+     * @return array<string, mixed>
+     */
+    private function collectRequestBodyData(Span $span, Request $request, DataCollectionPolicy $policy, array $headers): array
+    {
+        if (\array_key_exists('http.request.body.data', $span->getData())) {
+            return [];
+        }
+
+        $limit = HttpBodyCollector::getMaxBodyLength($policy, DataCollectionOptions::HTTP_BODY_INCOMING_REQUEST);
+        if (0 === $limit) {
+            return [];
+        }
+
+        if ((float) $request->headers->get('Content-Length', '0') > $limit) {
+            return [];
+        }
+
+        $body = $request->request->all();
+        if ([] === $body) {
+            $body = $request->getContent();
+        }
+
+        return HttpDataCollector::collectBodyData($policy, DataCollectionOptions::HTTP_BODY_INCOMING_REQUEST, $body, $headers['content-type'][0] ?? '');
+    }
+
+    protected function getRequestUrl(Request $request, DataCollectionPolicy $policy): string
+    {
+        // getUri() normalizes the query, losing repeated parameters and original encoding.
+        $url = $request->getSchemeAndHttpHost() . $request->getBaseUrl() . $request->getPathInfo();
+        /** @var string $query */
+        $query = $request->server->get('QUERY_STRING', '');
+        if ('' !== $query) {
+            $url .= '?' . $query;
+        }
+
+        return HttpDataCollector::collectUrl($policy, $url, $request->getUri());
     }
 
     /**

--- a/src/EventListener/LoginListener.php
+++ b/src/EventListener/LoginListener.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sentry\SentryBundle\EventListener;
 
+use Sentry\DataCollection\DataCollectionPolicy;
 use Sentry\State\HubInterface;
 use Sentry\State\Scope;
 use Sentry\UserDataBag;
@@ -88,9 +89,8 @@ final class LoginListener
             return;
         }
 
-        $client = $this->hub->getClient();
-
-        if (null === $client || !$client->getOptions()->shouldSendDefaultPii()) {
+        $policy = DataCollectionPolicy::fromHub($this->hub);
+        if (!$policy->shouldCollectUserInfo()) {
             return;
         }
 

--- a/src/EventListener/RequestListener.php
+++ b/src/EventListener/RequestListener.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sentry\SentryBundle\EventListener;
 
+use Sentry\DataCollection\DataCollectionPolicy;
 use Sentry\State\HubInterface;
 use Sentry\State\Scope;
 use Sentry\UserDataBag;
@@ -46,18 +47,19 @@ final class RequestListener
             return;
         }
 
-        $client = $this->hub->getClient();
-
-        if (null === $client || !$client->getOptions()->shouldSendDefaultPii()) {
+        $policy = DataCollectionPolicy::fromHub($this->hub);
+        if (!$policy->shouldCollectUserInfo()) {
             return;
         }
 
-        $this->hub->configureScope(static function (Scope $scope) use ($event): void {
+        /** @var string|null $ipAddress */
+        $ipAddress = $event->getRequest()->getClientIp();
+        $this->hub->configureScope(static function (Scope $scope) use ($ipAddress): void {
             $user = $scope->getUser() ?? new UserDataBag();
 
             if (null === $user->getIpAddress()) {
                 try {
-                    $user->setIpAddress($event->getRequest()->getClientIp());
+                    $user->setIpAddress($ipAddress);
                 } catch (\InvalidArgumentException $e) {
                     // If the IP is in an invalid format, we ignore it
                 }

--- a/src/EventListener/TracingRequestListener.php
+++ b/src/EventListener/TracingRequestListener.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sentry\SentryBundle\EventListener;
 
+use Sentry\DataCollection\DataCollectionPolicy;
 use Sentry\Integration\RequestFetcherInterface;
 use Sentry\SentryBundle\Integration\RequestFetcher;
 use Sentry\State\HubInterface;
@@ -74,10 +75,13 @@ final class TracingRequestListener extends AbstractTracingRequestListener
             $context->setSource(TransactionSource::url());
         }
 
+        $policy = DataCollectionPolicy::fromHub($this->hub);
         $context->setStartTimestamp($requestStartTime);
-        $context->setData($this->getData($request));
+        $context->setData($this->getData($request, $policy));
 
-        $this->hub->setSpan($this->hub->startTransaction($context));
+        $transaction = $this->hub->startTransaction($context);
+        $this->collectRequestData($transaction, $request, $policy);
+        $this->hub->setSpan($transaction);
     }
 
     /**
@@ -109,15 +113,14 @@ final class TracingRequestListener extends AbstractTracingRequestListener
      *
      * @return array<string, string>
      */
-    private function getData(Request $request): array
+    private function getData(Request $request, DataCollectionPolicy $policy): array
     {
-        $client = $this->hub->getClient();
         $httpFlavor = $this->getHttpFlavor($request);
 
         $data = [
             'net.host.port' => (string) $request->getPort(),
             'http.request.method' => $request->getMethod(),
-            'http.url' => $request->getUri(),
+            'http.url' => $this->getRequestUrl($request, $policy),
             'route' => $this->getRouteName($request),
         ];
 
@@ -131,8 +134,9 @@ final class TracingRequestListener extends AbstractTracingRequestListener
             $data['net.host.name'] = $request->getHost();
         }
 
-        if (null !== $request->getClientIp() && null !== $client && $client->getOptions()->shouldSendDefaultPii()) {
-            $data['net.peer.ip'] = $request->getClientIp();
+        $clientIp = $request->getClientIp();
+        if (null !== $clientIp && $policy->shouldCollectUserInfo()) {
+            $data['net.peer.ip'] = $clientIp;
         }
 
         return $data;

--- a/src/EventListener/TracingSubRequestListener.php
+++ b/src/EventListener/TracingSubRequestListener.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sentry\SentryBundle\EventListener;
 
+use Sentry\DataCollection\DataCollectionPolicy;
 use Sentry\Tracing\Span;
 use Sentry\Tracing\SpanContext;
 use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
@@ -34,19 +35,21 @@ final class TracingSubRequestListener extends AbstractTracingRequestListener
             return;
         }
 
-        $this->hub->setSpan(
-            $span->startChild(
-                SpanContext::make()
-                    ->setOp('http.server')
-                    ->setData([
-                        'http.request.method' => $request->getMethod(),
-                        'http.url' => $request->getUri(),
-                        'route' => $this->getRouteName($request),
-                    ])
-                    ->setOrigin('auto.http.server')
-                    ->setDescription(\sprintf('%s %s%s%s', $request->getMethod(), $request->getSchemeAndHttpHost(), $request->getBaseUrl(), $request->getPathInfo()))
-            )
+        $policy = DataCollectionPolicy::fromHub($this->hub);
+
+        $childSpan = $span->startChild(
+            SpanContext::make()
+                ->setOp('http.server')
+                ->setData([
+                    'http.request.method' => $request->getMethod(),
+                    'http.url' => $this->getRequestUrl($request, $policy),
+                    'route' => $this->getRouteName($request),
+                ])
+                ->setOrigin('auto.http.server')
+                ->setDescription(\sprintf('%s %s%s%s', $request->getMethod(), $request->getSchemeAndHttpHost(), $request->getBaseUrl(), $request->getPathInfo()))
         );
+        $this->collectRequestData($childSpan, $request, $policy);
+        $this->hub->setSpan($childSpan);
     }
 
     /**

--- a/src/Integration/RequestFetcher.php
+++ b/src/Integration/RequestFetcher.php
@@ -64,7 +64,20 @@ final class RequestFetcher implements RequestFetcherInterface, ResetInterface
         }
 
         try {
-            return $this->httpMessageFactory->createRequest($request);
+            $serverRequest = $this->httpMessageFactory->createRequest($request);
+
+            // The bridge exposes Symfony's form bag as the parsed body even
+            // for content types that Symfony does not parse into that bag.
+            $contentType = strtolower(trim(explode(';', (string) $request->headers->get('Content-Type'), 2)[0]));
+            $isForm = 'application/x-www-form-urlencoded' === $contentType || 'multipart/form-data' === $contentType;
+            if (!$isForm
+                && [] === $serverRequest->getParsedBody()
+                && [] === $request->request->all()
+                && '' !== $request->getContent()) {
+                $serverRequest = $serverRequest->withParsedBody(null);
+            }
+
+            return $serverRequest;
         } catch (\Throwable $exception) {
             return null;
         }

--- a/src/Resources/config/schema/sentry-1.0.xsd
+++ b/src/Resources/config/schema/sentry-1.0.xsd
@@ -32,6 +32,7 @@
             <xsd:element name="class-serializer" type="class-serializer" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="ignore-exception" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="ignore-transaction" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="data-collection" type="data-collection" minOccurs="0" maxOccurs="1" />
         </xsd:sequence>
 
         <xsd:attribute name="default-integrations" type="xsd:boolean" />
@@ -75,6 +76,68 @@
         <xsd:attribute name="max-request-body-size" type="max-request-body-size" />
         <xsd:attribute name="strict-trace-continuation" type="xsd:boolean" />
     </xsd:complexType>
+
+    <xsd:complexType name="data-collection">
+        <xsd:sequence>
+            <xsd:element name="cookies" type="key-value-collection" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="http-headers" type="http-headers" minOccurs="0" maxOccurs="1" />
+            <xsd:choice minOccurs="0">
+                <xsd:element name="http-body" type="http-body-type" maxOccurs="unbounded" />
+                <!-- An explicitly empty list disables collection of all bodies. -->
+                <xsd:element name="http-bodies">
+                    <xsd:complexType />
+                </xsd:element>
+            </xsd:choice>
+            <xsd:element name="url-query-params" type="key-value-collection" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="gen-ai" type="gen-ai" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="stack-frame-variables" type="key-value-collection" minOccurs="0" maxOccurs="1" />
+        </xsd:sequence>
+
+        <xsd:attribute name="user-info" type="xsd:boolean" />
+        <xsd:attribute name="database-query-data" type="xsd:boolean" />
+        <xsd:attribute name="queues" type="xsd:boolean" />
+        <xsd:attribute name="frame-context-lines" type="xsd:integer" />
+    </xsd:complexType>
+
+    <xsd:complexType name="key-value-collection">
+        <xsd:sequence>
+            <xsd:element name="term" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+        </xsd:sequence>
+
+        <xsd:attribute name="mode" type="collection-mode" />
+    </xsd:complexType>
+
+    <xsd:complexType name="http-headers">
+        <xsd:sequence>
+            <xsd:element name="term" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="request" type="key-value-collection" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="response" type="key-value-collection" minOccurs="0" maxOccurs="1" />
+        </xsd:sequence>
+
+        <xsd:attribute name="mode" type="collection-mode" />
+    </xsd:complexType>
+
+    <xsd:complexType name="gen-ai">
+        <xsd:attribute name="inputs" type="xsd:boolean" />
+        <xsd:attribute name="outputs" type="xsd:boolean" />
+    </xsd:complexType>
+
+    <xsd:simpleType name="collection-mode">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="off" />
+            <xsd:enumeration value="denyList" />
+            <xsd:enumeration value="allowList" />
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="http-body-type">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="incomingRequest" />
+            <xsd:enumeration value="outgoingRequest" />
+            <xsd:enumeration value="incomingResponse" />
+            <xsd:enumeration value="outgoingResponse" />
+        </xsd:restriction>
+    </xsd:simpleType>
 
     <xsd:complexType name="tag">
         <xsd:simpleContent>

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -51,6 +51,8 @@ services:
     tags:
       - { name: kernel.event_listener, event: kernel.request, method: handleKernelRequestEvent, priority: 4 }
       - { name: kernel.event_listener, event: kernel.response, method: handleKernelResponseEvent, priority: 15 }
+      # Collect main and subrequest response data once, after response preparation and session cookies.
+      - { name: kernel.event_listener, event: kernel.response, method: collectKernelResponseEvent, priority: -1024 }
       - { name: kernel.event_listener, event: kernel.terminate, method: handleKernelTerminateEvent, priority: 5 }
 
   Sentry\SentryBundle\EventListener\TracingSubRequestListener:

--- a/src/Tracing/HttpClient/AbstractTraceableHttpClient.php
+++ b/src/Tracing/HttpClient/AbstractTraceableHttpClient.php
@@ -7,8 +7,14 @@ namespace Sentry\SentryBundle\Tracing\HttpClient;
 use GuzzleHttp\Psr7\Uri;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
-use Sentry\ClientInterface;
+use Sentry\DataCollection\DataCollectionOptions;
+use Sentry\DataCollection\DataCollectionPolicy;
+use Sentry\DataCollection\HttpDataCollector;
+use Sentry\DataCollection\HttpHeaderNormalizer;
+use Sentry\DataCollection\KeyValueDataFilter;
+use Sentry\Options;
 use Sentry\State\HubInterface;
+use Sentry\Tracing\Span;
 use Sentry\Tracing\SpanContext;
 use Symfony\Component\HttpClient\Response\ResponseStream;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -37,10 +43,21 @@ abstract class AbstractTraceableHttpClient implements HttpClientInterface, Reset
      */
     protected $hub;
 
-    public function __construct(HttpClientInterface $client, HubInterface $hub)
+    /**
+     * Request defaults that are not visible in individual request arguments.
+     *
+     * @var array<string, mixed>
+     */
+    protected $defaultRequestOptions = ['headers' => []];
+
+    /**
+     * @param array<string, mixed> $defaultOptions
+     */
+    public function __construct(HttpClientInterface $client, HubInterface $hub, array $defaultOptions = [])
     {
         $this->client = $client;
         $this->hub = $hub;
+        $this->defaultRequestOptions = $this->resolveRequestOptions($defaultOptions);
     }
 
     /**
@@ -50,19 +67,18 @@ abstract class AbstractTraceableHttpClient implements HttpClientInterface, Reset
     {
         $uri = new Uri($url);
         $headers = $options['headers'] ?? [];
+        $parentSpan = $this->hub->getSpan();
+        $policy = DataCollectionPolicy::fromHub($this->hub);
 
-        $span = $this->hub->getSpan();
-        $client = $this->hub->getClient();
-
-        if (null === $span) {
-            if (self::shouldAttachTracingHeaders($client, $uri)) {
+        if (null === $parentSpan) {
+            if (self::shouldAttachTracingHeaders($policy->getOptions(), $uri)) {
                 $headers['baggage'] = getBaggage();
                 $headers['sentry-trace'] = getTraceparent();
             }
 
             $options['headers'] = $headers;
 
-            return new TraceableResponse($this->client, $this->client->request($method, $url, $options), $span);
+            return new TraceableResponse($this->client, $this->client->request($method, $url, $options), null, $policy);
         }
 
         $partialUri = Uri::fromParts([
@@ -71,34 +87,77 @@ abstract class AbstractTraceableHttpClient implements HttpClientInterface, Reset
             'port' => $uri->getPort(),
             'path' => $uri->getPath(),
         ]);
-
-        $context = SpanContext::make()
-            ->setOp('http.client')
-            ->setOrigin('auto.http.client')
-            ->setDescription($method . ' ' . (string) $partialUri);
-
         $contextData = [
             'http.url' => (string) $partialUri,
             'http.request.method' => $method,
         ];
-        if ('' !== $uri->getQuery()) {
-            $contextData['http.query'] = $uri->getQuery();
-        }
+        $contextData += HttpDataCollector::collectQueryData($policy, $uri->getQuery());
         if ('' !== $uri->getFragment()) {
             $contextData['http.fragment'] = $uri->getFragment();
         }
-        $context->setData($contextData);
 
-        $childSpan = $span->startChild($context);
+        $context = SpanContext::make()
+            ->setOp('http.client')
+            ->setOrigin('auto.http.client')
+            ->setDescription($method . ' ' . (string) $partialUri)
+            ->setData($contextData);
+        $childSpan = $parentSpan->startChild($context);
 
-        if (self::shouldAttachTracingHeaders($client, $uri)) {
+        if (self::shouldAttachTracingHeaders($policy->getOptions(), $uri)) {
             $headers['baggage'] = $childSpan->toBaggage();
             $headers['sentry-trace'] = $childSpan->toTraceparent();
         }
 
         $options['headers'] = $headers;
+        $this->collectRequestData($childSpan, $policy, $options);
 
-        return new TraceableResponse($this->client, $this->client->request($method, $url, $options), $childSpan);
+        return new TraceableResponse(
+            $this->client,
+            $this->client->request($method, $url, $options),
+            $childSpan,
+            $policy
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function collectRequestData(Span $span, DataCollectionPolicy $policy, array $options): void
+    {
+        if (!$span->getSampled()) {
+            return;
+        }
+
+        $requestOptions = $this->resolveRequestOptions($options);
+        /** @var array<array-key, string[]> $headers */
+        $headers = $requestOptions['headers'];
+        $hasAuthenticationOption = ($requestOptions['auth_basic'] ?? false) || ($requestOptions['auth_bearer'] ?? false);
+        if ($hasAuthenticationOption && !($headers['authorization'] ?? false)) {
+            $headers['authorization'] = [KeyValueDataFilter::FILTERED_VALUE];
+        }
+
+        $data = HttpDataCollector::collectRequestData($policy, $headers);
+        $body = $requestOptions['json'] ?? $requestOptions['body'] ?? null;
+        $contentType = isset($requestOptions['json']) ? '' : ($headers['content-type'][0] ?? '');
+        if (\is_string($body) || \is_array($body)) {
+            $data += HttpDataCollector::collectBodyData($policy, DataCollectionOptions::HTTP_BODY_OUTGOING_REQUEST, $body, $contentType);
+        }
+
+        $span->setData(array_diff_key($data, $span->getData()));
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @return array<string, mixed>
+     */
+    protected function resolveRequestOptions(array $options): array
+    {
+        /** @var array<array-key, mixed> $headers */
+        $headers = $options['headers'] ?? [];
+        $options['headers'] = HttpHeaderNormalizer::normalize($headers) + $this->defaultRequestOptions['headers'];
+
+        return $options + $this->defaultRequestOptions;
     }
 
     /**
@@ -132,20 +191,13 @@ abstract class AbstractTraceableHttpClient implements HttpClientInterface, Reset
         }
     }
 
-    private static function shouldAttachTracingHeaders(?ClientInterface $client, Uri $uri): bool
+    private static function shouldAttachTracingHeaders(?Options $options, Uri $uri): bool
     {
-        if (null !== $client) {
-            $sdkOptions = $client->getOptions();
-
-            // Check if the request destination is allow listed in the trace_propagation_targets option.
-            if (
-                null === $sdkOptions->getTracePropagationTargets()
-                || \in_array($uri->getHost(), $sdkOptions->getTracePropagationTargets())
-            ) {
-                return true;
-            }
+        if (null === $options) {
+            return false;
         }
 
-        return false;
+        return null === $options->getTracePropagationTargets()
+            || \in_array($uri->getHost(), $options->getTracePropagationTargets());
     }
 }

--- a/src/Tracing/HttpClient/AbstractTraceableResponse.php
+++ b/src/Tracing/HttpClient/AbstractTraceableResponse.php
@@ -4,9 +4,14 @@ declare(strict_types=1);
 
 namespace Sentry\SentryBundle\Tracing\HttpClient;
 
+use Sentry\DataCollection\DataCollectionOptions;
+use Sentry\DataCollection\DataCollectionPolicy;
+use Sentry\DataCollection\HttpBodyCollector;
+use Sentry\DataCollection\HttpDataCollector;
 use Sentry\Tracing\Span;
 use Sentry\Tracing\SpanStatus;
 use Symfony\Contracts\HttpClient\ChunkInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -26,15 +31,40 @@ abstract class AbstractTraceableResponse implements ResponseInterface
     protected $client;
 
     /**
+     * Kept after timing finishes because response bodies can be materialized later.
+     *
      * @var Span|null
      */
     protected $span;
 
-    public function __construct(HttpClientInterface $client, ResponseInterface $response, ?Span $span)
+    /**
+     * Retained so delayed response collection observes live option updates.
+     *
+     * @var DataCollectionPolicy
+     */
+    private $policy;
+
+    /**
+     * @var bool
+     */
+    private $timingFinished = false;
+
+    /**
+     * @var bool
+     */
+    private $responseDataCollected = false;
+
+    /**
+     * @var string
+     */
+    private $contentType = '';
+
+    public function __construct(HttpClientInterface $client, ResponseInterface $response, ?Span $span, ?DataCollectionPolicy $policy = null)
     {
         $this->client = $client;
         $this->response = $response;
         $this->span = $span;
+        $this->policy = $policy ?? DataCollectionPolicy::fromOptions(null);
     }
 
     public function __destruct()
@@ -71,19 +101,27 @@ abstract class AbstractTraceableResponse implements ResponseInterface
     public function getContent(bool $throw = true): string
     {
         try {
-            return $this->response->getContent($throw);
+            $body = $this->response->getContent($throw);
         } finally {
             $this->finishSpan();
         }
+
+        $this->collectBody($body);
+
+        return $body;
     }
 
     public function toArray(bool $throw = true): array
     {
         try {
-            return $this->response->toArray($throw);
+            $body = $this->response->toArray($throw);
         } finally {
             $this->finishSpan();
         }
+
+        $this->collectBody($body);
+
+        return $body;
     }
 
     public function cancel(): void
@@ -93,11 +131,11 @@ abstract class AbstractTraceableResponse implements ResponseInterface
     }
 
     /**
-     * @internal
-     *
      * @param iterable<AbstractTraceableResponse> $responses
      *
      * @return \Generator<AbstractTraceableResponse, ChunkInterface>
+     *
+     * @internal
      */
     public static function stream(HttpClientInterface $client, iterable $responses, ?float $timeout): \Generator
     {
@@ -122,29 +160,64 @@ abstract class AbstractTraceableResponse implements ResponseInterface
         }
     }
 
-    private function finishSpan(): void
+    /**
+     * @param string|array<array-key, mixed> $body
+     */
+    private function collectBody($body): void
     {
-        if (null === $this->span) {
+        $span = $this->span;
+        if (null === $span || !$span->getSampled()
+            || \array_key_exists('http.response.body.data', $span->getData())
+            || 0 === HttpBodyCollector::getMaxBodyLength($this->policy, DataCollectionOptions::HTTP_BODY_INCOMING_RESPONSE)) {
             return;
         }
 
-        // We finish the span (which means setting the span end timestamp) first
-        // to ensure the measured time is as close as possible to the duration of
-        // the HTTP request
-        $this->span->finish();
+        $this->collectResponseData();
+        $data = HttpDataCollector::collectBodyData($this->policy, DataCollectionOptions::HTTP_BODY_INCOMING_RESPONSE, $body, $this->contentType);
+        $span->setData(array_diff_key($data, $span->getData()));
+    }
 
-        /** @var int $statusCode */
-        $statusCode = $this->response->getInfo('http_code');
-
-        // If the returned status code is 0, it means that this info isn't available
-        // yet (e.g. an error happened before the request was sent), hence we cannot
-        // determine what happened.
-        if (0 === $statusCode) {
-            $this->span->setStatus(SpanStatus::unknownError());
-        } else {
-            $this->span->setStatus(SpanStatus::createFromHttpStatusCode($statusCode));
+    private function finishSpan(): void
+    {
+        $span = $this->span;
+        if (null === $span) {
+            return;
         }
 
-        $this->span = null;
+        if (!$this->timingFinished) {
+            $this->timingFinished = true;
+            $span->finish();
+
+            /** @var int $statusCode */
+            $statusCode = $this->response->getInfo('http_code');
+            $span->setStatus(0 === $statusCode
+                ? SpanStatus::unknownError()
+                : SpanStatus::createFromHttpStatusCode($statusCode));
+        }
+
+        $this->collectResponseData();
+    }
+
+    private function collectResponseData(): void
+    {
+        $span = $this->span;
+        if ($this->responseDataCollected || null === $span || !$span->getSampled()) {
+            return;
+        }
+
+        if ($this->policy->isLegacyMode()) {
+            return;
+        }
+
+        $this->responseDataCollected = true;
+        try {
+            $headers = $this->response->getHeaders(false);
+        } catch (TransportExceptionInterface $exception) {
+            return;
+        }
+
+        $this->contentType = $headers['content-type'][0] ?? '';
+        $data = HttpDataCollector::collectResponseData($this->policy, $headers);
+        $span->setData(array_diff_key($data, $span->getData()));
     }
 }

--- a/src/Tracing/HttpClient/TraceableHttpClientForV5.php
+++ b/src/Tracing/HttpClient/TraceableHttpClientForV5.php
@@ -16,6 +16,7 @@ final class TraceableHttpClientForV5 extends AbstractTraceableHttpClient
     {
         $clone = clone $this;
         $clone->client = $this->client->withOptions($options);
+        $clone->defaultRequestOptions = $clone->resolveRequestOptions($options);
 
         return $clone;
     }

--- a/src/Tracing/HttpClient/TraceableHttpClientForV6.php
+++ b/src/Tracing/HttpClient/TraceableHttpClientForV6.php
@@ -16,6 +16,7 @@ final class TraceableHttpClientForV6 extends AbstractTraceableHttpClient
     {
         $clone = clone $this;
         $clone->client = $this->client->withOptions($options);
+        $clone->defaultRequestOptions = $clone->resolveRequestOptions($options);
 
         return $clone;
     }

--- a/tests/DataCollection/HttpUrlCollectionTest.php
+++ b/tests/DataCollection/HttpUrlCollectionTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\DataCollection;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\ClientInterface;
+use Sentry\Options;
+use Sentry\SentryBundle\EventListener\TracingRequestListener;
+use Sentry\SentryBundle\EventListener\TracingSubRequestListener;
+use Sentry\SentryBundle\Tracing\HttpClient\TraceableHttpClient;
+use Sentry\State\Hub;
+use Sentry\Tracing\Transaction;
+use Sentry\Tracing\TransactionContext;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+final class HttpUrlCollectionTest extends TestCase
+{
+    private const QUERY = 'page=one+two&tag=a&tag=b&%74oken=secret&a.b=dot';
+    private const FILTERED_QUERY = 'page=one+two&tag=a&tag=b&%74oken=[Filtered]&a.b=dot';
+
+    public function testLegacyServerUrlUsesSymfonyRequestUri(): void
+    {
+        $request = Request::create('https://example.com/path?' . self::QUERY);
+
+        [$transaction, $span] = $this->traceServerRequest(null, $request);
+
+        $this->assertSame($request->getUri(), $transaction->getData()['http.url']);
+        $this->assertSame($request->getUri(), $span->getData()['http.url']);
+    }
+
+    /**
+     * @dataProvider serverUrlPolicyProvider
+     *
+     * @param array<string, mixed>|null $dataCollection
+     */
+    public function testServerUrls(?array $dataCollection, string $expectedUrl): void
+    {
+        $request = Request::create('https://example.com/path?' . self::QUERY);
+        $originalUri = $request->getUri();
+
+        [$transaction, $span] = $this->traceServerRequest($dataCollection, $request);
+
+        $this->assertSame($expectedUrl, $transaction->getData()['http.url']);
+        $this->assertSame('GET https://example.com/path', $transaction->getName());
+        $this->assertSame($expectedUrl, $span->getData()['http.url']);
+        $this->assertSame('GET https://example.com/path', $span->getDescription());
+        $this->assertSame($originalUri, $request->getUri());
+        $this->assertSame(self::QUERY, $request->server->get('QUERY_STRING'));
+    }
+
+    /**
+     * @dataProvider clientQueryPolicyProvider
+     *
+     * @param array<string, mixed>|null $dataCollection
+     * @param array<string, mixed>      $expectedQueryData
+     */
+    public function testClientQuery(?array $dataCollection, array $expectedQueryData): void
+    {
+        if (!class_exists(MockHttpClient::class)) {
+            $this->markTestSkipped('This test requires symfony/http-client.');
+        }
+
+        $hub = $this->createHub($dataCollection);
+        $transaction = new Transaction(TransactionContext::make()->setSampled(true));
+        $transaction->initSpanRecorder();
+        $hub->setSpan($transaction);
+        $httpClient = new TraceableHttpClient(new MockHttpClient(new MockResponse()), $hub);
+        $url = 'https://username:password@example.com/path?' . self::QUERY . '#fragment';
+        $response = $httpClient->request('GET', $url);
+        $this->assertSame(200, $response->getStatusCode());
+        $untracedResponse = (new MockHttpClient(new MockResponse()))->request('GET', $url);
+        $this->assertSame($untracedResponse->getInfo('url'), $response->getInfo('url'));
+
+        $recorder = $transaction->getSpanRecorder();
+        $this->assertNotNull($recorder);
+        $spans = $recorder->getSpans();
+        $this->assertCount(2, $spans);
+        $data = $spans[1]->getData();
+        $this->assertSame('https://example.com/path', $data['http.url']);
+        $this->assertSame('fragment', $data['http.fragment']);
+        $this->assertSame($expectedQueryData, array_intersect_key($data, ['http.query' => true]));
+        $this->assertSame('GET https://example.com/path', $spans[1]->getDescription());
+    }
+
+    /**
+     * @return \Generator<mixed>
+     */
+    public function serverUrlPolicyProvider(): \Generator
+    {
+        yield 'defaults' => [[], 'https://example.com/path?' . self::FILTERED_QUERY];
+        yield 'off' => [['url_query_params' => ['mode' => 'off']], 'https://example.com/path'];
+        yield 'deny list' => [
+            ['url_query_params' => ['mode' => 'denyList', 'terms' => ['page']]],
+            'https://example.com/path?page=[Filtered]&tag=a&tag=b&%74oken=[Filtered]&a.b=dot',
+        ];
+        yield 'allow list' => [
+            ['url_query_params' => ['mode' => 'allowList', 'terms' => ['page', 'token']]],
+            'https://example.com/path?page=one+two&tag=[Filtered]&tag=[Filtered]&%74oken=[Filtered]&a.b=[Filtered]',
+        ];
+    }
+
+    public function clientQueryPolicyProvider(): \Generator
+    {
+        yield 'legacy' => [null, ['http.query' => self::QUERY]];
+        yield 'defaults' => [[], ['http.query' => self::FILTERED_QUERY]];
+        yield 'off' => [['url_query_params' => ['mode' => 'off']], []];
+        yield 'deny list' => [
+            ['url_query_params' => ['mode' => 'denyList', 'terms' => ['page']]],
+            ['http.query' => 'page=[Filtered]&tag=a&tag=b&%74oken=[Filtered]&a.b=dot'],
+        ];
+        yield 'allow list' => [
+            ['url_query_params' => ['mode' => 'allowList', 'terms' => ['page', 'token']]],
+            ['http.query' => 'page=one+two&tag=[Filtered]&tag=[Filtered]&%74oken=[Filtered]&a.b=[Filtered]'],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed>|null $dataCollection
+     *
+     * @return array{Transaction, \Sentry\Tracing\Span}
+     */
+    private function traceServerRequest(?array $dataCollection, Request $request): array
+    {
+        $hub = $this->createHub($dataCollection);
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        (new TracingRequestListener($hub))->handleKernelRequestEvent(new RequestEvent(
+            $kernel,
+            $request,
+            (int) \constant(HttpKernelInterface::class . '::' . (\defined(HttpKernelInterface::class . '::MAIN_REQUEST') ? 'MAIN_REQUEST' : 'MASTER_REQUEST'))
+        ));
+        $transaction = $hub->getTransaction();
+        $this->assertNotNull($transaction);
+        (new TracingSubRequestListener($hub))->handleKernelRequestEvent(new RequestEvent($kernel, $request, HttpKernelInterface::SUB_REQUEST));
+        $span = $hub->getSpan();
+        $this->assertNotNull($span);
+        $this->assertNotSame($transaction, $span);
+
+        return [$transaction, $span];
+    }
+
+    /**
+     * @param array<string, mixed>|null $dataCollection
+     */
+    private function createHub(?array $dataCollection): Hub
+    {
+        $options = new Options(['data_collection' => $dataCollection, 'traces_sample_rate' => 1.0]);
+        $client = $this->createMock(ClientInterface::class);
+        $client->method('getOptions')->willReturn($options);
+
+        return new Hub($client);
+    }
+}

--- a/tests/DependencyInjection/Compiler/HttpClientTracingPassTest.php
+++ b/tests/DependencyInjection/Compiler/HttpClientTracingPassTest.php
@@ -9,6 +9,8 @@ use Sentry\SentryBundle\DependencyInjection\Compiler\HttpClientTracingPass;
 use Sentry\SentryBundle\Tracing\HttpClient\TraceableHttpClient;
 use Sentry\State\HubInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class HttpClientTracingPassTest extends TestCase
@@ -60,6 +62,43 @@ final class HttpClientTracingPassTest extends TestCase
         $container->compile();
 
         $this->assertFalse($container->hasDefinition('http_client'));
+    }
+
+    /**
+     * @dataProvider frameworkClientProvider
+     */
+    public function testFrameworkDefaultOptionsAreAvailableForCollection(string $serviceId): void
+    {
+        $container = $this->createContainerBuilder(true, true, $serviceId);
+        $options = ['headers' => ['X-Default' => 'visible', 'Cookie' => 'theme=dark']];
+        $container->getDefinition($serviceId)
+            ->setFactory([HttpClient::class, 'create'])
+            ->setArguments([$options]);
+        $container->compile();
+
+        $this->assertSame($options, $container->getDefinition($serviceId)->getArgument(2));
+    }
+
+    public function testMockClientDoesNotCollectTransportDefaultOptions(): void
+    {
+        $container = $this->createContainerBuilder(true, true, 'http_client.transport');
+        $container->getDefinition('http_client.transport')
+            ->setFactory([HttpClient::class, 'create'])
+            ->setArguments([['headers' => ['X-Default' => 'unused', 'Cookie' => 'theme=unused']]]);
+        $container->register('http_client.mock_client', MockHttpClient::class)
+            ->setDecoratedService('http_client.transport', null, -10);
+        $container->compile();
+
+        $this->assertSame([], $container->getDefinition('http_client.transport')->getArgument(2));
+    }
+
+    /**
+     * @return \Generator<mixed>
+     */
+    public function frameworkClientProvider(): \Generator
+    {
+        yield 'transport service' => ['http_client.transport'];
+        yield 'legacy service' => ['http_client'];
     }
 
     /**

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -341,6 +341,99 @@ final class ConfigurationTest extends TestCase
     }
 
     /**
+     * @dataProvider collectionListOverrideProvider
+     *
+     * @param array<string, mixed> $base
+     * @param array<string, mixed> $override
+     */
+    public function testCollectionListsAreReplacedAcrossConfigFiles(array $base, array $override): void
+    {
+        $processor = new Processor();
+        /** @var array{options: array<string, mixed>} $merged */
+        $merged = $processor->processConfiguration(new Configuration(), [
+            ['options' => ['data_collection' => $base]],
+            ['options' => ['data_collection' => $override]],
+        ]);
+        /** @var array{options: array<string, mixed>} $expected */
+        $expected = $this->processConfiguration(['options' => ['data_collection' => $override]]);
+        $this->assertSame($expected['options']['data_collection'], $merged['options']['data_collection']);
+    }
+
+    public function collectionListOverrideProvider(): \Generator
+    {
+        yield 'disable bodies' => [['http_bodies' => ['incomingRequest']], ['http_bodies' => []]];
+        yield 'restrict bodies' => [['http_bodies' => ['incomingRequest', 'outgoingResponse']], ['http_bodies' => ['incomingRequest']]];
+        foreach (['cookies', 'url_query_params', 'stack_frame_variables', 'http_headers'] as $key) {
+            yield $key => [
+                [$key => ['mode' => 'allowList', 'terms' => ['email']]],
+                [$key => ['mode' => 'allowList', 'terms' => []]],
+            ];
+        }
+        foreach (['request', 'response'] as $direction) {
+            yield $direction . ' headers' => [
+                ['http_headers' => [$direction => ['mode' => 'allowList', 'terms' => ['email']]]],
+                ['http_headers' => [$direction => ['mode' => 'allowList', 'terms' => []]]],
+            ];
+        }
+    }
+
+    public function testDataCollectionOptionIsAbsentByDefault(): void
+    {
+        /** @var array{options: array<string, mixed>} $config */
+        $config = $this->processConfiguration([]);
+
+        $this->assertArrayNotHasKey('data_collection', $config['options']);
+    }
+
+    public function testNullDataCollectionOptionPreservesLegacyMode(): void
+    {
+        /** @var array{options: array<string, mixed>} $config */
+        $config = $this->processConfiguration(['options' => ['data_collection' => null]]);
+
+        $this->assertArrayNotHasKey('data_collection', $config['options']);
+        $this->assertNull((new Options($config['options']))->getDataCollection());
+    }
+
+    public function testEmptyDataCollectionOptionUsesCoreDefaults(): void
+    {
+        /** @var array{options: array<string, mixed>} $config */
+        $config = $this->processConfiguration(['options' => ['data_collection' => []]]);
+        $options = new Options($config['options']);
+        $dataCollection = $options->getDataCollection();
+
+        $this->assertNotNull($dataCollection);
+        $this->assertSame([
+            'incomingRequest',
+            'outgoingRequest',
+            'incomingResponse',
+            'outgoingResponse',
+        ], $dataCollection->getHttpBodies());
+    }
+
+    /**
+     * @dataProvider stackFrameVariablesBooleanDataProvider
+     */
+    public function testDataCollectionNormalizesStackFrameVariablesBoolean(bool $value, string $expectedMode): void
+    {
+        /** @var array{options: array{data_collection: array{stack_frame_variables: array{mode: string}}}} $config */
+        $config = $this->processConfiguration([
+            'options' => [
+                'data_collection' => [
+                    'stack_frame_variables' => $value,
+                ],
+            ],
+        ]);
+
+        $this->assertSame($expectedMode, $config['options']['data_collection']['stack_frame_variables']['mode']);
+    }
+
+    public function stackFrameVariablesBooleanDataProvider(): \Generator
+    {
+        yield [true, 'denyList'];
+        yield [false, 'off'];
+    }
+
+    /**
      * @dataProvider maxRequestBodySizeValuesDataProvider
      */
     public function testMaxRequestBodySizeValues(string $maxRequestBodySize): void

--- a/tests/DependencyInjection/Fixtures/php/data_collection_bodies_disabled.php
+++ b/tests/DependencyInjection/Fixtures/php/data_collection_bodies_disabled.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $container): void {
+    $container->extension('sentry', [
+        'options' => [
+            'data_collection' => ['http_bodies' => []],
+        ],
+    ]);
+};

--- a/tests/DependencyInjection/Fixtures/php/full.php
+++ b/tests/DependencyInjection/Fixtures/php/full.php
@@ -50,6 +50,38 @@ $container->loadFromExtension('sentry', [
         'in_app_exclude' => ['%kernel.cache_dir%'],
         'in_app_include' => ['%kernel.project_dir%'],
         'send_default_pii' => true,
+        'data_collection' => [
+            'user_info' => false,
+            'cookies' => [
+                'mode' => 'allowList',
+                'terms' => ['theme'],
+            ],
+            'http_headers' => [
+                'request' => [
+                    'mode' => 'denyList',
+                    'terms' => ['x-request'],
+                ],
+                'response' => [
+                    'mode' => 'off',
+                ],
+            ],
+            'http_bodies' => ['incomingRequest', 'incomingResponse'],
+            'url_query_params' => [
+                'mode' => 'allowList',
+                'terms' => ['page'],
+            ],
+            'gen_ai' => [
+                'inputs' => false,
+                'outputs' => true,
+            ],
+            'database_query_data' => false,
+            'queues' => false,
+            'stack_frame_variables' => [
+                'mode' => 'denyList',
+                'terms' => ['local_secret'],
+            ],
+            'frame_context_lines' => 3,
+        ],
         'max_value_length' => 255,
         'transport' => 'App\\Sentry\\Transport',
         'http_client' => 'App\\Sentry\\HttpClient',

--- a/tests/DependencyInjection/Fixtures/xml/data_collection_bodies_disabled.xml
+++ b/tests/DependencyInjection/Fixtures/xml/data_collection_bodies_disabled.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:sentry="https://sentry.io/schema/dic/sentry-symfony"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                               https://sentry.io/schema/dic/sentry-symfony https://sentry.io/schema/dic/sentry-symfony/sentry-1.0.xsd">
+    <sentry:config>
+        <sentry:options>
+            <sentry:data-collection>
+                <sentry:http-bodies />
+            </sentry:data-collection>
+        </sentry:options>
+    </sentry:config>
+</container>

--- a/tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/tests/DependencyInjection/Fixtures/xml/full.xml
@@ -60,6 +60,26 @@
             <sentry:class-serializer class="App\FooClass">App\Sentry\Serializer\FooClassSerializer</sentry:class-serializer>
             <sentry:ignore-exception>Symfony\Component\HttpKernel\Exception\BadRequestHttpException</sentry:ignore-exception>
             <sentry:ignore-transaction>GET tracing_ignored_transaction</sentry:ignore-transaction>
+            <sentry:data-collection user-info="false" database-query-data="false" queues="false" frame-context-lines="3">
+                <sentry:cookies mode="allowList">
+                    <sentry:term>theme</sentry:term>
+                </sentry:cookies>
+                <sentry:http-headers>
+                    <sentry:request mode="denyList">
+                        <sentry:term>x-request</sentry:term>
+                    </sentry:request>
+                    <sentry:response mode="off" />
+                </sentry:http-headers>
+                <sentry:http-body>incomingRequest</sentry:http-body>
+                <sentry:http-body>incomingResponse</sentry:http-body>
+                <sentry:url-query-params mode="allowList">
+                    <sentry:term>page</sentry:term>
+                </sentry:url-query-params>
+                <sentry:gen-ai inputs="false" outputs="true" />
+                <sentry:stack-frame-variables mode="denyList">
+                    <sentry:term>local_secret</sentry:term>
+                </sentry:stack-frame-variables>
+            </sentry:data-collection>
         </sentry:options>
         <sentry:messenger enabled="true" capture-soft-fails="false" isolate-breadcrumbs-by-message="true" isolate-context-by-message="true"/>
         <sentry:tracing>

--- a/tests/DependencyInjection/Fixtures/yml/data_collection_bodies_disabled.yml
+++ b/tests/DependencyInjection/Fixtures/yml/data_collection_bodies_disabled.yml
@@ -1,0 +1,4 @@
+sentry:
+    options:
+        data_collection:
+            http_bodies: []

--- a/tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/tests/DependencyInjection/Fixtures/yml/full.yml
@@ -47,6 +47,36 @@ sentry:
         in_app_include:
             - '%kernel.project_dir%'
         send_default_pii: true
+        data_collection:
+            user_info: false
+            cookies:
+                mode: allowList
+                terms:
+                    - theme
+            http_headers:
+                request:
+                    mode: denyList
+                    terms:
+                        - x-request
+                response:
+                    mode: off
+            http_bodies:
+                - incomingRequest
+                - incomingResponse
+            url_query_params:
+                mode: allowList
+                terms:
+                    - page
+            gen_ai:
+                inputs: false
+                outputs: true
+            database_query_data: false
+            queues: false
+            stack_frame_variables:
+                mode: denyList
+                terms:
+                    - local_secret
+            frame_context_lines: 3
         max_value_length: 255
         transport: App\Sentry\Transport
         http_client: App\Sentry\HttpClient

--- a/tests/DependencyInjection/SentryExtensionTest.php
+++ b/tests/DependencyInjection/SentryExtensionTest.php
@@ -53,6 +53,14 @@ abstract class SentryExtensionTest extends TestCase
 {
     abstract protected function loadFixture(ContainerBuilder $container, string $fixtureFile): void;
 
+    public function testDataCollectionBodiesCanBeDisabled(): void
+    {
+        $container = $this->createContainerFromFixture('data_collection_bodies_disabled');
+        /** @var array{data_collection: array{http_bodies: string[]}} $options */
+        $options = $container->getDefinition('sentry.client.options')->getArgument(0);
+        $this->assertSame([], $options['data_collection']['http_bodies']);
+    }
+
     public function testErrorListener(): void
     {
         $container = $this->createContainerFromFixture('full');
@@ -320,6 +328,39 @@ abstract class SentryExtensionTest extends TestCase
             'in_app_exclude' => [$container->getParameter('kernel.cache_dir')],
             'in_app_include' => [$container->getParameter('kernel.project_dir')],
             'send_default_pii' => true,
+            'data_collection' => [
+                'user_info' => false,
+                'cookies' => [
+                    'mode' => 'allowList',
+                    'terms' => ['theme'],
+                ],
+                'http_headers' => [
+                    'request' => [
+                        'mode' => 'denyList',
+                        'terms' => ['x-request'],
+                    ],
+                    'response' => [
+                        'mode' => 'off',
+                        'terms' => [],
+                    ],
+                ],
+                'http_bodies' => ['incomingRequest', 'incomingResponse'],
+                'url_query_params' => [
+                    'mode' => 'allowList',
+                    'terms' => ['page'],
+                ],
+                'gen_ai' => [
+                    'inputs' => false,
+                    'outputs' => true,
+                ],
+                'database_query_data' => false,
+                'queues' => false,
+                'stack_frame_variables' => [
+                    'mode' => 'denyList',
+                    'terms' => ['local_secret'],
+                ],
+                'frame_context_lines' => 3,
+            ],
             'max_value_length' => 255,
             'transport' => new Reference('App\\Sentry\\Transport'),
             'http_client' => new Reference('App\\Sentry\\HttpClient'),

--- a/tests/End2End/App/Controller/MainController.php
+++ b/tests/End2End/App/Controller/MainController.php
@@ -4,15 +4,20 @@ declare(strict_types=1);
 
 namespace Sentry\SentryBundle\Tests\End2End\App\Controller;
 
+use Sentry\SentryBundle\Tracing\HttpClient\TraceableHttpClient;
 use Sentry\SentrySdk;
 use Sentry\State\HubInterface;
 use Sentry\State\Scope;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
 
 class MainController
 {
@@ -78,6 +83,112 @@ class MainController
         $subRequest = $request->duplicate([], null, $path);
 
         return $this->kernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
+    }
+
+    public function httpClientCollection(Request $request): Response
+    {
+        $httpClient = new TraceableHttpClient(new MockHttpClient(new MockResponse('{"name":"Bob","token":"secret"}', [
+            'http_code' => $request->query->getBoolean('error') ? 500 : 200,
+            'response_headers' => ['Content-Type: application/json', 'X-Test: response', 'Set-Cookie: theme=light; Path=/', 'Set-Cookie: session_id=secret; HttpOnly'],
+        ])), $this->sentry);
+        $options = [
+            'headers' => ['X-Test' => 'request', 'Cookie' => 'theme=dark; session_id=secret'],
+        ];
+        if ($request->query->getBoolean('defaults')) {
+            $httpClient = $httpClient->withOptions($options);
+            $options = [];
+        }
+        $options['query'] = ['search' => 'new', 'token' => 'secret'];
+        if ($request->query->getBoolean('body')) {
+            $options['json'] = ['name' => 'Alice'];
+        }
+        $response = $httpClient->request('POST', 'https://example.com?search=old', $options);
+        if ($request->query->getBoolean('error')) {
+            try {
+                $response->getContent();
+            } catch (HttpExceptionInterface $exception) {
+                return new Response($response->getContent(false));
+            }
+        }
+        if ($request->query->getBoolean('array')) {
+            return new JsonResponse($response->toArray());
+        }
+        if ($request->query->getBoolean('stream')) {
+            $content = '';
+            foreach ($httpClient->stream($response) as $chunk) {
+                if (!$chunk->isTimeout()) {
+                    $content .= $chunk->getContent();
+                }
+            }
+        } else {
+            $content = $response->getContent();
+        }
+
+        return new Response($content);
+    }
+
+    public function preparedResponse(Request $request): Response
+    {
+        $request->setRequestFormat('json');
+        if ($request->query->getBoolean('session')) {
+            $request->getSession()->set('theme', 'dark');
+        }
+
+        return new Response('{"name":"Alice","password":"secret"}');
+    }
+
+    public function bodyCollection(Request $request): Response
+    {
+        $span = $this->sentry->getSpan();
+        if ($request->query->getBoolean('explicit') && null !== $span) {
+            $span->setData([
+                'http.request.body.data' => [],
+                'http.response.body.data' => [],
+            ]);
+        }
+
+        if (!$request->attributes->get('body_subrequest', false)) {
+            $subrequest = $request->duplicate(null, null, [
+                '_controller' => __METHOD__,
+                'body_subrequest' => true,
+            ]);
+
+            return $this->kernel->handle($subrequest, HttpKernelInterface::SUB_REQUEST);
+        }
+
+        return new Response($request->getContent(), 200, [
+            'Content-Type' => $request->headers->get('Content-Type', 'application/octet-stream'),
+        ]);
+    }
+
+    public function headerCollection(Request $request): Response
+    {
+        $isSubrequest = $request->attributes->get('header_subrequest', false);
+        if (!$isSubrequest) {
+            $subrequest = $request->duplicate(null, null, ['_controller' => __METHOD__, 'header_subrequest' => true]);
+            $subrequest->headers->set('X-Test', 'subrequest');
+            $subrequest->cookies->set('theme', 'subrequest');
+            $this->kernel->handle($subrequest, HttpKernelInterface::SUB_REQUEST);
+            $this->sentry->captureMessage('Header collection');
+        }
+
+        $span = $this->sentry->getSpan();
+        \assert(null !== $span);
+        $span->setData(['http.response.header.x-explicit' => null]);
+        $span->setData(['http.response.header.set_cookie.explicit' => null]);
+        $response = new Response('Headers unchanged', 200, [
+            'X-Test' => [$isSubrequest ? 'subrequest' : 'main', 'second'],
+            'X-Debug' => 'visible',
+            'X-Debug-Extra' => 'visible',
+            'X-Test-Extra' => 'visible',
+            'Authorization' => 'response-secret',
+            'X-Explicit' => 'automatic',
+        ]);
+        $response->headers->setCookie(new Cookie('session_id', 'response-cookie'));
+        $response->headers->setCookie(new Cookie('theme', $isSubrequest ? 'subrequest' : 'light'));
+        $response->headers->setCookie(new Cookie('explicit', 'automatic'));
+
+        return $response;
     }
 
     public function runtimeContext(Request $request): JsonResponse

--- a/tests/End2End/App/KernelWithHttpHeaders.php
+++ b/tests/End2End/App/KernelWithHttpHeaders.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\End2End\App;
+
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorageFactory;
+
+/**
+ * @internal
+ */
+final class KernelWithHttpHeaders extends KernelWithTracing
+{
+    /**
+     * @var array<string, mixed>
+     */
+    private $options;
+
+    /**
+     * @var bool
+     */
+    private $session;
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function __construct(array $options, bool $session = false)
+    {
+        parent::__construct('test', false);
+        $this->options = $options;
+        $this->session = $session;
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader): void
+    {
+        parent::registerContainerConfiguration($loader);
+        $loader->load(function (ContainerBuilder $container): void {
+            $container->loadFromExtension('sentry', ['options' => $this->options]);
+            if ($this->session) {
+                $storage = class_exists(MockFileSessionStorageFactory::class)
+                    ? ['storage_factory_id' => 'session.storage.factory.mock_file']
+                    : ['storage_id' => 'session.storage.mock_file'];
+                $container->loadFromExtension('framework', ['session' => $storage]);
+            }
+        }, 'closure');
+    }
+}

--- a/tests/End2End/App/routing.yml
+++ b/tests/End2End/App/routing.yml
@@ -26,6 +26,18 @@ notice:
   path:  /notice
   defaults: { _controller: 'Sentry\SentryBundle\Tests\End2End\App\Controller\MainController::notice' }
 
+header_collection:
+  path: /header-collection
+  defaults: { _controller: 'Sentry\SentryBundle\Tests\End2End\App\Controller\MainController::headerCollection' }
+
+prepared_response:
+  path: /prepared-response
+  defaults: { _controller: 'Sentry\SentryBundle\Tests\End2End\App\Controller\MainController::preparedResponse' }
+
+http_client_collection:
+  path: /http-client-collection
+  defaults: { _controller: 'Sentry\SentryBundle\Tests\End2End\App\Controller\MainController::httpClientCollection' }
+
 runtime_context:
   path: /runtime-context
   defaults: { _controller: 'Sentry\SentryBundle\Tests\End2End\App\Controller\MainController::runtimeContext' }
@@ -85,6 +97,10 @@ namespaced_tracing_cache_populate:
 just_logging:
   path: /just-logging
   defaults: { _controller: 'Sentry\SentryBundle\Tests\End2End\App\Controller\LoggingController::justLogging' }
+
+body_collection:
+  path: /body-collection
+  defaults: { _controller: 'Sentry\SentryBundle\Tests\End2End\App\Controller\MainController::bodyCollection' }
 
 logging_With_Error:
   path: /logging-with-error

--- a/tests/End2End/App/url_data_collection.yml
+++ b/tests/End2End/App/url_data_collection.yml
@@ -1,0 +1,3 @@
+sentry:
+  options:
+    data_collection: {}

--- a/tests/End2End/HttpBodyCollectionEnd2EndTest.php
+++ b/tests/End2End/HttpBodyCollectionEnd2EndTest.php
@@ -13,7 +13,7 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 /**
  * @runTestsInSeparateProcesses
  *
- * @phpstan-type BodyData array{http.request.body.data?: mixed, http.response.body.data?: mixed}
+ * @phpstan-type BodyData array{'http.request.body.data'?: mixed, 'http.response.body.data'?: mixed}
  * @phpstan-type BodyExchange array{main: BodyData, subrequest: BodyData, eventRequestBody: mixed, requestContent: string, responseContent: string}
  */
 final class HttpBodyCollectionEnd2EndTest extends TestCase
@@ -237,9 +237,11 @@ final class HttpBodyCollectionEnd2EndTest extends TestCase
             }));
             $this->assertCount(1, $subspans);
             $eventRequest = $transactions[0]->getRequest();
+            $transactionData = $transactions[0]->getContexts()['trace']['data'];
+            $this->assertIsArray($transactionData);
 
             return [
-                'main' => $this->bodyData($transactions[0]->getContexts()['trace']['data']),
+                'main' => $this->bodyData($transactionData),
                 'subrequest' => $this->bodyData($subspans[0]->getData()),
                 'eventRequestBody' => $eventRequest['data'] ?? null,
                 'requestContent' => $client->getRequest()->getContent(),

--- a/tests/End2End/HttpBodyCollectionEnd2EndTest.php
+++ b/tests/End2End/HttpBodyCollectionEnd2EndTest.php
@@ -1,0 +1,265 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\End2End;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\Event;
+use Sentry\SentryBundle\Tests\End2End\App\KernelWithHttpHeaders;
+use Sentry\Tracing\Span;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+/**
+ * @runTestsInSeparateProcesses
+ *
+ * @phpstan-type BodyData array{http.request.body.data?: mixed, http.response.body.data?: mixed}
+ * @phpstan-type BodyExchange array{main: BodyData, subrequest: BodyData, eventRequestBody: mixed, requestContent: string, responseContent: string}
+ */
+final class HttpBodyCollectionEnd2EndTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        StubTransport::$events = [];
+    }
+
+    /**
+     * @dataProvider bodyFormatProvider
+     *
+     * @param mixed $expected
+     */
+    public function testConfiguredBodyFormats(string $content, string $contentType, $expected): void
+    {
+        $exchange = $this->request(['data_collection' => []], $content, $contentType);
+        $expectedData = [
+            'http.request.body.data' => $expected,
+            'http.response.body.data' => $expected,
+        ];
+
+        $this->assertSame($expectedData, $exchange['main']);
+        $this->assertSame($expectedData, $exchange['subrequest']);
+    }
+
+    public function bodyFormatProvider(): \Generator
+    {
+        $json = '{"profile":{"password":"secret","name":"Alice"}}';
+        $filtered = ['profile' => ['password' => '[Filtered]', 'name' => 'Alice']];
+
+        yield 'JSON' => [$json, 'application/json', $filtered];
+        yield 'JSON suffix' => [$json, 'application/problem+json; charset=UTF-8', $filtered];
+        yield 'form' => ['name=Alice&token=secret', 'application/x-www-form-urlencoded', ['name' => 'Alice', 'token' => '[Filtered]']];
+        yield 'invalid JSON' => ['{invalid', 'application/json', '[Filtered]'];
+        yield 'raw' => ['secret', 'text/plain', '[Filtered]'];
+        yield 'empty object' => ['{}', 'application/json', []];
+    }
+
+    public function testEmptyBodiesAreNotAdded(): void
+    {
+        $exchange = $this->request(['data_collection' => []], '', 'application/json');
+
+        $this->assertSame([], $exchange['main']);
+        $this->assertSame([], $exchange['subrequest']);
+    }
+
+    /**
+     * @dataProvider legacyPiiProvider
+     */
+    public function testConfiguredCollectionIgnoresLegacyPii(bool $sendDefaultPii): void
+    {
+        $content = '{"password":"secret"}';
+        $exchange = $this->request(['data_collection' => [], 'send_default_pii' => $sendDefaultPii], $content, 'application/json');
+        $expected = [
+            'http.request.body.data' => ['password' => '[Filtered]'],
+            'http.response.body.data' => ['password' => '[Filtered]'],
+        ];
+
+        $this->assertSame($expected, $exchange['main']);
+        $this->assertSame($expected, $exchange['subrequest']);
+    }
+
+    /**
+     * @dataProvider bodyDirectionProvider
+     *
+     * @param array<string, mixed> $dataCollection
+     * @param array<string, mixed> $expected
+     */
+    public function testBodyDirectionsCanBeConfiguredIndependently(array $dataCollection, array $expected): void
+    {
+        $content = '{"password":"secret"}';
+        $exchange = $this->request(['data_collection' => $dataCollection], $content, 'application/json');
+
+        $this->assertSame($expected, $exchange['main']);
+        $this->assertSame($expected, $exchange['subrequest']);
+    }
+
+    public function bodyDirectionProvider(): \Generator
+    {
+        $filtered = ['password' => '[Filtered]'];
+
+        yield 'request only' => [['http_bodies' => ['incomingRequest']], ['http.request.body.data' => $filtered]];
+        yield 'response only' => [['http_bodies' => ['outgoingResponse']], ['http.response.body.data' => $filtered]];
+        yield 'disabled' => [['http_bodies' => []], []];
+    }
+
+    public function testDisabledBodyCollectionOverridesLegacyPii(): void
+    {
+        $options = ['data_collection' => ['http_bodies' => []], 'send_default_pii' => true];
+        $exchange = $this->request($options, '{"password":"secret"}', 'application/json');
+
+        $this->assertSame([], $exchange['main']);
+        $this->assertSame([], $exchange['subrequest']);
+    }
+
+    /**
+     * @dataProvider legacyPiiProvider
+     */
+    public function testLegacyModeDoesNotAddBodiesToSpans(bool $sendDefaultPii): void
+    {
+        $content = '{"password":"secret"}';
+        $exchange = $this->request(['send_default_pii' => $sendDefaultPii], $content, 'application/json');
+
+        $this->assertSame([], $exchange['main']);
+        $this->assertSame([], $exchange['subrequest']);
+        $this->assertSame(['password' => 'secret'], $exchange['eventRequestBody']);
+    }
+
+    public function legacyPiiProvider(): \Generator
+    {
+        yield 'PII disabled' => [false];
+        yield 'PII enabled' => [true];
+    }
+
+    /**
+     * @dataProvider requestLimitProvider
+     *
+     * @param array<string, mixed> $options
+     * @param array<string, mixed> $expected
+     */
+    public function testRequestBodyLimitsDoNotDisableResponseBodies(array $options, string $content, array $expected): void
+    {
+        $exchange = $this->request($options + ['data_collection' => []], $content, 'text/plain');
+
+        $this->assertSame($expected, $exchange['main']);
+        $this->assertSame($expected, $exchange['subrequest']);
+    }
+
+    public function requestLimitProvider(): \Generator
+    {
+        yield 'request collection disabled' => [
+            ['max_request_body_size' => 'never'],
+            'secret',
+            ['http.response.body.data' => '[Filtered]'],
+        ];
+        yield 'request too large' => [
+            ['max_request_body_size' => 'small'],
+            str_repeat('x', 1001),
+            ['http.response.body.data' => '[Filtered]'],
+        ];
+    }
+
+    public function testOversizedResponseBodyIsNotAdded(): void
+    {
+        $exchange = $this->request(['data_collection' => []], str_repeat('x', 100001), 'text/plain');
+
+        $this->assertSame([], $exchange['main']);
+        $this->assertSame([], $exchange['subrequest']);
+    }
+
+    /**
+     * @dataProvider explicitBodyConfigurationProvider
+     *
+     * @param array<string, mixed> $dataCollection
+     */
+    public function testExplicitBodyDataIsPreserved(array $dataCollection): void
+    {
+        $exchange = $this->request(['data_collection' => $dataCollection], '{"password":"secret"}', 'application/json', '/body-collection?explicit=1');
+        $expected = ['http.request.body.data' => [], 'http.response.body.data' => []];
+
+        $this->assertSame($expected, $exchange['main']);
+        $this->assertSame($expected, $exchange['subrequest']);
+    }
+
+    public function explicitBodyConfigurationProvider(): \Generator
+    {
+        yield 'collection enabled' => [[]];
+        yield 'collection disabled' => [['http_bodies' => []]];
+    }
+
+    public function testCollectionDoesNotConsumeRequestOrResponseContent(): void
+    {
+        $content = '{"name":"Alice"}';
+        $exchange = $this->request(['data_collection' => []], $content, 'application/json');
+
+        $this->assertSame($content, $exchange['requestContent']);
+        $this->assertSame($content, $exchange['responseContent']);
+    }
+
+    public function testEventBodyWithoutTracing(): void
+    {
+        $kernel = new KernelWithHttpHeaders(['data_collection' => [], 'max_request_body_size' => 'always', 'traces_sample_rate' => 0.0]);
+        $client = new KernelBrowser($kernel);
+        try {
+            $body = '{"name":"Alice","password":"secret"}';
+            $client->request('POST', '/200', [], [], ['CONTENT_TYPE' => 'application/json'], $body);
+            $events = array_values(array_filter(StubTransport::$events, static function (Event $event): bool {
+                return null === $event->getTransaction();
+            }));
+
+            $this->assertCount(1, $events);
+            $this->assertSame(['name' => 'Alice', 'password' => '[Filtered]'], $events[0]->getRequest()['data']);
+            $this->assertSame($body, $client->getRequest()->getContent());
+        } finally {
+            $kernel->shutdown();
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @phpstan-return BodyExchange
+     */
+    private function request(array $options, string $content, string $contentType, string $path = '/body-collection'): array
+    {
+        $kernel = new KernelWithHttpHeaders($options + ['max_request_body_size' => 'always']);
+        $client = new KernelBrowser($kernel);
+
+        try {
+            $client->request('POST', $path, [], [], [
+                'CONTENT_TYPE' => $contentType,
+                'CONTENT_LENGTH' => (string) \strlen($content),
+            ], $content);
+            $transactions = array_values(array_filter(StubTransport::$events, static function (Event $event): bool {
+                return null !== $event->getTransaction();
+            }));
+            $this->assertCount(1, $transactions);
+            $subspans = array_values(array_filter($transactions[0]->getSpans(), static function (Span $span): bool {
+                return 'http.server' === $span->getOp();
+            }));
+            $this->assertCount(1, $subspans);
+            $eventRequest = $transactions[0]->getRequest();
+
+            return [
+                'main' => $this->bodyData($transactions[0]->getContexts()['trace']['data']),
+                'subrequest' => $this->bodyData($subspans[0]->getData()),
+                'eventRequestBody' => $eventRequest['data'] ?? null,
+                'requestContent' => $client->getRequest()->getContent(),
+                'responseContent' => (string) $client->getResponse()->getContent(),
+            ];
+        } finally {
+            $kernel->shutdown();
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @phpstan-return BodyData
+     */
+    private function bodyData(array $data): array
+    {
+        return array_intersect_key($data, [
+            'http.request.body.data' => true,
+            'http.response.body.data' => true,
+        ]);
+    }
+}

--- a/tests/End2End/HttpClientCollectionEnd2EndTest.php
+++ b/tests/End2End/HttpClientCollectionEnd2EndTest.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\End2End;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\Event;
+use Sentry\SentryBundle\Tests\End2End\App\KernelWithHttpHeaders;
+use Sentry\Tracing\Span;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpClient\MockHttpClient;
+
+/**
+ * @runTestsInSeparateProcesses
+ */
+final class HttpClientCollectionEnd2EndTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!class_exists(MockHttpClient::class)) {
+            $this->markTestSkipped('This test requires symfony/http-client.');
+        }
+        StubTransport::$events = [];
+    }
+
+    /**
+     * @dataProvider legacyPiiProvider
+     */
+    public function testConfiguredDefaultsCollectHeadersAndCookies(bool $pii): void
+    {
+        $data = $this->request(['data_collection' => [], 'send_default_pii' => $pii]);
+
+        $this->assertCollectedHeaders($data);
+        $this->assertCollectedCookies($data);
+        $this->assertResponseBody($data);
+        $this->assertNoRawCookieHeaders($data);
+    }
+
+    /**
+     * @dataProvider legacyPiiProvider
+     */
+    public function testLegacyConfigurationDoesNotAddHeadersOrCookies(bool $pii): void
+    {
+        $data = $this->request(['send_default_pii' => $pii]);
+
+        $this->assertArrayNotHasKey('http.request.header.x-test', $data);
+        $this->assertArrayNotHasKey('http.response.header.x-test', $data);
+        $this->assertArrayNotHasKey('http.request.header.cookie.theme', $data);
+        $this->assertArrayNotHasKey('http.response.header.set_cookie.theme', $data);
+        $this->assertNoBodies($data);
+        $this->assertNoRawCookieHeaders($data);
+    }
+
+    /**
+     * @dataProvider legacyPiiProvider
+     */
+    public function testDisablingHeadersStillCollectsCookies(bool $pii): void
+    {
+        $data = $this->request(['data_collection' => ['http_headers' => ['mode' => 'off']], 'send_default_pii' => $pii]);
+
+        $this->assertArrayNotHasKey('http.request.header.x-test', $data);
+        $this->assertArrayNotHasKey('http.response.header.x-test', $data);
+        $this->assertCollectedCookies($data);
+        $this->assertResponseBody($data);
+        $this->assertNoRawCookieHeaders($data);
+    }
+
+    /**
+     * @dataProvider legacyPiiProvider
+     */
+    public function testDisablingCookiesStillCollectsHeaders(bool $pii): void
+    {
+        $data = $this->request(['data_collection' => ['cookies' => ['mode' => 'off']], 'send_default_pii' => $pii]);
+
+        $this->assertCollectedHeaders($data);
+        $this->assertArrayNotHasKey('http.request.header.cookie.theme', $data);
+        $this->assertArrayNotHasKey('http.response.header.set_cookie.theme', $data);
+        $this->assertResponseBody($data);
+        $this->assertNoRawCookieHeaders($data);
+    }
+
+    /**
+     * @dataProvider legacyPiiProvider
+     */
+    public function testDisablingBodiesStillCollectsHeadersAndCookies(bool $pii): void
+    {
+        $data = $this->request(['data_collection' => ['http_bodies' => []], 'send_default_pii' => $pii]);
+
+        $this->assertCollectedHeaders($data);
+        $this->assertCollectedCookies($data);
+        $this->assertNoBodies($data);
+        $this->assertNoRawCookieHeaders($data);
+    }
+
+    public function testStreamingCollectsHeadersAndCookies(): void
+    {
+        $data = $this->request(['data_collection' => []], 'stream=1');
+
+        $this->assertCollectedHeaders($data);
+        $this->assertCollectedCookies($data);
+        $this->assertNoBodies($data);
+        $this->assertNoRawCookieHeaders($data);
+    }
+
+    public function testDecodingJsonCollectsHeadersAndCookies(): void
+    {
+        $data = $this->request(['data_collection' => []], 'array=1');
+
+        $this->assertCollectedHeaders($data);
+        $this->assertCollectedCookies($data);
+        $this->assertResponseBody($data);
+        $this->assertNoRawCookieHeaders($data);
+    }
+
+    public function testClientDefaultsAreCollected(): void
+    {
+        if (!method_exists(MockHttpClient::class, 'withOptions')) {
+            $this->markTestSkipped('withOptions is not available.');
+        }
+        $data = $this->request(['data_collection' => []], 'defaults=1');
+
+        $this->assertCollectedHeaders($data);
+        $this->assertCollectedCookies($data);
+        $this->assertResponseBody($data);
+        $this->assertNoRawCookieHeaders($data);
+    }
+
+    public function testGeneratedBodyHeadersAreNotCollected(): void
+    {
+        $data = $this->request(['data_collection' => []], 'body=1');
+
+        $this->assertArrayNotHasKey('http.request.header.content-type', $data);
+        $this->assertArrayNotHasKey('http.request.header.content-length', $data);
+        $this->assertCollectedHeaders($data);
+        $this->assertCollectedCookies($data);
+        $this->assertSame(['name' => 'Alice'], $data['http.request.body.data']);
+        $this->assertResponseBody($data);
+        $this->assertNoRawCookieHeaders($data);
+    }
+
+    public function testHttpErrorResponsesCollectHeadersAndCookies(): void
+    {
+        $data = $this->request(['data_collection' => []], 'error=1');
+
+        $this->assertCollectedHeaders($data);
+        $this->assertCollectedCookies($data);
+        $this->assertResponseBody($data);
+        $this->assertNoRawCookieHeaders($data);
+    }
+
+    public function legacyPiiProvider(): \Generator
+    {
+        yield 'legacy PII disabled' => [false];
+        yield 'legacy PII enabled' => [true];
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @return array<string, mixed>
+     */
+    private function request(array $options, string $query = ''): array
+    {
+        $kernel = new KernelWithHttpHeaders($options);
+        $client = new KernelBrowser($kernel);
+        try {
+            $client->request('GET', '/http-client-collection?' . $query);
+            $this->assertSame('{"name":"Bob","token":"secret"}', $client->getResponse()->getContent());
+            $transactions = array_values(array_filter(StubTransport::$events, static function (Event $event): bool {
+                return null !== $event->getTransaction();
+            }));
+            $this->assertCount(1, $transactions);
+            $spans = array_values(array_filter($transactions[0]->getSpans(), static function (Span $span): bool {
+                return 'http.client' === $span->getOp();
+            }));
+            $this->assertCount(1, $spans);
+            $data = $spans[0]->getData();
+            $this->assertSame('search=old', $data['http.query']);
+
+            return $data;
+        } finally {
+            $kernel->shutdown();
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function assertCollectedHeaders(array $data): void
+    {
+        $this->assertSame(['request'], $data['http.request.header.x-test']);
+        $this->assertSame(['response'], $data['http.response.header.x-test']);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function assertCollectedCookies(array $data): void
+    {
+        $this->assertSame('dark', $data['http.request.header.cookie.theme']);
+        $this->assertSame('light', $data['http.response.header.set_cookie.theme']);
+        $this->assertSame('[Filtered]', $data['http.request.header.cookie.session_id']);
+        $this->assertSame('[Filtered]', $data['http.response.header.set_cookie.session_id']);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function assertResponseBody(array $data): void
+    {
+        $this->assertSame(['name' => 'Bob', 'token' => '[Filtered]'], $data['http.response.body.data']);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function assertNoBodies(array $data): void
+    {
+        $this->assertArrayNotHasKey('http.request.body.data', $data);
+        $this->assertArrayNotHasKey('http.response.body.data', $data);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function assertNoRawCookieHeaders(array $data): void
+    {
+        foreach (['http.request.header.cookie', 'http.request.header.set-cookie', 'http.response.header.cookie', 'http.response.header.set-cookie'] as $key) {
+            $this->assertArrayNotHasKey($key, $data);
+        }
+    }
+}

--- a/tests/End2End/HttpHeaderCollectionEnd2EndTest.php
+++ b/tests/End2End/HttpHeaderCollectionEnd2EndTest.php
@@ -1,0 +1,401 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\End2End;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\Event;
+use Sentry\SentryBundle\Tests\End2End\App\KernelWithHttpHeaders;
+use Sentry\Tracing\Span;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\BrowserKit\Cookie;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @runTestsInSeparateProcesses
+ *
+ * @phpstan-type Exchange array{spans: array<string, array<string, mixed>>, event: Event, request: Request, response: Response, eventRequest: array{headers?: array<string, string[]>, cookies?: array<string, mixed>}}
+ */
+final class HttpHeaderCollectionEnd2EndTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        StubTransport::$events = [];
+    }
+
+    /**
+     * @dataProvider legacyPiiProvider
+     */
+    public function testDefaultHeadersAreCollectedForMainAndSubrequests(bool $pii): void
+    {
+        $result = $this->request(['data_collection' => [], 'send_default_pii' => $pii]);
+
+        $this->assertCollectedHeaders($result['spans']);
+        $this->assertArrayHasKey('headers', $result['eventRequest']);
+        $this->assertSame(['[Filtered]'], $result['eventRequest']['headers']['authorization']);
+    }
+
+    /**
+     * @dataProvider legacyPiiProvider
+     */
+    public function testDefaultCookiesAreCollectedForMainAndSubrequests(bool $pii): void
+    {
+        $result = $this->request(['data_collection' => [], 'send_default_pii' => $pii]);
+
+        $this->assertCollectedCookies($result['spans']);
+        $this->assertArrayHasKey('cookies', $result['eventRequest']);
+        $this->assertSame('dark', $result['eventRequest']['cookies']['theme']);
+        $this->assertSame('[Filtered]', $result['eventRequest']['cookies']['session_id']);
+    }
+
+    /**
+     * @dataProvider legacyHeadersProvider
+     */
+    public function testLegacyConfigurationPreservesEventHeadersWithoutAddingSpanHeaders(bool $pii, string $authorization): void
+    {
+        $result = $this->request(['send_default_pii' => $pii]);
+
+        foreach ($result['spans'] as $data) {
+            $this->assertArrayNotHasKey('http.request.header.x-test', $data);
+            $this->assertArrayNotHasKey('http.response.header.x-test', $data);
+            $this->assertArrayNotHasKey('http.request.header.cookie.theme', $data);
+            $this->assertArrayNotHasKey('http.response.header.set_cookie.theme', $data);
+        }
+        $this->assertArrayHasKey('headers', $result['eventRequest']);
+        $this->assertSame([$authorization], $result['eventRequest']['headers']['authorization']);
+    }
+
+    /**
+     * @dataProvider legacyPiiProvider
+     */
+    public function testRequestHeadersCanBeDisabledIndependently(bool $pii): void
+    {
+        $result = $this->request(['data_collection' => ['http_headers' => ['request' => ['mode' => 'off']]], 'send_default_pii' => $pii]);
+
+        foreach ($result['spans'] as $name => $data) {
+            $this->assertArrayNotHasKey('http.request.header.x-test', $data);
+            $this->assertArrayNotHasKey('http.request.header.authorization', $data);
+            $this->assertSame([$name, 'second'], $data['http.response.header.x-test']);
+            $this->assertSame(['[Filtered]'], $data['http.response.header.authorization']);
+        }
+        $this->assertArrayNotHasKey('headers', $result['eventRequest']);
+        $this->assertCollectedCookies($result['spans']);
+    }
+
+    /**
+     * @dataProvider legacyPiiProvider
+     */
+    public function testResponseHeadersCanBeDisabledIndependently(bool $pii): void
+    {
+        $result = $this->request(['data_collection' => ['http_headers' => ['response' => ['mode' => 'off']]], 'send_default_pii' => $pii]);
+
+        foreach ($result['spans'] as $name => $data) {
+            $this->assertSame([$name], $data['http.request.header.x-test']);
+            $this->assertSame(['[Filtered]'], $data['http.request.header.authorization']);
+            $this->assertArrayNotHasKey('http.response.header.x-test', $data);
+            $this->assertArrayNotHasKey('http.response.header.authorization', $data);
+        }
+        $this->assertArrayHasKey('headers', $result['eventRequest']);
+        $this->assertSame(['[Filtered]'], $result['eventRequest']['headers']['authorization']);
+        $this->assertCollectedCookies($result['spans']);
+    }
+
+    /**
+     * @dataProvider legacyPiiProvider
+     */
+    public function testDisablingBothHeaderDirectionsStillCollectsCookies(bool $pii): void
+    {
+        $result = $this->request(['data_collection' => ['http_headers' => ['mode' => 'off']], 'send_default_pii' => $pii]);
+
+        foreach ($result['spans'] as $data) {
+            $this->assertArrayNotHasKey('http.request.header.x-test', $data);
+            $this->assertArrayNotHasKey('http.response.header.x-test', $data);
+        }
+        $this->assertArrayNotHasKey('headers', $result['eventRequest']);
+        $this->assertCollectedCookies($result['spans']);
+        $this->assertArrayHasKey('cookies', $result['eventRequest']);
+        $this->assertSame('dark', $result['eventRequest']['cookies']['theme']);
+    }
+
+    /**
+     * @dataProvider legacyPiiProvider
+     */
+    public function testDisablingCookiesStillCollectsHeaders(bool $pii): void
+    {
+        $result = $this->request(['data_collection' => ['cookies' => ['mode' => 'off']], 'send_default_pii' => $pii]);
+
+        foreach ($result['spans'] as $data) {
+            $this->assertArrayNotHasKey('http.request.header.cookie.theme', $data);
+            $this->assertArrayNotHasKey('http.request.header.cookie.session_id', $data);
+            $this->assertArrayNotHasKey('http.response.header.set_cookie.theme', $data);
+            $this->assertArrayNotHasKey('http.response.header.set_cookie.session_id', $data);
+        }
+        $this->assertArrayNotHasKey('cookies', $result['eventRequest']);
+        $this->assertCollectedHeaders($result['spans']);
+    }
+
+    /**
+     * @dataProvider legacyPiiProvider
+     */
+    public function testHeadersAndCookiesCanBothBeDisabled(bool $pii): void
+    {
+        $result = $this->request(['data_collection' => ['http_headers' => ['mode' => 'off'], 'cookies' => ['mode' => 'off']], 'send_default_pii' => $pii]);
+
+        foreach ($result['spans'] as $data) {
+            foreach (['http.request.header.x-test', 'http.response.header.x-test', 'http.request.header.authorization', 'http.response.header.authorization', 'http.request.header.cookie.theme', 'http.response.header.set_cookie.theme', 'http.request.header.cookie.session_id', 'http.response.header.set_cookie.session_id'] as $key) {
+                $this->assertArrayNotHasKey($key, $data);
+            }
+        }
+        $this->assertArrayNotHasKey('headers', $result['eventRequest']);
+        $this->assertArrayNotHasKey('cookies', $result['eventRequest']);
+    }
+
+    /**
+     * @dataProvider legacyPiiProvider
+     */
+    public function testHeaderAllowListKeepsExactMatchesAndFiltersSensitiveValues(bool $pii): void
+    {
+        $result = $this->request(['data_collection' => ['http_headers' => ['mode' => 'allowList', 'terms' => ['x-test', 'authorization']]], 'send_default_pii' => $pii]);
+
+        $this->assertCollectedHeaders($result['spans'], '[Filtered]', '[Filtered]');
+        $this->assertArrayHasKey('headers', $result['eventRequest']);
+        $this->assertSame(['[Filtered]'], $result['eventRequest']['headers']['authorization']);
+        $this->assertSame(['[Filtered]'], $result['eventRequest']['headers']['x-debug']);
+    }
+
+    /**
+     * @dataProvider legacyPiiProvider
+     */
+    public function testHeaderDenyListFiltersPartialCustomMatches(bool $pii): void
+    {
+        $result = $this->request(['data_collection' => ['http_headers' => ['mode' => 'denyList', 'terms' => ['x-debug']]], 'send_default_pii' => $pii]);
+
+        $this->assertCollectedHeaders($result['spans'], '[Filtered]', '[Filtered]', 'visible');
+        $this->assertArrayHasKey('headers', $result['eventRequest']);
+        $this->assertSame(['[Filtered]'], $result['eventRequest']['headers']['x-debug']);
+        $this->assertSame(['[Filtered]'], $result['eventRequest']['headers']['x-debug-extra']);
+    }
+
+    /**
+     * @dataProvider legacyPiiProvider
+     */
+    public function testCookieAllowListFiltersUnlistedAndSensitiveCookies(bool $pii): void
+    {
+        $result = $this->request(['data_collection' => ['cookies' => ['mode' => 'allowList', 'terms' => ['session']]], 'send_default_pii' => $pii]);
+
+        foreach ($result['spans'] as $data) {
+            $this->assertSame('[Filtered]', $data['http.request.header.cookie.theme']);
+            $this->assertSame('[Filtered]', $data['http.request.header.cookie.session_id']);
+            $this->assertSame('[Filtered]', $data['http.response.header.set_cookie.theme']);
+            $this->assertSame('[Filtered]', $data['http.response.header.set_cookie.session_id']);
+        }
+        $this->assertArrayHasKey('cookies', $result['eventRequest']);
+        $this->assertSame('[Filtered]', $result['eventRequest']['cookies']['theme']);
+        $this->assertSame('[Filtered]', $result['eventRequest']['cookies']['session_id']);
+    }
+
+    /**
+     * @dataProvider userCollectionEnabledProvider
+     *
+     * @param array<string, mixed> $options
+     */
+    public function testUserIpIsCollectedOnEventsAndTransactions(array $options): void
+    {
+        $result = $this->request($options);
+        $user = $result['event']->getUser();
+
+        $this->assertNotNull($user);
+        $this->assertSame($result['request']->getClientIp(), $user->getIpAddress());
+        $this->assertSame($result['request']->getClientIp(), $result['spans']['main']['net.peer.ip']);
+    }
+
+    /**
+     * @dataProvider userCollectionDisabledProvider
+     *
+     * @param array<string, mixed> $options
+     */
+    public function testDisabledUserInfoDoesNotAddIpToEventsOrTransactions(array $options): void
+    {
+        $result = $this->request($options);
+
+        $this->assertNull($result['event']->getUser());
+        $this->assertArrayNotHasKey('net.peer.ip', $result['spans']['main']);
+    }
+
+    /**
+     * @dataProvider explicitDataProvider
+     *
+     * @param array<string, mixed> $options
+     */
+    public function testExplicitSpanValuesArePreserved(array $options): void
+    {
+        $result = $this->request($options);
+
+        foreach ($result['spans'] as $data) {
+            $this->assertArrayHasKey('http.response.header.x-explicit', $data);
+            $this->assertNull($data['http.response.header.x-explicit']);
+            $this->assertArrayHasKey('http.response.header.set_cookie.explicit', $data);
+            $this->assertNull($data['http.response.header.set_cookie.explicit']);
+        }
+    }
+
+    /**
+     * @dataProvider rawCookieHeadersProvider
+     *
+     * @param array<string, mixed> $collection
+     */
+    public function testRawCookieHeadersAreExcluded(array $collection): void
+    {
+        $result = $this->request(['data_collection' => $collection]);
+
+        foreach ($result['spans'] as $data) {
+            foreach (['http.request.header.cookie', 'http.request.header.set-cookie', 'http.response.header.cookie', 'http.response.header.set-cookie'] as $key) {
+                $this->assertArrayNotHasKey($key, $data);
+            }
+        }
+        $this->assertArrayNotHasKey('cookie', $result['eventRequest']['headers'] ?? []);
+        $this->assertArrayNotHasKey('set-cookie', $result['eventRequest']['headers'] ?? []);
+    }
+
+    public function testCollectionDoesNotModifyTheRequestOrResponse(): void
+    {
+        $result = $this->request(['data_collection' => []]);
+
+        $this->assertSame('Bearer request-secret', $result['request']->headers->get('Authorization'));
+        $this->assertSame('main', $result['request']->headers->get('X-Test'));
+        $this->assertSame('response-secret', $result['response']->headers->get('Authorization'));
+        $this->assertSame('response-cookie', $result['response']->headers->getCookies()[0]->getValue());
+    }
+
+    public function legacyPiiProvider(): \Generator
+    {
+        yield 'legacy PII disabled' => [false];
+        yield 'legacy PII enabled' => [true];
+    }
+
+    public function legacyHeadersProvider(): \Generator
+    {
+        yield 'legacy PII disabled' => [false, '[Filtered]'];
+        yield 'legacy PII enabled' => [true, 'Bearer request-secret'];
+    }
+
+    public function userCollectionEnabledProvider(): \Generator
+    {
+        yield 'legacy enabled' => [['send_default_pii' => true]];
+        yield 'configured defaults override legacy off' => [['data_collection' => [], 'send_default_pii' => false]];
+        yield 'configured defaults with legacy on' => [['data_collection' => [], 'send_default_pii' => true]];
+    }
+
+    public function userCollectionDisabledProvider(): \Generator
+    {
+        yield 'legacy disabled' => [['send_default_pii' => false]];
+        yield 'user info off with legacy off' => [['data_collection' => ['user_info' => false], 'send_default_pii' => false]];
+        yield 'user info off overrides legacy on' => [['data_collection' => ['user_info' => false], 'send_default_pii' => true]];
+    }
+
+    public function explicitDataProvider(): \Generator
+    {
+        yield 'legacy off' => [['send_default_pii' => false]];
+        yield 'legacy on' => [['send_default_pii' => true]];
+        yield 'configured defaults' => [['data_collection' => []]];
+        yield 'headers off' => [['data_collection' => ['http_headers' => ['mode' => 'off']]]];
+        yield 'cookies off' => [['data_collection' => ['cookies' => ['mode' => 'off']]]];
+        yield 'all off' => [['data_collection' => ['http_headers' => ['mode' => 'off'], 'cookies' => ['mode' => 'off']]]];
+    }
+
+    public function rawCookieHeadersProvider(): \Generator
+    {
+        yield 'configured defaults' => [[]];
+        yield 'headers off' => [['http_headers' => ['mode' => 'off']]];
+        yield 'cookies off' => [['cookies' => ['mode' => 'off']]];
+        yield 'explicitly allowed header names' => [['http_headers' => ['mode' => 'allowList', 'terms' => ['cookie', 'set-cookie']]]];
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @phpstan-return Exchange
+     */
+    private function request(array $options): array
+    {
+        $kernel = new KernelWithHttpHeaders($options);
+        $client = new KernelBrowser($kernel);
+        $client->getCookieJar()->set(new Cookie('theme', 'dark'));
+        $client->getCookieJar()->set(new Cookie('session_id', 'request-cookie'));
+        try {
+            $client->request('GET', '/header-collection', [], [], [
+                'HTTP_AUTHORIZATION' => 'Bearer request-secret',
+                'HTTP_X_TEST' => 'main',
+                'HTTP_X_DEBUG' => 'visible',
+                'HTTP_X_DEBUG_EXTRA' => 'visible',
+                'HTTP_X_TEST_EXTRA' => 'visible',
+                'HTTP_COOKIE' => 'session_id=request-cookie',
+            ]);
+            $request = $client->getRequest();
+            $this->assertInstanceOf(Request::class, $request);
+            $response = $client->getResponse();
+            $this->assertSame(200, $response->getStatusCode());
+            $transactions = array_values(array_filter(StubTransport::$events, static function (Event $event): bool {
+                return null !== $event->getTransaction();
+            }));
+            $this->assertCount(1, $transactions);
+            $mainData = $transactions[0]->getContexts()['trace']['data'];
+            $this->assertIsArray($mainData);
+            $subspans = array_values(array_filter($transactions[0]->getSpans(), static function (Span $span): bool {
+                return 'http.server' === $span->getOp();
+            }));
+            $this->assertCount(1, $subspans);
+            $messages = array_values(array_filter(StubTransport::$events, static function (Event $event): bool {
+                return 'Header collection' === $event->getMessage();
+            }));
+            $this->assertCount(1, $messages);
+            /** @var array{headers?: array<string, string[]>, cookies?: array<string, mixed>} $eventRequest */
+            $eventRequest = $messages[0]->getRequest();
+
+            return [
+                'spans' => ['main' => $mainData, 'subrequest' => $subspans[0]->getData()],
+                'event' => $messages[0],
+                'eventRequest' => $eventRequest,
+                'request' => $request,
+                'response' => $response,
+            ];
+        } finally {
+            $kernel->shutdown();
+        }
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $spans
+     */
+    private function assertCollectedHeaders(array $spans, string $debugValue = 'visible', string $extraValue = 'visible', ?string $testExtraValue = null): void
+    {
+        $testExtraValue = $testExtraValue ?? $extraValue;
+        foreach ($spans as $name => $data) {
+            $this->assertSame([$name], $data['http.request.header.x-test']);
+            $this->assertSame([$name, 'second'], $data['http.response.header.x-test']);
+            foreach (['http.request.header.', 'http.response.header.'] as $prefix) {
+                $this->assertSame(['[Filtered]'], $data[$prefix . 'authorization']);
+                $this->assertSame([$debugValue], $data[$prefix . 'x-debug']);
+                $this->assertSame([$extraValue], $data[$prefix . 'x-debug-extra']);
+                $this->assertSame([$testExtraValue], $data[$prefix . 'x-test-extra']);
+            }
+        }
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $spans
+     */
+    private function assertCollectedCookies(array $spans): void
+    {
+        $this->assertSame('dark', $spans['main']['http.request.header.cookie.theme']);
+        $this->assertSame('light', $spans['main']['http.response.header.set_cookie.theme']);
+        $this->assertSame('subrequest', $spans['subrequest']['http.request.header.cookie.theme']);
+        $this->assertSame('subrequest', $spans['subrequest']['http.response.header.set_cookie.theme']);
+        foreach ($spans as $data) {
+            $this->assertSame('[Filtered]', $data['http.request.header.cookie.session_id']);
+            $this->assertSame('[Filtered]', $data['http.response.header.set_cookie.session_id']);
+        }
+    }
+}

--- a/tests/End2End/HttpResponseCollectionEnd2EndTest.php
+++ b/tests/End2End/HttpResponseCollectionEnd2EndTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\End2End;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\Event;
+use Sentry\SentryBundle\Tests\End2End\App\KernelWithHttpHeaders;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @runTestsInSeparateProcesses
+ */
+final class HttpResponseCollectionEnd2EndTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        StubTransport::$events = [];
+    }
+
+    public function testInferredContentTypeIsCollected(): void
+    {
+        [$response, $data] = $this->request('GET', '/prepared-response');
+
+        $this->assertSame('{"name":"Alice","password":"secret"}', $response->getContent());
+        $this->assertSame(['application/json'], $data['http.response.header.content-type']);
+        $this->assertSame([$response->headers->get('Cache-Control')], $data['http.response.header.cache-control']);
+        $this->assertSame(['name' => 'Alice', 'password' => '[Filtered]'], $data['http.response.body.data']);
+    }
+
+    public function testHeadResponseCollectsHeadersWithoutABody(): void
+    {
+        [$response, $data] = $this->request('HEAD', '/prepared-response');
+
+        $this->assertSame('', $response->getContent());
+        $this->assertSame(['application/json'], $data['http.response.header.content-type']);
+        $this->assertSame([$response->headers->get('Cache-Control')], $data['http.response.header.cache-control']);
+        $this->assertArrayNotHasKey('http.response.body.data', $data);
+    }
+
+    public function testSessionCookiesAndCacheHeadersAreCollected(): void
+    {
+        [$response, $data] = $this->requestWithSession('GET', '/prepared-response?session=1');
+
+        $this->assertSame('{"name":"Alice","password":"secret"}', $response->getContent());
+        $cookies = $response->headers->getCookies();
+        $this->assertCount(1, $cookies);
+        $this->assertSame('MOCKSESSID', $cookies[0]->getName());
+        $this->assertSame('[Filtered]', $data['http.response.header.set_cookie.MOCKSESSID']);
+        $this->assertSame([$response->headers->get('Cache-Control')], $data['http.response.header.cache-control']);
+        $this->assertSame(['application/json'], $data['http.response.header.content-type']);
+        $this->assertArrayNotHasKey('http.response.header.set-cookie', $data);
+        $this->assertSame(['name' => 'Alice', 'password' => '[Filtered]'], $data['http.response.body.data']);
+    }
+
+    /**
+     * @return array{Response, array<string, mixed>}
+     */
+    private function request(string $method, string $url): array
+    {
+        return $this->requestWithKernel(new KernelWithHttpHeaders(['data_collection' => []]), $method, $url);
+    }
+
+    /**
+     * @return array{Response, array<string, mixed>}
+     */
+    private function requestWithSession(string $method, string $url): array
+    {
+        return $this->requestWithKernel(new KernelWithHttpHeaders(['data_collection' => []], true), $method, $url);
+    }
+
+    /**
+     * @return array{Response, array<string, mixed>}
+     */
+    private function requestWithKernel(KernelWithHttpHeaders $kernel, string $method, string $url): array
+    {
+        $client = new KernelBrowser($kernel);
+        try {
+            $client->request($method, $url);
+            $response = $client->getResponse();
+            $this->assertSame(200, $response->getStatusCode());
+            $this->assertSame('application/json', $response->headers->get('Content-Type'));
+            $transactions = array_values(array_filter(StubTransport::$events, static function (Event $event): bool {
+                return null !== $event->getTransaction();
+            }));
+            $this->assertCount(1, $transactions);
+            $data = $transactions[0]->getContexts()['trace']['data'];
+            $this->assertIsArray($data);
+
+            return [$response, $data];
+        } finally {
+            $kernel->shutdown();
+        }
+    }
+}

--- a/tests/End2End/HttpUrlCollectionEnd2EndTest.php
+++ b/tests/End2End/HttpUrlCollectionEnd2EndTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\End2End;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\Event;
+use Sentry\SentryBundle\Tests\End2End\App\KernelWithExtraConfig;
+use Sentry\Tracing\Span;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @runTestsInSeparateProcesses
+ */
+final class HttpUrlCollectionEnd2EndTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        StubTransport::$events = [];
+    }
+
+    public function testLegacyUrlsUseSymfonyNormalization(): void
+    {
+        $url = 'http://localhost/subrequest?page=one+two&tag=a&tag=b&%74oken=secret&a.b=dot';
+        $this->assertRequestUrls([__DIR__ . '/App/tracing.yml'], Request::create($url)->getUri());
+    }
+
+    public function testConfiguredUrlsPreserveEncodingAndFilterSensitiveValues(): void
+    {
+        $this->assertRequestUrls(
+            [__DIR__ . '/App/tracing.yml', __DIR__ . '/App/url_data_collection.yml'],
+            'http://localhost/subrequest?page=one+two&tag=a&tag=b&%74oken=[Filtered]&a.b=dot'
+        );
+    }
+
+    /**
+     * @param string[] $config
+     */
+    private function assertRequestUrls(array $config, string $expectedUrl): void
+    {
+        $kernel = new KernelWithExtraConfig($config);
+        // Boot lazily so the SDK's first request fetcher belongs to this request's kernel.
+        $client = new KernelBrowser($kernel);
+        $url = 'http://localhost/subrequest?page=one+two&tag=a&tag=b&%74oken=secret&a.b=dot';
+
+        try {
+            $client->request('GET', $url);
+            $this->assertSame(200, $client->getResponse()->getStatusCode());
+            $request = $client->getRequest();
+            $this->assertInstanceOf(Request::class, $request);
+            $this->assertSame(Request::create($url)->getUri(), $request->getUri());
+            $this->assertSame('page=one+two&tag=a&tag=b&%74oken=secret&a.b=dot', $request->server->get('QUERY_STRING'));
+            $transactions = array_values(array_filter(StubTransport::$events, static function (Event $event): bool {
+                return null !== $event->getTransaction();
+            }));
+            $this->assertCount(1, $transactions);
+            $traceData = $transactions[0]->getContexts()['trace']['data'];
+            $this->assertIsArray($traceData);
+            $this->assertSame($expectedUrl, $traceData['http.url']);
+            $spans = array_values(array_filter($transactions[0]->getSpans(), static function (Span $span): bool {
+                return 'http.server' === $span->getOp();
+            }));
+            $this->assertCount(1, $spans);
+            $this->assertSame($expectedUrl, $spans[0]->getData()['http.url']);
+        } finally {
+            $kernel->shutdown();
+        }
+    }
+}

--- a/tests/EventListener/HttpBodyCollectionTest.php
+++ b/tests/EventListener/HttpBodyCollectionTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\ClientInterface;
+use Sentry\DataCollection\DataCollectionPolicy;
+use Sentry\Options;
+use Sentry\SentryBundle\EventListener\AbstractTracingRequestListener;
+use Sentry\State\Hub;
+use Sentry\Tracing\Transaction;
+use Sentry\Tracing\TransactionContext;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+final class HttpBodyCollectionTest extends TestCase
+{
+    /**
+     * @dataProvider disabledCollectionProvider
+     *
+     * @param array<string, mixed> $options
+     */
+    public function testDisabledBodiesAreNotRead(array $options): void
+    {
+        $request = $this->requestWhoseBodyMustNotBeRead();
+        $response = $this->responseWhoseBodyMustNotBeRead();
+
+        $span = $this->collect($request, $response, $options);
+
+        $this->assertArrayNotHasKey('http.request.body.data', $span->getData());
+        $this->assertArrayNotHasKey('http.response.body.data', $span->getData());
+    }
+
+    public function disabledCollectionProvider(): \Generator
+    {
+        yield 'legacy' => [[]];
+        yield 'legacy PII enabled' => [['send_default_pii' => true]];
+        yield 'bodies disabled' => [['data_collection' => ['http_bodies' => []]]];
+        yield 'bodies disabled overrides PII' => [['data_collection' => ['http_bodies' => []], 'send_default_pii' => true]];
+    }
+
+    public function testUnsampledBodiesAreNotRead(): void
+    {
+        $span = new Transaction(TransactionContext::make()->setSampled(false));
+
+        $this->collect($this->requestWhoseBodyMustNotBeRead(), $this->responseWhoseBodyMustNotBeRead(), ['data_collection' => []], $span);
+
+        $this->assertArrayNotHasKey('http.request.body.data', $span->getData());
+        $this->assertArrayNotHasKey('http.response.body.data', $span->getData());
+    }
+
+    public function testExplicitBodyDataIsPreservedWithoutReadingBodies(): void
+    {
+        $span = new Transaction(TransactionContext::make()->setSampled(true));
+        $span->setData([
+            'http.request.body.data' => null,
+            'http.response.body.data' => null,
+        ]);
+
+        $this->collect($this->requestWhoseBodyMustNotBeRead(), $this->responseWhoseBodyMustNotBeRead(), ['data_collection' => []], $span);
+
+        $this->assertNull($span->getData()['http.request.body.data']);
+        $this->assertNull($span->getData()['http.response.body.data']);
+    }
+
+    public function testStreamedResponseIsNotCollected(): void
+    {
+        $response = new StreamedResponse(static function (): void {
+            throw new \LogicException('Must not invoke output callbacks');
+        });
+
+        $span = $this->collect(Request::create('/'), $response, ['data_collection' => []]);
+
+        $this->assertArrayNotHasKey('http.response.body.data', $span->getData());
+    }
+
+    public function testFileResponseIsNotCollected(): void
+    {
+        $span = $this->collect(Request::create('/'), new BinaryFileResponse(__FILE__), ['data_collection' => []]);
+
+        $this->assertArrayNotHasKey('http.response.body.data', $span->getData());
+    }
+
+    public function testParsedFormDataIsFilteredWithoutChangingRequest(): void
+    {
+        $request = Request::create('/', 'POST', ['name' => 'Alice', 'password' => 'secret']);
+        $span = $this->collect($request, new Response(), ['data_collection' => []]);
+
+        $this->assertSame(['name' => 'Alice', 'password' => '[Filtered]'], $span->getData()['http.request.body.data']);
+        $this->assertSame('secret', $request->request->get('password'));
+    }
+
+    public function testOversizedRequestIsNotRead(): void
+    {
+        $request = $this->getMockBuilder(Request::class)->onlyMethods(['getContent'])->getMock();
+        $request->headers->set('Content-Length', '1001');
+        $request->expects($this->never())->method('getContent');
+
+        $span = $this->collect($request, new Response(), ['data_collection' => [], 'max_request_body_size' => 'small']);
+        $this->assertArrayNotHasKey('http.request.body.data', $span->getData());
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function collect(Request $request, Response $response, array $options, ?Transaction $span = null): Transaction
+    {
+        $client = $this->createMock(ClientInterface::class);
+        $client->method('getOptions')->willReturn(new Options($options + ['max_request_body_size' => 'always']));
+        $hub = new Hub($client);
+        $span = $span ?? new Transaction(TransactionContext::make()->setSampled(true));
+        $hub->setSpan($span);
+        $type = (int) \constant(HttpKernelInterface::class . '::' . (\defined(HttpKernelInterface::class . '::MAIN_REQUEST') ? 'MAIN_REQUEST' : 'MASTER_REQUEST'));
+        $listener = new class($hub) extends AbstractTracingRequestListener {
+            public function collectRequest(\Sentry\Tracing\Span $span, Request $request): void
+            {
+                $this->collectRequestData($span, $request, DataCollectionPolicy::fromHub($this->hub));
+            }
+        };
+        $listener->collectRequest($span, $request);
+        $listener->collectKernelResponseEvent(new ResponseEvent($this->createMock(HttpKernelInterface::class), $request, $type, $response));
+
+        return $span;
+    }
+
+    private function requestWhoseBodyMustNotBeRead(): Request
+    {
+        $request = $this->getMockBuilder(Request::class)->onlyMethods(['getContent'])->getMock();
+        $request->expects($this->never())->method('getContent');
+
+        return $request;
+    }
+
+    private function responseWhoseBodyMustNotBeRead(): Response
+    {
+        $response = $this->getMockBuilder(Response::class)->onlyMethods(['getContent'])->getMock();
+        $response->expects($this->never())->method('getContent');
+
+        return $response;
+    }
+}

--- a/tests/EventListener/HttpHeaderCollectionTest.php
+++ b/tests/EventListener/HttpHeaderCollectionTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\ClientInterface;
+use Sentry\Options;
+use Sentry\SentryBundle\EventListener\TracingRequestListener;
+use Sentry\SentryBundle\EventListener\TracingSubRequestListener;
+use Sentry\State\Hub;
+use Sentry\Tracing\SpanStatus;
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\HeaderBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+final class HttpHeaderCollectionTest extends TestCase
+{
+    /**
+     * @dataProvider legacyCollectionProvider
+     *
+     * @param array<string, mixed> $options
+     */
+    public function testLegacySpansDoNotCollectHeaders(array $options): void
+    {
+        $this->assertHeadersAreNotCollected($options, 0);
+    }
+
+    public function testUnsampledSpansDoNotReadHeaders(): void
+    {
+        $this->assertHeadersAreNotCollected(['data_collection' => [], 'traces_sample_rate' => 0.0], 0);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function assertHeadersAreNotCollected(array $options, int $expectedReads): void
+    {
+        $hub = $this->createHub($options);
+        $request = Request::create('https://example.com');
+        $request->headers = $this->getMockBuilder(HeaderBag::class)->setConstructorArgs([$request->headers->all()])->onlyMethods(['getIterator'])->getMock();
+        $request->headers->expects($this->exactly($expectedReads))->method('getIterator')->willReturn(new \ArrayIterator(['x-test' => ['visible']]));
+        $response = new Response();
+        $response->headers = $this->createMock(ResponseHeaderBag::class);
+        $response->headers->expects($this->exactly($expectedReads))->method('getIterator')->willReturn(new \ArrayIterator(['x-test' => ['visible']]));
+        $response->headers->expects($this->exactly($expectedReads))->method('getCookies')->willReturn([]);
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        foreach ([
+            [new TracingRequestListener($hub), $this->mainRequestType()],
+            [new TracingSubRequestListener($hub), HttpKernelInterface::SUB_REQUEST],
+        ] as [$listener, $type]) {
+            $listener->handleKernelRequestEvent(new RequestEvent($kernel, $request, $type));
+            $listener->collectKernelResponseEvent(new ResponseEvent($kernel, $request, $type, $response));
+            $span = $hub->getSpan();
+            $this->assertNotNull($span);
+            $this->assertArrayNotHasKey('http.request.header.x-test', $span->getData());
+            $this->assertArrayNotHasKey('http.response.header.x-test', $span->getData());
+        }
+    }
+
+    public function testDisabledResponseCookiesAreNotCollected(): void
+    {
+        $hub = $this->createHub(['data_collection' => ['cookies' => ['mode' => 'off']]]);
+        $listener = new TracingRequestListener($hub);
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $request = Request::create('https://example.com');
+        $listener->handleKernelRequestEvent(new RequestEvent($kernel, $request, $this->mainRequestType()));
+        $response = new Response();
+        $cookie = new class('session_id', 'secret') extends Cookie {
+            public function __toString(): string
+            {
+                throw new \LogicException('Telemetry must not serialize cookies.');
+            }
+        };
+        $response->headers->setCookie($cookie);
+        $listener->collectKernelResponseEvent(new ResponseEvent($kernel, $request, $this->mainRequestType(), $response));
+        $span = $hub->getSpan();
+        $this->assertNotNull($span);
+        $this->assertArrayNotHasKey('http.response.header.set-cookie', $span->getData());
+        $this->assertArrayNotHasKey('http.response.header.set_cookie.session_id', $span->getData());
+        $this->assertSame('secret', $cookie->getValue());
+    }
+
+    public function testResponseDataIsCollectedAfterStatus(): void
+    {
+        $hub = $this->createHub(['data_collection' => []]);
+        $listener = new TracingRequestListener($hub);
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $request = Request::create('https://example.com');
+        $listener->handleKernelRequestEvent(new RequestEvent($kernel, $request, $this->mainRequestType()));
+        $response = new Response('', 200, ['X-Test' => 'controller']);
+        $event = new ResponseEvent($kernel, $request, $this->mainRequestType(), $response);
+        $listener->handleKernelResponseEvent($event);
+
+        $span = $hub->getSpan();
+        $this->assertNotNull($span);
+        $this->assertSame(SpanStatus::ok(), $span->getStatus());
+        $this->assertArrayNotHasKey('http.response.header.x-test', $span->getData());
+
+        $response->headers->set('X-Test', 'prepared');
+        $listener->collectKernelResponseEvent($event);
+
+        $this->assertSame(['prepared'], $span->getData()['http.response.header.x-test']);
+    }
+
+    public function testParsedResponseCookiesDoNotSerializeHeaders(): void
+    {
+        $hub = $this->createHub(['data_collection' => ['http_headers' => ['mode' => 'off']]]);
+        $listener = new TracingRequestListener($hub);
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $request = Request::create('https://example.com');
+        $listener->handleKernelRequestEvent(new RequestEvent($kernel, $request, $this->mainRequestType()));
+        $response = new Response();
+        $response->headers->setCookie(new class('session_id', 'secret') extends Cookie {
+            public function __toString(): string
+            {
+                throw new \LogicException('Telemetry must not serialize cookies.');
+            }
+        });
+        $response->headers->setCookie(new Cookie('theme', 'dark', 0, '/'));
+        $response->headers->setCookie(new Cookie('theme', 'light', 0, '/other'));
+        $response->headers->setCookie(new Cookie('locale', null, 0, '/'));
+        $response->headers->setCookie(new Cookie('locale', 'en', 0, '/other'));
+        $listener->collectKernelResponseEvent(new ResponseEvent($kernel, $request, $this->mainRequestType(), $response));
+        $span = $hub->getSpan();
+        $this->assertNotNull($span);
+        $this->assertSame('[Filtered]', $span->getData()['http.response.header.set_cookie.session_id']);
+        $this->assertSame(['dark', 'light'], $span->getData()['http.response.header.set_cookie.theme']);
+        $this->assertSame([null, 'en'], $span->getData()['http.response.header.set_cookie.locale']);
+        $this->assertArrayNotHasKey('http.response.header.set-cookie', $span->getData());
+    }
+
+    /**
+     * @return \Generator<mixed>
+     */
+    public function legacyCollectionProvider(): \Generator
+    {
+        yield 'legacy pii off' => [['send_default_pii' => false]];
+        yield 'legacy pii on' => [['send_default_pii' => true]];
+        yield 'null collection pii off' => [['data_collection' => null, 'send_default_pii' => false]];
+        yield 'null collection pii on' => [['data_collection' => null, 'send_default_pii' => true]];
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function createHub(array $options): Hub
+    {
+        $client = $this->createMock(ClientInterface::class);
+        $client->method('getOptions')->willReturn(new Options($options + ['traces_sample_rate' => 1.0]));
+
+        return new Hub($client);
+    }
+
+    private function mainRequestType(): int
+    {
+        return (int) \constant(HttpKernelInterface::class . '::' . (\defined(HttpKernelInterface::class . '::MAIN_REQUEST') ? 'MAIN_REQUEST' : 'MASTER_REQUEST'));
+    }
+}

--- a/tests/EventListener/LoginListenerTest.php
+++ b/tests/EventListener/LoginListenerTest.php
@@ -54,6 +54,22 @@ final class LoginListenerTest extends TestCase
         $this->listener = new LoginListener($this->hub, $this->tokenStorage);
     }
 
+    public function testConfiguredDefaultsCollectUserDespiteLegacyPiiBeingDisabled(): void
+    {
+        $user = $this->handleRequestWithCollection(['send_default_pii' => false, 'data_collection' => []], 1);
+
+        $this->assertSame('collected-user', $user->getId());
+        $this->assertSame('explicit@example.com', $user->getEmail());
+    }
+
+    public function testDisabledUserCollectionOverridesLegacyPiiBeingEnabled(): void
+    {
+        $user = $this->handleRequestWithCollection(['send_default_pii' => true, 'data_collection' => ['user_info' => false]], 0);
+
+        $this->assertNull($user->getId());
+        $this->assertSame('explicit@example.com', $user->getEmail());
+    }
+
     /**
      * @dataProvider authenticationTokenDataProvider
      * @dataProvider authenticationTokenForSymfonyVersionLowerThan54DataProvider
@@ -488,6 +504,33 @@ final class LoginListenerTest extends TestCase
         } else {
             $this->listener->handleAuthenticationSuccessEvent(new AuthenticationSuccessEvent(new AuthenticatedTokenStub(new UserWithIdentifierStub())));
         }
+    }
+
+    /**
+     * @param array<string, mixed> $configuration
+     */
+    private function handleRequestWithCollection(array $configuration, int $expectedScopeUpdates): UserDataBag
+    {
+        $client = $this->createMock(ClientInterface::class);
+        $client->method('getOptions')->willReturn(new Options($configuration));
+        $this->hub->method('getClient')->willReturn($client);
+        $scope = new Scope();
+        $scope->setUser(new UserDataBag(null, 'explicit@example.com'));
+        $this->hub->expects($this->exactly($expectedScopeUpdates))->method('configureScope')->willReturnCallback(static function (callable $callback) use ($scope): void {
+            $callback($scope);
+        });
+        $this->tokenStorage->method('getToken')->willReturn(new AuthenticatedTokenStub(new UserWithIdentifierStub('collected-user')));
+
+        $this->listener->handleKernelRequestEvent(new RequestEvent(
+            $this->createMock(HttpKernelInterface::class),
+            new Request(),
+            (int) \constant(HttpKernelInterface::class . '::' . (\defined(HttpKernelInterface::class . '::MAIN_REQUEST') ? 'MAIN_REQUEST' : 'MASTER_REQUEST'))
+        ));
+
+        $user = $scope->getUser();
+        $this->assertNotNull($user);
+
+        return $user;
     }
 }
 

--- a/tests/EventListener/LoginListenerTest.php
+++ b/tests/EventListener/LoginListenerTest.php
@@ -519,7 +519,10 @@ final class LoginListenerTest extends TestCase
         $this->hub->expects($this->exactly($expectedScopeUpdates))->method('configureScope')->willReturnCallback(static function (callable $callback) use ($scope): void {
             $callback($scope);
         });
-        $this->tokenStorage->method('getToken')->willReturn(new AuthenticatedTokenStub(new UserWithIdentifierStub('collected-user')));
+        $token = version_compare(Kernel::VERSION, '5.4', '<')
+            ? new LegacyAuthenticatedTokenStub(new UserWithIdentifierStub('collected-user'))
+            : new AuthenticatedTokenStub(new UserWithIdentifierStub('collected-user'));
+        $this->tokenStorage->method('getToken')->willReturn($token);
 
         $this->listener->handleKernelRequestEvent(new RequestEvent(
             $this->createMock(HttpKernelInterface::class),

--- a/tests/EventListener/RequestListenerTest.php
+++ b/tests/EventListener/RequestListenerTest.php
@@ -89,6 +89,34 @@ final class RequestListenerTest extends TestCase
             new UserDataBag(),
         ];
 
+        yield 'options.data_collection.user_info = FALSE overrides send_default_pii' => [
+            new RequestEvent(
+                $this->createMock(HttpKernelInterface::class),
+                new Request([], [], [], [], [], ['REMOTE_ADDR' => '127.0.0.1']),
+                \defined(HttpKernelInterface::class . '::MAIN_REQUEST') ? HttpKernelInterface::MAIN_REQUEST : (int) \constant(HttpKernelInterface::class . '::MASTER_REQUEST')
+            ),
+            $this->getMockedClientWithOptions(new Options([
+                'send_default_pii' => true,
+                'data_collection' => ['user_info' => false],
+            ])),
+            new UserDataBag(),
+            new UserDataBag(),
+        ];
+
+        yield 'options.data_collection.user_info = TRUE overrides send_default_pii' => [
+            new RequestEvent(
+                $this->createMock(HttpKernelInterface::class),
+                new Request([], [], [], [], [], ['REMOTE_ADDR' => '127.0.0.1']),
+                \defined(HttpKernelInterface::class . '::MAIN_REQUEST') ? HttpKernelInterface::MAIN_REQUEST : (int) \constant(HttpKernelInterface::class . '::MASTER_REQUEST')
+            ),
+            $this->getMockedClientWithOptions(new Options([
+                'send_default_pii' => false,
+                'data_collection' => ['user_info' => true],
+            ])),
+            new UserDataBag(),
+            new UserDataBag(null, null, '127.0.0.1'),
+        ];
+
         yield 'request.clientIp IS NULL' => [
             new RequestEvent(
                 $this->createMock(HttpKernelInterface::class),

--- a/tests/EventListener/TracingRequestListenerTest.php
+++ b/tests/EventListener/TracingRequestListenerTest.php
@@ -484,6 +484,24 @@ final class TracingRequestListenerTest extends TestCase
         ));
     }
 
+    public function testCollectResponseRequestEventDoesNothingIfNoTransactionIsSetOnHub(): void
+    {
+        $this->hub->expects($this->once())
+            ->method('getSpan')
+            ->willReturn(null);
+
+        $this->hub->expects($this->never())
+            ->method('getClient');
+
+        $requestType = (int) \constant(HttpKernelInterface::class . '::' . (\defined(HttpKernelInterface::class . '::MAIN_REQUEST') ? 'MAIN_REQUEST' : 'MASTER_REQUEST'));
+        $this->listener->collectKernelResponseEvent(new ResponseEvent(
+            $this->createMock(HttpKernelInterface::class),
+            new Request(),
+            $requestType,
+            new Response()
+        ));
+    }
+
     /**
      * @group time-sensitive
      */

--- a/tests/Integration/RequestFetcherTest.php
+++ b/tests/Integration/RequestFetcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sentry\SentryBundle\Tests\Integration;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
@@ -51,6 +52,44 @@ final class RequestFetcherTest extends TestCase
             ->willReturn($expectedRequest);
 
         $this->assertSame($expectedRequest, $this->requestFetcher->fetchRequest());
+    }
+
+    public function testEmptyBridgeFormBagDoesNotMaskRawBody(): void
+    {
+        $request = Request::create('/', 'POST', [], [], [], ['CONTENT_TYPE' => 'application/json'], '{"name":"Alice"}');
+        $psrRequest = (new ServerRequest('POST', '/', [], '{"name":"Alice"}'))->withParsedBody([]);
+        $this->requestStack->method('getCurrentRequest')->willReturn($request);
+        $this->httpMessageFactory->method('createRequest')->willReturn($psrRequest);
+
+        $result = $this->requestFetcher->fetchRequest();
+        $this->assertNotNull($result);
+        $this->assertNull($result->getParsedBody());
+        $this->assertSame('{"name":"Alice"}', (string) $result->getBody());
+        $this->assertSame('{"name":"Alice"}', $request->getContent());
+    }
+
+    public function testEmptyParsedFormBodyIsPreserved(): void
+    {
+        $request = Request::create('/', 'POST', [], [], [], ['CONTENT_TYPE' => 'application/x-www-form-urlencoded'], 'malformed');
+        $psrRequest = (new ServerRequest('POST', '/'))->withParsedBody([]);
+        $this->requestStack->method('getCurrentRequest')->willReturn($request);
+        $this->httpMessageFactory->method('createRequest')->willReturn($psrRequest);
+
+        $result = $this->requestFetcher->fetchRequest();
+        $this->assertNotNull($result);
+        $this->assertSame([], $result->getParsedBody());
+    }
+
+    public function testEmptyParsedBodyIsPreservedWhenTheRawBodyIsEmpty(): void
+    {
+        $request = Request::create('/', 'POST');
+        $psrRequest = (new ServerRequest('POST', '/'))->withParsedBody([]);
+        $this->requestStack->method('getCurrentRequest')->willReturn($request);
+        $this->httpMessageFactory->method('createRequest')->willReturn($psrRequest);
+
+        $result = $this->requestFetcher->fetchRequest();
+        $this->assertNotNull($result);
+        $this->assertSame([], $result->getParsedBody());
     }
 
     public function testFetchRequestReturnsNullIfTheRequestStackIsEmpty(): void

--- a/tests/Tracing/HttpClient/HttpBodyCollectionTest.php
+++ b/tests/Tracing/HttpClient/HttpBodyCollectionTest.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\Tracing\HttpClient;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\ClientInterface;
+use Sentry\DataCollection\DataCollectionPolicy;
+use Sentry\Options;
+use Sentry\SentryBundle\Tracing\HttpClient\TraceableHttpClient;
+use Sentry\SentryBundle\Tracing\HttpClient\TraceableResponse;
+use Sentry\State\Hub;
+use Sentry\Tracing\Span;
+use Sentry\Tracing\TransactionContext;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class HttpBodyCollectionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!class_exists(MockHttpClient::class)) {
+            $this->markTestSkipped('This test requires symfony/http-client.');
+        }
+    }
+
+    public function testRepeatedReadsKeepFirstBodyAndTiming(): void
+    {
+        $span = (new Span())->setSampled(true);
+        $underlying = $this->createMock(ResponseInterface::class);
+        $underlying->expects($this->once())->method('getHeaders')->with(false)->willReturn(['content-type' => ['application/json']]);
+        $underlying->expects($this->exactly(2))->method('getContent')->willReturn('{"token":"secret"}');
+        $underlying->method('getInfo')->willReturn(200);
+        $response = $this->wrap($underlying, $span);
+
+        $this->assertSame('{"token":"secret"}', $response->getContent());
+        $finishedAt = $span->getEndTimestamp();
+        $this->assertNotNull($finishedAt);
+        $this->assertSame(['token' => '[Filtered]'], $span->getData()['http.response.body.data']);
+
+        $span->setData(['http.response.body.data' => []]);
+        $this->assertSame('{"token":"secret"}', $response->getContent());
+        $this->assertSame([], $span->getData()['http.response.body.data']);
+        $this->assertSame($finishedAt, $span->getEndTimestamp());
+    }
+
+    public function testSuccessfulReadAfterDecodingFailure(): void
+    {
+        $raw = (new MockHttpClient(new MockResponse('{invalid', ['response_headers' => ['Content-Type: application/json']])))->request('GET', 'https://example.com');
+        $span = (new Span())->setSampled(true);
+        $response = $this->wrap($raw, $span);
+
+        try {
+            $response->toArray();
+            $this->fail('Expected a decoding exception');
+        } catch (DecodingExceptionInterface $exception) {
+            $finishedAt = $span->getEndTimestamp();
+            $this->assertNotNull($finishedAt);
+            $this->assertArrayNotHasKey('http.response.body.data', $span->getData());
+            $this->assertSame('{invalid', $response->getContent());
+            $this->assertSame('[Filtered]', $span->getData()['http.response.body.data']);
+            $this->assertSame($finishedAt, $span->getEndTimestamp());
+        }
+    }
+
+    public function testDestructionDoesNotReadBody(): void
+    {
+        $underlying = $this->responseWhoseBodyMustNotBeRead();
+        $span = (new Span())->setSampled(true);
+        $response = $this->wrap($underlying, $span);
+
+        unset($response);
+
+        $this->assertNotNull($span->getEndTimestamp());
+        $this->assertArrayNotHasKey('http.response.body.data', $span->getData());
+    }
+
+    public function testCancellationDoesNotReadBody(): void
+    {
+        $underlying = $this->responseWhoseBodyMustNotBeRead();
+        $span = (new Span())->setSampled(true);
+        $response = $this->wrap($underlying, $span);
+
+        $response->cancel();
+        unset($response);
+
+        $this->assertNotNull($span->getEndTimestamp());
+        $this->assertArrayNotHasKey('http.response.body.data', $span->getData());
+    }
+
+    /**
+     * @dataProvider explicitResponseBodyProvider
+     *
+     * @param mixed $explicit
+     */
+    public function testExplicitResponseBodyIsPreserved($explicit): void
+    {
+        $span = (new Span())->setSampled(true)->setData(['http.response.body.data' => $explicit]);
+        $underlying = $this->createMock(ResponseInterface::class);
+        $underlying->expects($this->once())->method('toArray')->willReturn(['password' => 'secret']);
+        $underlying->method('getHeaders')->willReturn([]);
+        $underlying->method('getInfo')->willReturn(200);
+
+        $this->assertSame(['password' => 'secret'], $this->wrap($underlying, $span)->toArray());
+        $this->assertSame($explicit, $span->getData()['http.response.body.data']);
+    }
+
+    public function explicitResponseBodyProvider(): \Generator
+    {
+        yield 'null' => [null];
+        yield 'empty' => [[]];
+        yield 'populated' => [['password' => 'explicit']];
+    }
+
+    /**
+     * @dataProvider declaredBodyProvider
+     *
+     * @param array<string, mixed> $requestOptions
+     * @param array<string, mixed> $expectedBodyData
+     */
+    public function testDeclaredRequestBodies(array $requestOptions, array $expectedBodyData): void
+    {
+        $data = $this->collectDeclaredRequestBody($requestOptions);
+
+        $this->assertSame(
+            $expectedBodyData,
+            array_intersect_key($data, ['http.request.body.data' => true])
+        );
+    }
+
+    public function declaredBodyProvider(): \Generator
+    {
+        yield 'json without header' => [['json' => ['password' => 'secret']], ['http.request.body.data' => ['password' => '[Filtered]']]];
+        yield 'empty json' => [['json' => []], ['http.request.body.data' => []]];
+        yield 'scalar json' => [['json' => '{"password":"secret"}'], ['http.request.body.data' => '[Filtered]']];
+        yield 'empty scalar json' => [['json' => ''], []];
+        yield 'empty raw body' => [['body' => ''], []];
+        yield 'boolean json' => [['json' => false], []];
+        yield 'numeric json' => [['json' => 123], []];
+        yield 'json takes precedence' => [['json' => ['name' => 'json'], 'body' => 'ignored'], ['http.request.body.data' => ['name' => 'json']]];
+        yield 'empty json does not fall back to body' => [['json' => '', 'body' => 'ignored'], []];
+        yield 'null json falls back to body' => [['json' => null, 'body' => ['name' => 'form']], ['http.request.body.data' => ['name' => 'form']]];
+        yield 'raw JSON document' => [['body' => '{"password":"secret"}', 'headers' => ['Content-Type' => 'application/json']], ['http.request.body.data' => ['password' => '[Filtered]']]];
+        yield 'declared JSON string ignores content type' => [['json' => '{"name":"Alice"}', 'headers' => ['Content-Type' => 'application/json']], ['http.request.body.data' => '[Filtered]']];
+        yield 'json object' => [['json' => new \stdClass()], []];
+        yield 'form' => [['body' => ['name' => 'Alice', 'password' => 'secret']], ['http.request.body.data' => ['name' => 'Alice', 'password' => '[Filtered]']]];
+        yield 'unsupported raw' => [['body' => 'secret'], ['http.request.body.data' => '[Filtered]']];
+        yield 'callback' => [['body' => static function (): string {
+            throw new \LogicException('Do not call');
+        }], []];
+    }
+
+    public function testUnbufferedContentIsCollectedFromTheReturnedValue(): void
+    {
+        $raw = (new MockHttpClient(new MockResponse('{"token":"secret"}', ['response_headers' => ['Content-Type: application/json']])))->request('GET', 'https://example.com', ['buffer' => false]);
+        $span = (new Span())->setSampled(true);
+
+        $this->assertSame('{"token":"secret"}', $this->wrap($raw, $span)->getContent());
+        $this->assertSame(['token' => '[Filtered]'], $span->getData()['http.response.body.data']);
+    }
+
+    public function testToStreamDoesNotCollectBody(): void
+    {
+        $raw = (new MockHttpClient(new MockResponse('{"token":"secret"}')))->request('GET', 'https://example.com');
+        $span = (new Span())->setSampled(true);
+        $response = $this->wrap($raw, $span);
+        if (!method_exists($response, 'toStream')) {
+            $this->markTestSkipped('toStream is not available.');
+        }
+
+        $this->assertSame('{"token":"secret"}', stream_get_contents($response->toStream()));
+        $this->assertArrayNotHasKey('http.response.body.data', $span->getData());
+    }
+
+    public function testRuntimeOptionUpdatesAffectLaterCollection(): void
+    {
+        $options = new Options(['data_collection' => ['http_bodies' => []]]);
+        $span = (new Span())->setSampled(true);
+        $underlying = $this->createMock(ResponseInterface::class);
+        $underlying->method('getContent')->willReturn('{"name":"Alice"}');
+        $underlying->method('getHeaders')->willReturn(['content-type' => ['application/json']]);
+        $underlying->method('getInfo')->willReturn(200);
+        $response = new TraceableResponse($this->createMock(HttpClientInterface::class), $underlying, $span, DataCollectionPolicy::fromOptions($options));
+
+        $dataCollection = $options->getDataCollection();
+        $this->assertNotNull($dataCollection);
+        $dataCollection->setHttpBodies(['incomingResponse']);
+        $response->getContent();
+
+        $this->assertSame(['name' => 'Alice'], $span->getData()['http.response.body.data']);
+    }
+
+    public function testReplacingRuntimeOptionsAffectsLaterCollection(): void
+    {
+        $options = new Options(['data_collection' => ['http_bodies' => []]]);
+        $previous = $options->getDataCollection();
+        $span = (new Span())->setSampled(true);
+        $underlying = $this->createMock(ResponseInterface::class);
+        $underlying->method('getContent')->willReturn('{"name":"Alice"}');
+        $underlying->method('getHeaders')->willReturn(['content-type' => ['application/json']]);
+        $underlying->method('getInfo')->willReturn(200);
+        $response = new TraceableResponse($this->createMock(HttpClientInterface::class), $underlying, $span, DataCollectionPolicy::fromOptions($options));
+
+        $options->updateOptions(['data_collection' => ['http_bodies' => ['incomingResponse']]]);
+        $this->assertNotSame($previous, $options->getDataCollection());
+        $response->getContent();
+
+        $this->assertSame(['name' => 'Alice'], $span->getData()['http.response.body.data']);
+    }
+
+    private function responseWhoseBodyMustNotBeRead(): ResponseInterface
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects($this->never())->method('getContent');
+        $response->expects($this->never())->method('toArray');
+        $response->method('getHeaders')->willReturn([]);
+        $response->method('getInfo')->willReturn(200);
+
+        return $response;
+    }
+
+    /**
+     * @param array<string, mixed> $requestOptions
+     *
+     * @return array<string, mixed>
+     */
+    private function collectDeclaredRequestBody(array $requestOptions): array
+    {
+        $sdk = $this->createMock(ClientInterface::class);
+        $sdk->method('getOptions')->willReturn(new Options(['data_collection' => [], 'max_request_body_size' => 'always', 'traces_sample_rate' => 1.0]));
+        $hub = new Hub($sdk);
+        $transaction = $hub->startTransaction(TransactionContext::make());
+        $hub->setSpan($transaction);
+        $underlying = $this->createMock(HttpClientInterface::class);
+        $rawResponse = $this->createMock(ResponseInterface::class);
+        $rawResponse->method('getHeaders')->willReturn([]);
+        $rawResponse->method('getInfo')->willReturn(200);
+        $underlying->expects($this->once())->method('request')->willReturn($rawResponse);
+
+        $client = new TraceableHttpClient($underlying, $hub);
+        $client->request('POST', 'https://example.com', $requestOptions)->getContent();
+        $recorder = $transaction->getSpanRecorder();
+        $this->assertNotNull($recorder);
+
+        return $recorder->getSpans()[1]->getData();
+    }
+
+    private function wrap(ResponseInterface $response, Span $span): TraceableResponse
+    {
+        return new TraceableResponse(
+            $this->createMock(HttpClientInterface::class),
+            $response,
+            $span,
+            DataCollectionPolicy::fromOptions(new Options(['data_collection' => []]))
+        );
+    }
+}

--- a/tests/Tracing/HttpClient/HttpDataCollectionTest.php
+++ b/tests/Tracing/HttpClient/HttpDataCollectionTest.php
@@ -531,9 +531,14 @@ final class HttpDataCollectionTest extends TestCase
      */
     public function testEmptyAuthenticationOptionsDoNotCollectAuthorizationHeader(array $authenticationOption): void
     {
-        $data = $this->collectRequestOptions($authenticationOption);
+        $underlying = $this->createMock(HttpClientInterface::class);
+        $underlying->expects($this->once())->method('request')->willReturn(new MockResponse());
+        $transaction = null;
+        $client = $this->client($underlying, ['data_collection' => []], $transaction);
+        $response = $client->request('GET', 'https://example.com', $authenticationOption);
 
-        $this->assertArrayNotHasKey('http.request.header.authorization', $data);
+        $this->assertArrayNotHasKey('http.request.header.authorization', $this->span($transaction)->getData());
+        unset($response);
     }
 
     public function emptyAuthenticationOptionProvider(): \Generator

--- a/tests/Tracing/HttpClient/HttpDataCollectionTest.php
+++ b/tests/Tracing/HttpClient/HttpDataCollectionTest.php
@@ -1,0 +1,793 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\SentryBundle\Tests\Tracing\HttpClient;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\ClientInterface;
+use Sentry\DataCollection\DataCollectionPolicy;
+use Sentry\Options;
+use Sentry\SentryBundle\Tracing\HttpClient\TraceableHttpClient;
+use Sentry\SentryBundle\Tracing\HttpClient\TraceableResponse;
+use Sentry\State\Hub;
+use Sentry\Tracing\Span;
+use Sentry\Tracing\Transaction;
+use Sentry\Tracing\TransactionContext;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class HttpDataCollectionTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (!class_exists(MockHttpClient::class)) {
+            self::markTestSkipped('This test requires symfony/http-client.');
+        }
+    }
+
+    /**
+     * @dataProvider legacyPiiProvider
+     */
+    public function testConfiguredDefaultsCollectHeadersAndCookies(bool $pii): void
+    {
+        $data = $this->collect(['data_collection' => [], 'send_default_pii' => $pii]);
+
+        $this->assertCollectedHeaders($data, 'request');
+        $this->assertCollectedHeaders($data, 'response');
+        $this->assertCollectedCookies($data);
+    }
+
+    /**
+     * @dataProvider legacyPiiProvider
+     */
+    public function testLegacyConfigurationDoesNotAddHeadersOrCookies(bool $pii): void
+    {
+        $data = $this->collect(['data_collection' => null, 'send_default_pii' => $pii]);
+
+        $this->assertArrayNotHasKey('http.request.header.x-request', $data);
+        $this->assertArrayNotHasKey('http.response.header.x-response', $data);
+        $this->assertArrayNotHasKey('http.request.header.cookie.theme', $data);
+        $this->assertArrayNotHasKey('http.response.header.set_cookie.theme', $data);
+    }
+
+    /**
+     * @dataProvider legacyPiiProvider
+     */
+    public function testDisablingHeadersStillCollectsCookies(bool $pii): void
+    {
+        $data = $this->collect(['data_collection' => ['http_headers' => ['mode' => 'off']], 'send_default_pii' => $pii]);
+
+        $this->assertArrayNotHasKey('http.request.header.x-request', $data);
+        $this->assertArrayNotHasKey('http.response.header.x-response', $data);
+        $this->assertCollectedCookies($data);
+    }
+
+    /**
+     * @dataProvider legacyPiiProvider
+     */
+    public function testRequestHeadersCanBeDisabledIndependently(bool $pii): void
+    {
+        $data = $this->collect(['data_collection' => ['http_headers' => ['request' => ['mode' => 'off']]], 'send_default_pii' => $pii]);
+
+        $this->assertArrayNotHasKey('http.request.header.x-request', $data);
+        $this->assertCollectedHeaders($data, 'response');
+        $this->assertCollectedCookies($data);
+    }
+
+    /**
+     * @dataProvider legacyPiiProvider
+     */
+    public function testResponseHeadersCanBeDisabledIndependently(bool $pii): void
+    {
+        $data = $this->collect(['data_collection' => ['http_headers' => ['response' => ['mode' => 'off']]], 'send_default_pii' => $pii]);
+
+        $this->assertCollectedHeaders($data, 'request');
+        $this->assertArrayNotHasKey('http.response.header.x-response', $data);
+        $this->assertCollectedCookies($data);
+    }
+
+    /**
+     * @dataProvider legacyPiiProvider
+     */
+    public function testDisablingCookiesStillCollectsHeaders(bool $pii): void
+    {
+        $data = $this->collect(['data_collection' => ['cookies' => ['mode' => 'off']], 'send_default_pii' => $pii]);
+
+        $this->assertCollectedHeaders($data, 'request');
+        $this->assertCollectedHeaders($data, 'response');
+        $this->assertArrayNotHasKey('http.request.header.cookie.theme', $data);
+        $this->assertArrayNotHasKey('http.response.header.set_cookie.theme', $data);
+    }
+
+    /**
+     * @dataProvider legacyPiiProvider
+     */
+    public function testDisablingBodiesDoesNotChangeHeaderOrCookieCollection(bool $pii): void
+    {
+        $data = $this->collect(['data_collection' => ['http_bodies' => []], 'send_default_pii' => $pii]);
+
+        $this->assertCollectedHeaders($data, 'request');
+        $this->assertCollectedHeaders($data, 'response');
+        $this->assertCollectedCookies($data);
+        $this->assertArrayNotHasKey('http.request.body.data', $data);
+        $this->assertArrayNotHasKey('http.response.body.data', $data);
+    }
+
+    /**
+     * @dataProvider legacyPiiProvider
+     */
+    public function testOutgoingRequestBodyCanBeEnabledIndependently(bool $pii): void
+    {
+        $data = $this->collect(['data_collection' => ['http_bodies' => ['outgoingRequest']], 'send_default_pii' => $pii]);
+
+        $this->assertCollectedHeaders($data, 'request');
+        $this->assertCollectedHeaders($data, 'response');
+        $this->assertCollectedCookies($data);
+        $this->assertSame(['name' => 'Alice', 'password' => '[Filtered]'], $data['http.request.body.data']);
+        $this->assertArrayNotHasKey('http.response.body.data', $data);
+    }
+
+    /**
+     * @dataProvider legacyPiiProvider
+     */
+    public function testIncomingResponseBodyCanBeEnabledIndependently(bool $pii): void
+    {
+        $data = $this->collect(['data_collection' => ['http_bodies' => ['incomingResponse']], 'send_default_pii' => $pii]);
+
+        $this->assertCollectedHeaders($data, 'request');
+        $this->assertCollectedHeaders($data, 'response');
+        $this->assertCollectedCookies($data);
+        $this->assertArrayNotHasKey('http.request.body.data', $data);
+        $this->assertSame(['name' => 'Bob', 'token' => '[Filtered]'], $data['http.response.body.data']);
+    }
+
+    public function legacyPiiProvider(): \Generator
+    {
+        yield 'legacy PII disabled' => [false];
+        yield 'legacy PII enabled' => [true];
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @return array<string, mixed>
+     */
+    private function collect(array $options): array
+    {
+        $transaction = null;
+        $responseBody = '{"name":"Bob","token":"response-secret"}';
+        $mock = new MockResponse($responseBody, ['response_headers' => [
+            'Content-Type: application/json', 'X-Response: visible', 'Authorization: response-secret',
+            'Set-Cookie: session_id=response-secret; HttpOnly', 'Set-Cookie: theme=light; Path=/',
+        ]]);
+        $client = $this->client(new MockHttpClient($mock), $options, $transaction);
+        $requestBody = '{"name":"Alice","password":"request-secret"}';
+        $response = $client->request('POST', 'https://example.com', ['headers' => [
+            'Content-Type' => 'application/json', 'X-Request' => 'visible', 'Authorization' => 'request-secret',
+            'Cookie' => 'session_id=request-secret; theme=dark',
+        ], 'body' => $requestBody]);
+        $this->assertSame($responseBody, $response->getContent());
+        $this->assertSame($requestBody, $mock->getRequestOptions()['body']);
+        $this->assertSame(['Cookie: session_id=request-secret; theme=dark'], $mock->getRequestOptions()['normalized_headers']['cookie']);
+        $data = $this->span($transaction)->getData();
+        foreach (['http.request.header.cookie', 'http.request.header.set-cookie', 'http.response.header.cookie', 'http.response.header.set-cookie'] as $key) {
+            $this->assertArrayNotHasKey($key, $data);
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function assertCollectedHeaders(array $data, string $direction): void
+    {
+        $this->assertSame(['visible'], $data['http.' . $direction . '.header.x-' . $direction]);
+        $this->assertSame(['[Filtered]'], $data['http.' . $direction . '.header.authorization']);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function assertCollectedCookies(array $data): void
+    {
+        $this->assertSame('dark', $data['http.request.header.cookie.theme']);
+        $this->assertSame('light', $data['http.response.header.set_cookie.theme']);
+        $this->assertSame('[Filtered]', $data['http.request.header.cookie.session_id']);
+        $this->assertSame('[Filtered]', $data['http.response.header.set_cookie.session_id']);
+    }
+
+    public function testToArrayCollectsHeadersWithoutRereadingContent(): void
+    {
+        $body = '{"name":"Bob","token":"secret"}';
+        $transaction = null;
+        $client = $this->client(new MockHttpClient(new MockResponse($body, ['response_headers' => [
+            'Content-Type: application/json', 'Content-Length: ' . \strlen($body),
+        ]])), ['data_collection' => []], $transaction);
+        $this->assertSame(['name' => 'Bob', 'token' => 'secret'], $client->request('GET', 'https://example.com', ['buffer' => false])->toArray());
+        $this->assertSame(['name' => 'Bob', 'token' => '[Filtered]'], $this->span($transaction)->getData()['http.response.body.data']);
+    }
+
+    public function testResponseHeadersAreCollectedOnce(): void
+    {
+        $span = (new Span())->setSampled(true);
+        $headers = ['content-type' => ['application/json'], 'x-response' => ['visible']];
+        $body = '{"name":"Bob","token":"secret"}';
+        $underlying = $this->createMock(ResponseInterface::class);
+        $underlying->method('getStatusCode')->willReturn(200);
+        $underlying->expects($this->exactly(2))->method('getHeaders')->willReturn($headers);
+        $underlying->method('getContent')->willReturn($body);
+        $underlying->method('toArray')->willReturn(['name' => 'Bob', 'token' => 'secret']);
+        $underlying->method('getInfo')->willReturnCallback(function (?string $type = null) {
+            $this->assertNotSame('response_headers', $type);
+
+            return 'http_code' === $type ? 200 : null;
+        });
+        $response = new TraceableResponse($this->createMock(HttpClientInterface::class), $underlying, $span, $this->policy());
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame($headers, $response->getHeaders());
+        $this->assertArrayNotHasKey('http.response.header.x-response', $span->getData());
+        $this->assertSame($body, $response->getContent());
+        $this->assertSame(['name' => 'Bob', 'token' => 'secret'], $response->toArray());
+        unset($response);
+
+        $this->assertSame(['visible'], $span->getData()['http.response.header.x-response']);
+        $this->assertSame(['name' => 'Bob', 'token' => '[Filtered]'], $span->getData()['http.response.body.data']);
+    }
+
+    /**
+     * @dataProvider bodyAccessorProvider
+     */
+    public function testBodyAccessorsFinishTimingBeforeCollectingHeaders(string $method): void
+    {
+        $span = (new Span())->setSampled(true);
+        $underlying = $this->createMock(ResponseInterface::class);
+        $underlying->method('getContent')->willReturn('{"name":"Bob"}');
+        $underlying->method('toArray')->willReturn(['name' => 'Bob']);
+        $underlying->expects($this->once())->method('getHeaders')->with(false)->willReturnCallback(function () use ($span): array {
+            $this->assertNotNull($span->getEndTimestamp());
+
+            return ['content-type' => ['application/json']];
+        });
+        $underlying->method('getInfo')->willReturnCallback(function (?string $type = null) use ($span) {
+            $this->assertNotNull($span->getEndTimestamp());
+            $this->assertNotSame('response_headers', $type);
+
+            return 200;
+        });
+        $response = new TraceableResponse($this->createMock(HttpClientInterface::class), $underlying, $span, $this->policy());
+
+        $response->{$method}();
+
+        $this->assertSame(['name' => 'Bob'], $span->getData()['http.response.body.data']);
+    }
+
+    public function bodyAccessorProvider(): \Generator
+    {
+        yield 'getContent' => ['getContent'];
+        yield 'toArray' => ['toArray'];
+    }
+
+    public function testDestructionCollectsHeadersWithoutReadingTheBody(): void
+    {
+        $span = (new Span())->setSampled(true);
+        $underlying = $this->createMock(ResponseInterface::class);
+        $underlying->expects($this->never())->method('getContent');
+        $underlying->expects($this->never())->method('toArray');
+        $underlying->expects($this->once())->method('getHeaders')->with(false)->willReturn(['x-response' => ['visible']]);
+        $underlying->expects($this->once())->method('getInfo')->with('http_code')->willReturn(200);
+        $response = new TraceableResponse($this->createMock(HttpClientInterface::class), $underlying, $span, $this->policy());
+        unset($response);
+
+        $this->assertSame(['visible'], $span->getData()['http.response.header.x-response']);
+        $this->assertNotNull($span->getEndTimestamp());
+    }
+
+    public function testUnavailableHeadersDoNotPreventReturningTheBody(): void
+    {
+        $span = (new Span())->setSampled(true);
+        $underlying = $this->createMock(ResponseInterface::class);
+        $underlying->method('toArray')->willReturn(['name' => 'Bob', 'token' => 'secret']);
+        $underlying->expects($this->once())->method('getHeaders')->with(false)->willThrowException(new TransportException('Headers unavailable'));
+        $underlying->method('getInfo')->willReturnCallback(static function (?string $type = null) {
+            return 'http_code' === $type ? 200 : null;
+        });
+        $response = new TraceableResponse($this->createMock(HttpClientInterface::class), $underlying, $span, $this->policy());
+
+        $this->assertSame(['name' => 'Bob', 'token' => 'secret'], $response->toArray());
+        $this->assertSame(['name' => 'Bob', 'token' => '[Filtered]'], $span->getData()['http.response.body.data']);
+    }
+
+    public function testStreamingDoesNotAcquireBody(): void
+    {
+        $transaction = null;
+        $client = $this->client(new MockHttpClient(new MockResponse('secret', ['response_headers' => ['X-Response: visible']])), ['data_collection' => []], $transaction);
+        $response = $client->request('GET', 'https://example.com', ['buffer' => false]);
+        $content = '';
+        foreach ($client->stream($response) as $chunk) {
+            $this->assertFalse($chunk->isTimeout());
+            $content .= $chunk->getContent();
+        }
+        $this->assertSame('secret', $content);
+        $this->assertSame(['visible'], $this->span($transaction)->getData()['http.response.header.x-response']);
+        $this->assertArrayNotHasKey('http.response.body.data', $this->span($transaction)->getData());
+    }
+
+    public function testFinishingWithoutSpanDoesNotReadHeaders(): void
+    {
+        $underlying = $this->responseWhoseHeadersMustNotBeRead();
+        $response = new TraceableResponse($this->createMock(HttpClientInterface::class), $underlying, null, $this->policy());
+
+        $this->assertSame('body', $response->getContent());
+        unset($response);
+    }
+
+    public function testFinishingWithoutCollectionOptionsDoesNotReadHeaders(): void
+    {
+        $underlying = $this->responseWhoseHeadersMustNotBeRead();
+        $response = new TraceableResponse($this->createMock(HttpClientInterface::class), $underlying, (new Span())->setSampled(true), null);
+
+        $this->assertSame('body', $response->getContent());
+        unset($response);
+    }
+
+    public function testUnavailableHeadersDoNotMaskTransportErrors(): void
+    {
+        $span = (new Span())->setSampled(true);
+        $error = new TransportException('Request failed');
+        $underlying = $this->createMock(ResponseInterface::class);
+        $underlying->method('getInfo')->willReturn(0);
+        $underlying->expects($this->once())->method('getHeaders')->with(false)->willThrowException(new TransportException('Headers unavailable'));
+        $underlying->expects($this->once())->method('getContent')->willThrowException($error);
+        $response = new TraceableResponse($this->createMock(HttpClientInterface::class), $underlying, $span, $this->policy());
+
+        $this->expectExceptionObject($error);
+        try {
+            $response->getContent();
+        } finally {
+            $this->assertNotNull($span->getEndTimestamp());
+            $this->assertSame([], $span->getData());
+            unset($response);
+        }
+    }
+
+    public function testUnavailableHeadersDoNotPreventCancellation(): void
+    {
+        $span = (new Span())->setSampled(true);
+        $underlying = $this->createMock(ResponseInterface::class);
+        $underlying->method('getInfo')->willReturn(0);
+        $underlying->expects($this->once())->method('getHeaders')->with(false)->willThrowException(new TransportException('Headers unavailable'));
+        $underlying->expects($this->once())->method('cancel');
+        $underlying->expects($this->never())->method('getContent');
+        $response = new TraceableResponse($this->createMock(HttpClientInterface::class), $underlying, $span, $this->policy());
+
+        $response->cancel();
+
+        $this->assertNotNull($span->getEndTimestamp());
+        $this->assertSame([], $span->getData());
+        unset($response);
+    }
+
+    public function testResourceRequestBodyIsNotRead(): void
+    {
+        $stream = fopen('php://temp', 'w+');
+        $this->assertIsResource($stream);
+        fwrite($stream, 'secret');
+        fseek($stream, 2);
+
+        try {
+            $data = $this->collectRequestBody($stream);
+
+            $this->assertArrayNotHasKey('http.request.body.data', $data);
+            $this->assertSame(2, ftell($stream));
+        } finally {
+            fclose($stream);
+        }
+    }
+
+    public function testCallbackRequestBodyIsNotInvoked(): void
+    {
+        $body = static function (): string {
+            throw new \LogicException('Do not invoke callback bodies');
+        };
+
+        $this->assertArrayNotHasKey('http.request.body.data', $this->collectRequestBody($body));
+    }
+
+    public function testSampledResponsesReadHeadersWhenFinished(): void
+    {
+        $this->assertHeaderReadsOnFinish(1.0, 1);
+    }
+
+    public function testUnsampledResponsesDoNotReadHeaders(): void
+    {
+        $this->assertHeaderReadsOnFinish(0.0, 0);
+    }
+
+    private function assertHeaderReadsOnFinish(float $rate, int $expectedReads): void
+    {
+        $underlyingResponse = $this->createMock(ResponseInterface::class);
+        $underlyingResponse->expects($this->never())->method('getContent');
+        $underlyingResponse->expects($this->exactly($expectedReads))->method('getHeaders')->with(false)->willReturn([]);
+        $underlyingResponse->expects($this->never())->method('toArray');
+        $underlyingResponse->expects($this->never())->method('getStatusCode');
+        $underlyingResponse->expects($this->once())->method('getInfo')->with('http_code')->willReturn(200);
+        $underlying = $this->createMock(HttpClientInterface::class);
+        $underlying->method('request')->willReturn($underlyingResponse);
+        $transaction = null;
+        $client = $this->client($underlying, ['data_collection' => [], 'traces_sample_rate' => $rate], $transaction);
+        $response = $client->request('GET', 'https://example.com');
+        unset($response);
+    }
+
+    public function testExplicitAttributesArePreserved(): void
+    {
+        $transaction = null;
+        $client = $this->client(new MockHttpClient(new MockResponse('{"token":"secret"}', ['response_headers' => [
+            'Content-Type: application/json', 'X-Test: automatic', 'Set-Cookie: session=automatic',
+        ]])), ['data_collection' => []], $transaction);
+        $response = $client->request('GET', 'https://example.com');
+        $explicit = [
+            'http.response.header.x-test' => null,
+            'http.response.header.set_cookie.session' => 'explicit',
+            'http.response.body.data' => ['token' => 'explicit'],
+        ];
+        $span = $this->span($transaction);
+        $span->setData($explicit);
+        $response->getContent();
+        foreach ($explicit as $key => $value) {
+            $this->assertSame($value, $span->getData()[$key]);
+        }
+    }
+
+    public function testRequestCanRemoveDefaultCookieHeader(): void
+    {
+        $transaction = null;
+        $mock = new MockResponse();
+        $client = $this->client(new MockHttpClient($mock), ['data_collection' => []], $transaction);
+        if (!method_exists($client, 'withOptions')) {
+            $this->markTestSkipped('withOptions is not available.');
+        }
+        $client = $client->withOptions(['headers' => ['Cookie' => 'theme=default']]);
+        $response = $client->request('GET', 'https://example.com', ['headers' => ['cOoKiE' => []]]);
+        $response->getContent();
+        $this->assertArrayNotHasKey('http.request.header.cookie.theme', $this->span($transaction)->getData());
+        $this->assertSame([], $mock->getRequestOptions()['normalized_headers']['cookie']);
+    }
+
+    public function testClientDefaultHeadersAreCollected(): void
+    {
+        [$client, $transaction] = $this->clientWithDefaultHeaders();
+
+        $client->request('POST', 'https://example.com')->getContent();
+
+        $data = $this->span($transaction)->getData();
+        $this->assertSame(['base'], $data['http.request.header.x-default']);
+        $this->assertSame(['base'], $data['http.request.header.x-override']);
+        $this->assertSame('base', $data['http.request.header.cookie.theme']);
+    }
+
+    public function testClonedClientHeadersOverrideDefaults(): void
+    {
+        [$client, $transaction] = $this->clientWithDefaultHeaders();
+        $client = $client->withOptions(['headers' => ['x-override' => 'clone']]);
+
+        $client->request('POST', 'https://example.com')->getContent();
+
+        $data = $this->span($transaction)->getData();
+        $this->assertSame(['base'], $data['http.request.header.x-default']);
+        $this->assertSame(['clone'], $data['http.request.header.x-override']);
+        $this->assertSame('base', $data['http.request.header.cookie.theme']);
+    }
+
+    public function testRequestHeadersOverrideClonedClientHeaders(): void
+    {
+        [$client, $transaction, $response] = $this->clientWithDefaultHeaders();
+        $client = $client->withOptions(['headers' => ['x-override' => 'clone']]);
+
+        $client->request('POST', 'https://example.com', [
+            'headers' => ['X-OVERRIDE' => 'request', 'cOoKiE' => []],
+        ])->getContent();
+
+        $data = $this->span($transaction)->getData();
+        $this->assertSame(['base'], $data['http.request.header.x-default']);
+        $this->assertSame(['request'], $data['http.request.header.x-override']);
+        $this->assertArrayNotHasKey('http.request.header.cookie.theme', $data);
+        $this->assertSame([], $response->getRequestOptions()['normalized_headers']['cookie']);
+    }
+
+    /**
+     * @dataProvider authenticationOptionProvider
+     *
+     * @param array<string, mixed> $authenticationOption
+     */
+    public function testAuthenticationOptionsCollectGeneratedAuthorizationHeader(array $authenticationOption, string $expectedHeader): void
+    {
+        $transaction = null;
+        $mock = new MockResponse();
+        $client = $this->client(new MockHttpClient($mock), ['data_collection' => []], $transaction);
+        $client->request('GET', 'https://example.com', $authenticationOption)->getContent();
+
+        $this->assertSame([$expectedHeader], $mock->getRequestOptions()['normalized_headers']['authorization']);
+        $this->assertSame(['[Filtered]'], $this->span($transaction)->getData()['http.request.header.authorization']);
+    }
+
+    public function authenticationOptionProvider(): \Generator
+    {
+        yield 'basic authentication' => [['auth_basic' => 'user:password'], 'Authorization: Basic dXNlcjpwYXNzd29yZA=='];
+        yield 'bearer authentication' => [['auth_bearer' => 'secret-token'], 'Authorization: Bearer secret-token'];
+    }
+
+    /**
+     * @dataProvider emptyAuthenticationOptionProvider
+     *
+     * @param array<string, mixed> $authenticationOption
+     */
+    public function testEmptyAuthenticationOptionsDoNotCollectAuthorizationHeader(array $authenticationOption): void
+    {
+        $data = $this->collectRequestOptions($authenticationOption);
+
+        $this->assertArrayNotHasKey('http.request.header.authorization', $data);
+    }
+
+    public function emptyAuthenticationOptionProvider(): \Generator
+    {
+        yield 'empty basic authentication' => [['auth_basic' => '']];
+        yield 'empty bearer authentication' => [['auth_bearer' => '']];
+    }
+
+    public function testAuthenticationOptionCollectsAuthorizationWhenExplicitHeaderIsEmpty(): void
+    {
+        $transaction = null;
+        $mock = new MockResponse();
+        $client = $this->client(new MockHttpClient($mock), ['data_collection' => []], $transaction);
+        $client->request('GET', 'https://example.com', [
+            'auth_bearer' => 'secret-token',
+            'headers' => ['Authorization' => []],
+        ])->getContent();
+
+        $this->assertSame(['Authorization: Bearer secret-token'], $mock->getRequestOptions()['normalized_headers']['authorization']);
+        $this->assertSame(['[Filtered]'], $this->span($transaction)->getData()['http.request.header.authorization']);
+    }
+
+    public function testQueryCollectionUsesTheDeclaredUrl(): void
+    {
+        $transaction = null;
+        $underlying = new MockHttpClient(new MockResponse(), 'https://example.com');
+        $client = $this->client($underlying, ['data_collection' => []], $transaction);
+        $response = $client->request('GET', '/?%74oken=secret&search=old&q=a%20b', [
+            'query' => ['search' => 'new'],
+        ]);
+
+        $this->assertSame('https://example.com/?token=secret&search=new&q=a%20b', $response->getInfo('url'));
+        $this->assertSame('%74oken=[Filtered]&search=old&q=a%20b', $this->span($transaction)->getData()['http.query']);
+        $response->getContent();
+    }
+
+    public function testQueryOptionsWithoutADeclaredQueryAreNotCollected(): void
+    {
+        $transaction = null;
+        $client = $this->client(new MockHttpClient(new MockResponse()), ['data_collection' => []], $transaction);
+        $response = $client->request('GET', 'https://example.com', ['query' => ['search' => 'new']]);
+
+        $this->assertSame('https://example.com/?search=new', $response->getInfo('url'));
+        $this->assertArrayNotHasKey('http.query', $this->span($transaction)->getData());
+        $response->getContent();
+    }
+
+    public function testBodyOptionsDoNotInferCollectedContentType(): void
+    {
+        if (!method_exists(MockHttpClient::class, 'withOptions')) {
+            $this->markTestSkipped('withOptions is not available.');
+        }
+        $defaults = ['body' => ['name' => 'default']];
+        $mock = new MockResponse();
+        $transaction = null;
+        $client = $this->client((new MockHttpClient($mock))->withOptions($defaults), ['data_collection' => []], $transaction, $defaults);
+        $client->request('POST', 'https://example.com', [
+            'body' => ['name' => 'form'],
+        ])->getContent();
+
+        $this->assertSame('name=form', $mock->getRequestOptions()['body']);
+        $data = $this->span($transaction)->getData();
+        $this->assertArrayNotHasKey('http.request.header.content-type', $data);
+        $this->assertSame(['name' => 'form'], $data['http.request.body.data']);
+    }
+
+    /**
+     * @dataProvider bodyOptionProvider
+     *
+     * @param array<string, mixed> $requestOptions
+     * @param array<string, mixed> $expectedBody
+     */
+    public function testBodyOptionsDoNotAddHeadersToSpan(array $requestOptions, array $expectedBody): void
+    {
+        $data = $this->collectRequestOptions($requestOptions);
+
+        $this->assertArrayNotHasKey('http.request.header.content-type', $data);
+        $this->assertArrayNotHasKey('http.request.header.content-length', $data);
+        $this->assertSame($expectedBody, $data['http.request.body.data']);
+    }
+
+    public function bodyOptionProvider(): \Generator
+    {
+        yield 'JSON' => [['json' => ['name' => 'Alice']], ['name' => 'Alice']];
+        yield 'form' => [['body' => ['name' => 'Alice']], ['name' => 'Alice']];
+    }
+
+    public function testFileBodyOptionDoesNotAddHeadersToSpan(): void
+    {
+        $stream = fopen('php://temp', 'w+');
+        $this->assertIsResource($stream);
+        fwrite($stream, 'upload');
+        rewind($stream);
+
+        try {
+            $data = $this->collectRequestOptions(['body' => ['file' => $stream]]);
+
+            $this->assertArrayNotHasKey('http.request.header.content-type', $data);
+            $this->assertArrayNotHasKey('http.request.header.content-length', $data);
+            $this->assertSame(['file' => '[Filtered]'], $data['http.request.body.data']);
+        } finally {
+            fclose($stream);
+        }
+    }
+
+    public function testDeclaredContentLengthIsCollected(): void
+    {
+        $transaction = null;
+        $mock = new MockResponse();
+        $client = $this->client(new MockHttpClient($mock), ['data_collection' => []], $transaction);
+        $client->request('POST', 'https://example.com', [
+            'body' => 'hello',
+            'headers' => ['Content-Length' => '1', 'Content-Type' => 'text/plain'],
+        ])->getContent();
+
+        $data = $this->span($transaction)->getData();
+        $this->assertSame(['text/plain'], $data['http.request.header.content-type']);
+        $this->assertSame(['1'], $data['http.request.header.content-length']);
+    }
+
+    public function testDeclaredContentTypeIsCollected(): void
+    {
+        $transaction = null;
+        $mock = new MockResponse();
+        $client = $this->client(new MockHttpClient($mock), ['data_collection' => []], $transaction);
+        $client->request('POST', 'https://example.com', [
+            'body' => ['name' => 'Alice'],
+            'headers' => ['Content-Type' => 'text/plain'],
+        ])->getContent();
+
+        $this->assertSame(['text/plain'], $this->span($transaction)->getData()['http.request.header.content-type']);
+    }
+
+    public function testResponseHeadersCanBeCollectedAfterAnHttpException(): void
+    {
+        $transaction = null;
+        $body = '{"name":"Bob","token":"secret"}';
+        $client = $this->client(new MockHttpClient(new MockResponse($body, [
+            'http_code' => 500,
+            'response_headers' => ['Content-Type: application/json'],
+        ])), ['data_collection' => []], $transaction);
+        $response = $client->request('GET', 'https://example.com');
+        try {
+            $response->getContent();
+            $this->fail('Expected the HTTP exception.');
+        } catch (HttpExceptionInterface $exception) {
+            $span = $this->span($transaction);
+            $finishedAt = $span->getEndTimestamp();
+            $this->assertNotNull($finishedAt);
+            $this->assertSame(['application/json'], $span->getData()['http.response.header.content-type']);
+            $this->assertSame($body, $response->getContent(false));
+            $this->assertSame(['name' => 'Bob', 'token' => '[Filtered]'], $span->getData()['http.response.body.data']);
+            $this->assertSame($finishedAt, $span->getEndTimestamp());
+        }
+    }
+
+    public function testHttpErrorsRetainTheirBehavior(): void
+    {
+        $transaction = null;
+        $client = $this->client(new MockHttpClient(new MockResponse('error', ['http_code' => 500, 'response_headers' => ['X-Response: visible']])), ['data_collection' => []], $transaction);
+        $response = $client->request('GET', 'https://example.com');
+        try {
+            $response->getContent();
+            $this->fail('Expected the HTTP exception.');
+        } catch (HttpExceptionInterface $exception) {
+            $this->assertNotNull($this->span($transaction)->getEndTimestamp());
+            $this->assertSame(['visible'], $this->span($transaction)->getData()['http.response.header.x-response']);
+        }
+    }
+
+    private function responseWhoseHeadersMustNotBeRead(): ResponseInterface
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getContent')->willReturn('body');
+        $response->method('getInfo')->willReturn(200);
+        $response->expects($this->never())->method('getHeaders');
+
+        return $response;
+    }
+
+    /**
+     * @param mixed $body
+     *
+     * @return array<string, mixed>
+     */
+    private function collectRequestBody($body): array
+    {
+        $underlying = $this->createMock(HttpClientInterface::class);
+        $underlying->method('request')->willReturn(new MockResponse());
+        $transaction = null;
+        $client = $this->client($underlying, ['data_collection' => []], $transaction);
+        $response = $client->request('POST', 'https://example.com', ['body' => $body]);
+        $data = $this->span($transaction)->getData();
+        unset($response);
+
+        return $data;
+    }
+
+    /**
+     * @param array<string, mixed> $requestOptions
+     *
+     * @return array<string, mixed>
+     */
+    private function collectRequestOptions(array $requestOptions): array
+    {
+        $transaction = null;
+        $client = $this->client(new MockHttpClient(new MockResponse()), ['data_collection' => []], $transaction);
+        $client->request('POST', 'https://example.com', $requestOptions)->getContent();
+
+        return $this->span($transaction)->getData();
+    }
+
+    /**
+     * @return array{TraceableHttpClient, Transaction, MockResponse}
+     */
+    private function clientWithDefaultHeaders(): array
+    {
+        if (!method_exists(MockHttpClient::class, 'withOptions')) {
+            $this->markTestSkipped('withOptions is not available.');
+        }
+
+        $defaults = ['headers' => ['X-Default' => 'base', 'X-Override' => 'base', 'Cookie' => 'theme=base']];
+        $response = new MockResponse();
+        $transaction = null;
+        $client = $this->client((new MockHttpClient($response))->withOptions($defaults), ['data_collection' => []], $transaction, $defaults);
+
+        return [$client, $transaction, $response];
+    }
+
+    private function policy(): DataCollectionPolicy
+    {
+        return DataCollectionPolicy::fromOptions(new Options(['data_collection' => []]));
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     * @param array<string, mixed> $defaultOptions
+     */
+    private function client(HttpClientInterface $underlying, array $options, ?Transaction &$transaction, array $defaultOptions = []): TraceableHttpClient
+    {
+        $sdkClient = $this->createMock(ClientInterface::class);
+        $sdkClient->method('getOptions')->willReturn(new Options($options + ['traces_sample_rate' => 1.0]));
+        $hub = new Hub($sdkClient);
+        $transaction = $hub->startTransaction(TransactionContext::make());
+        $hub->setSpan($transaction);
+
+        return new TraceableHttpClient($underlying, $hub, $defaultOptions);
+    }
+
+    private function span(Transaction $transaction): Span
+    {
+        $recorder = $transaction->getSpanRecorder();
+        $this->assertNotNull($recorder);
+
+        return $recorder->getSpans()[1];
+    }
+}


### PR DESCRIPTION
Adds data_collection for HTTP related things. Adds code to capture headers, cookies and bodies for incoming and outgoing HTTP requests.

It uses shared classes from sentry-php to normalise and extract the facts